### PR TITLE
test: split PR 62 Playwright title metadata

### DIFF
--- a/STABILIZATION.md
+++ b/STABILIZATION.md
@@ -505,6 +505,10 @@ the current working direction until a product decision overrides them.
 - **Addressed in stabilization pass:** event find/update RPC location fields now validate against the shared `EventLocation` schema.
 - **Addressed in stabilization pass:** event creation now copies template option discounts by source option identity, so duplicate option titles do not miscopy discounts.
 - **Addressed in stabilization pass:** event creation now revalidates copied template ESNcard discounts before inserting the event. Copied discounts do not persist for event options changed to free, fail when ESNcard discounts are no longer enabled for the tenant, and fail when the template discount exceeds the event option price.
+- **Addressed in stabilization pass:** event edit saves now share one tested
+  submit-disabled guard between the Save Changes button and handler, so
+  invalid, submitting, and mutation-pending update writes cannot double-submit
+  on slow networks.
 - **Addressed in stabilization pass:** `event-management.doc.ts` no longer describes attendee export, attendee messaging, manual check-in controls, event settings tabs, event tags, featured images, notification settings, integrations, or event deletion as existing event-management UI.
 - **Addressed in stabilization pass:** unlisted-event dialog and event detail status copy now explain that unlisted events are hidden from lists while eligible direct links still work.
 - **Acceptable for now:** event edit locks are duplicated in guard, details `canEdit`, `findOneForEdit`, and `events.update`. Duplication is not ideal, but server-side checks are the source of truth.
@@ -552,28 +556,52 @@ the current working direction until a product decision overrides them.
 - **Addressed in stabilization pass:** full participant options no longer present the normal registration action and instead expose a distinct waitlist action backed by a `WAITLIST` registration and `waitlistSpots` counter update. Waitlisted participants can leave the waitlist before the event starts, which decrements `waitlistSpots` transactionally.
 - **Addressed in stabilization pass:** registration submission now rejects stored `random` and `application` options server-side instead of silently handling them as first-come-first-served.
 - **Addressed in stabilization pass:** event registration option cards now label participant options separately from organizer/helper options and use distinct organizer/helper signup action copy while preserving the shared registration-option model.
+- **Addressed in stabilization pass:** participant registration and waitlist
+  actions now share one mutation-pending guard between the buttons and handlers,
+  so slow registration or waitlist writes cannot be triggered twice from the
+  registration option card.
 - **Addressed in stabilization pass:** role-ineligible direct event links keep the event visible but show an explicit registration-unavailable state instead of silently rendering an empty registration section.
 - **Addressed in stabilization pass:** participant self-cancellation now covers pending and confirmed registrations before event start, rolls back reserved/confirmed counters including selected guest spots, blocks checked-in cancellations, and keeps refund copy honest for paid registrations.
 - **Addressed in stabilization pass:** organizer/admin cancellation is available from the organizer overview for confirmed participant registrations, requires event-organizer access or `events:organizeAll`, blocks checked-in cancellations, and rolls back confirmed counters without promising automatic refunds.
-- **Addressed in stabilization pass:** active registration cards now make transfer/resale unavailability explicit for pending, confirmed, and waitlisted registrations until the real transfer/resale flow exists.
-- **Should fix before relaunch:** transfer/resale and automatic refund flows are not implemented in the reviewed event registration path.
+- **Addressed in stabilization pass:** active registration cards now expose unpaid self-service transfer for confirmed, not checked-in registrations before event start, and keep transfer/resale unavailability explicit for pending and waitlisted registrations.
+- **Addressed in stabilization pass:** `events.findTransferTargets` and `events.transferEventRegistration` provide a conservative organizer-assisted transfer flow for confirmed, not checked-in, unpaid registrations between existing tenant users. The organizer overview opens an eligible-member lookup, and the target lookup and mutation require event-organizer access, fail closed when the target user is outside the tenant, role-ineligible for the registration option, or already has an active registration, and reject paid registrations until refund/resale money movement is implemented.
+- **Addressed in stabilization pass:** organizer overview participant actions now
+  use one shared checked-in/in-flight guard for cancellation and
+  organizer-assisted transfer buttons and handlers, so checked-in rows and
+  duplicate in-flight writes cannot be triggered from the page.
+- **Addressed in stabilization pass:** `events.transferMyRegistration` lets participants transfer their own confirmed unpaid registration to an existing eligible tenant user by email without exposing a tenant-member search surface.
+- **Addressed in stabilization pass:** active registration cancellation and
+  self-service transfer now share tested action guards between the buttons and
+  handlers, so cancellation and transfer writes cannot overlap or double-submit
+  locally on slow networks.
+- **Should fix before relaunch:** participant-facing paid transfer/resale money movement, resale-specific workflows, and automatic refund flows are not implemented in the reviewed event registration path.
 - **Addressed in stabilization pass:** active registration status now uses the shared persisted registration status literal union instead of raw `Schema.String`.
 - **Acceptable for now:** paid registration rollback is careful about cleaning up a failed checkout session creation path; deeper Stripe lifecycle review belongs in the finance pass.
 
 ### Test and Documentation Quality
 
 - `tests/specs/events/free-registration.test.ts` covers the free registration happy path using seeded scenario handles.
-- `src/app/events/event-registration-option/event-registration-option.component.spec.ts` covers registration-card state for full options, distinct waitlist availability, remaining-capacity guest selection helpers, and too-early/too-late registration windows without requiring a page-backed browser.
+- `src/app/events/event-registration-option/event-registration-option.component.spec.ts` covers registration-card state for full options, distinct waitlist availability, remaining-capacity guest selection helpers, participant registration/write action disabling, and too-early/too-late registration windows without requiring a page-backed browser.
 - `src/app/events/event-registration-option/event-registration-option.component.spec.ts` covers that stored `random` and `application` participant options do not expose a waitlist affordance even when full.
 - `src/server/effect/rpc/handlers/events/event-registration.service.spec.ts` covers server-side rejection for duplicate active registration, unpublished events, closed registration windows, role-ineligible users, cross-tenant options, full options, unsupported registration modes, same-event second registrations across options, transactional duplicate races, transactional capacity races, participant waitlist joining, and participant guest quantities.
-- `src/server/effect/rpc/handlers/events/events-registration.handlers.spec.ts` covers participant self-cancellation for pending, confirmed, and waitlisted registrations plus checked-in rejection paths.
+- `src/server/effect/rpc/handlers/events/events-registration.handlers.spec.ts` covers participant self-cancellation for pending, confirmed, and waitlisted registrations, buyer-plus-guest spot rollback, checked-in rejection paths, organizer-assisted transfer target lookup, and unpaid registration transfer guardrails including target tenant membership, role eligibility, duplicate active registration, and paid-transfer rejection.
+- `src/app/events/event-organize/event-organize.spec.ts` covers organizer overview stat aggregation and transfer-dialog participant identity copy. The organizer overview UI now exposes the unpaid transfer action next to cancellation for not-yet-checked-in participant registrations.
+- `src/app/events/event-organize/event-organize.spec.ts` covers the shared
+  organizer participant action guard that disables cancellation and
+  organizer-assisted transfer for checked-in rows or in-flight writes.
 - `src/server/effect/rpc/handlers/events/events-registration.handlers.spec.ts` covers organizer/admin cancellation for confirmed registrations and denial without event-organizer access.
 - `src/server/effect/rpc/handlers/events/events-lifecycle.handlers.spec.ts` covers server-side rejection of end-before-start events and close-before-open registration windows for event create/update.
 - `src/server/effect/rpc/handlers/events/events-lifecycle.handlers.spec.ts` covers template discount copying by stable source option id when template options share the same title, plus pre-insert rejection when copied ESNcard discounts are disabled or exceed the target event option price.
 - `src/server/effect/rpc/handlers/events/events-rpcs.schema.spec.ts` covers acceptance and rejection for the shared event location schema now used by Events RPC contracts.
 - `src/server/effect/rpc/handlers/events/events-rpcs.schema.spec.ts` covers the active registration status literal union and rejects unknown statuses.
 - `src/server/effect/rpc/handlers/events/events-rpcs.schema.spec.ts` covers the tax-rate label fields returned with event registration options for paid event cards.
-- `src/app/events/event-active-registration/event-active-registration.component.spec.ts` covers participant cancellation copy for single-spot, guest, and waitlisted registrations plus the visible transfer/resale-unavailable notes for pending, confirmed, and waitlisted active registrations.
+- `src/app/events/event-details/event-details.component.spec.ts` covers event
+  review and submit-for-review action guards for permission, status, and
+  mutation-pending states, keeping the event lifecycle actions safe on slow
+  networks and duplicate local triggers.
+- `src/app/events/event-edit/event-edit.spec.ts` covers event edit submit
+  guards for invalid, submitting, and mutation-pending states.
+- `src/app/events/event-active-registration/event-active-registration.component.spec.ts` covers participant cancellation copy for single-spot, guest, and waitlisted registrations; unpaid self-service transfer copy; cancellation/transfer action disabling; target-email normalization; and transfer/resale-unavailable notes for pending, waitlisted, and blocked confirmed active registrations.
 - `tests/docs/events/event-management.doc.ts` now documents only the current event details, registration, review/listing, edit, organizer overview, participant grouping/cancellation, and receipt surfaces.
 - `tests/docs/events/unlisted-admin.doc.ts` covers the updated direct-link explanation in the listing dialog and on unlisted event details.
 - `tests/docs/events/register.doc.ts` covers free and paid registration as generated documentation and Stripe-backed evidence, including guest quantity selection, the participant versus organizer/helper option wording, and participant self-cancellation copy.
@@ -619,7 +647,19 @@ the current working direction until a product decision overrides them.
 - **Addressed in this stabilization pass:** template registration offsets now fail with a typed bad request when a registration would open after it closes. Because offsets are "hours before event", `openRegistrationOffset` must be greater than or equal to `closeRegistrationOffset` for a normal window.
 - **Addressed in this stabilization pass:** template create/update and find-one RPC location fields now use the shared `EventLocation` schema instead of `Schema.Any`, matching the event boundary behavior.
 - **Should fix before relaunch:** simple-mode create/update always writes exactly two registration options. That matches the current UI but is thinner than the product model for reusable event knowledge.
-- **Should fix before relaunch:** template add-ons and registration questions exist in schema or product context, but simple-mode template create/update does not expose or persist them. Event creation has separate add-on copying logic, but the simple template editing path cannot maintain those richer fields yet.
+- **Addressed in stabilization pass:** template detail now returns and displays
+  existing reusable template add-ons from the current schema, including pricing,
+  purchase timing, quantity limits, and registration-option attachments. Simple
+  create/update still does not author add-ons, and there is still no reviewed
+  event-side add-on fulfillment or registration-question schema/copy path.
+- **Addressed in this stabilization pass:** create-event-from-template now
+  shows an explicit add-on boundary notice when the source template has
+  reusable add-ons. Event creation still copies registration options only until
+  event-side add-on fulfillment exists.
+- **Addressed in stabilization pass:** reset-from-zero seed data now includes
+  both free and paid reusable template add-ons attached to participant template
+  registration options, so Browser review can inspect the add-on detail surface
+  once the local runtime is available.
 - **Addressed in stabilization pass:** simple-mode template create/edit now exposes optional ESNcard discounted prices when the tenant ESNcard provider is enabled, persists them in `templateRegistrationOptionDiscounts`, returns them through `templates.findOne`, and shows them on template detail.
 - **Addressed in stabilization pass:** simple-mode template registration
   options now preserve editable option names plus public and registered-user
@@ -627,9 +667,24 @@ the current working direction until a product decision overrides them.
   flow into event creation through the existing template-to-event mapping.
 - **Addressed in stabilization pass:** simple-mode template create/edit now exposes the existing `planningTips` field as private organizer planning tips, persists trimmed notes through the template RPC/service, and shows them on the template detail page.
 - **Addressed in this stabilization pass:** registration mode now only offers first-come-first-served in event/template authoring controls. The contracts still accept existing stored `random`/`application` values, but new/edit UI no longer presents unsupported fulfillment modes.
+- **Addressed in stabilization pass:** event and template authoring controls now
+  render readable registration-mode labels instead of raw stored ids such as
+  `fcfs`, while the simple-mode UI still only offers first-come-first-served.
 - **Addressed in this stabilization pass:** template create/edit components use scoped `consola/browser` loggers instead of direct `console.*` calls.
 - **Addressed in stabilization pass:** template detail paid-option summaries now use the shared inclusive tax label component, matching the event registration card display and preserving the same fallback label when tax-rate details are unavailable.
 - **Addressed in stabilization pass:** template create/edit submit normalization clears hidden payment fields for free registrations, so toggling a paid option back to free no longer submits a stale `stripeTaxRateId` that the server correctly rejects.
+- **Addressed in stabilization pass:** creating an event from a template now
+  shares one tested submit-disabled guard between the template button and submit
+  handler, so invalid, submitting, and mutation-pending states cannot trigger
+  duplicate event creation on slow networks.
+- **Addressed in stabilization pass:** template create/edit writes now share the
+  same submit-disabled helper between buttons and handlers, so invalid,
+  submitting, and mutation-pending create/update states cannot duplicate
+  template writes on slow networks.
+- **Addressed in stabilization pass:** template category create/edit actions now
+  share one tested write-pending guard, so category buttons and handlers cannot
+  open overlapping dialogs or writes while a category create/update is already
+  pending.
 - **Acceptable for now:** the template detail page is a useful read-only summary and the "Create event" action is discoverable from the detail surface.
 
 ### Test and Documentation Quality
@@ -638,9 +693,36 @@ the current working direction until a product decision overrides them.
 - `tests/docs/templates/templates.doc.ts` documents simple-mode template creation, organizer planning tips, role defaults, payment field visibility, optional ESNcard discounted price fields, and role-picker behavior. It asserts that enabling payment reveals both the price and tax-rate controls before taking the payment-field screenshot.
 - `tests/specs/templates/paid-option-requires-tax-rate.spec.ts` now has active simple-mode UI coverage for the paid tax-rate requirement and a seeded inclusive tax-rate save path. Remaining fixme entries are limited to future bulk/no-compatible-rate UI behavior.
 - `src/app/templates/shared/template-form/template-registration-option-form.utilities.spec.ts` covers paid template tax-rate and ESNcard discount preservation, paid missing-tax-rate pass-through for server validation, and free-registration payment-field cleanup before create/edit submission.
+- `src/app/templates/template-create-event/template-create-event.mapper.spec.ts`
+  covers the template-to-event form mapping, including copied registration
+  option source ids for server-side template discount copying, relative
+  registration-window offsets, and the boundary that organizer planning tips
+  and reusable add-ons stay private to the template surface.
+- `src/app/templates/template-create-event/template-create-event.component.spec.ts`
+  pins the create-event-from-template submit guard for invalid, submitting, and
+  mutation-pending states, plus the visible notice for templates whose add-ons
+  are not copied into event-side fulfillment yet.
+- `src/app/templates/shared/template-form/template-form.utilities.spec.ts` pins
+  the shared template create/edit write guard for invalid, submitting, and
+  mutation-pending states.
+- `src/app/templates/categories/category-list/category-list.component.spec.ts`
+  pins the category create/edit action guard while create or update writes are
+  pending.
+- `src/shared/registration-modes.spec.ts` covers the readable labels used by
+  event/template authoring controls and template detail summaries for every
+  persisted registration-mode literal.
 - `src/server/effect/rpc/handlers/tax-rates.handlers.spec.ts` covers `taxRates.listActive` permission behavior and the current-tenant active/inclusive filter used to populate compatible template tax-rate selects.
 - `src/server/utils/validate-tax-rate.spec.ts` covers the shared server rule that paid options require a tenant-owned active inclusive tax rate and free options cannot carry stale tax-rate ids.
 - `src/server/effect/rpc/handlers/templates/simple-template.service.spec.ts` covers paid template registrations without tax rates, free template registrations with stale tax-rate ids, and invalid ESNcard discounted prices failing through the server-side validation path.
+- `src/db/schema/template-event-addons.spec.ts` pins the current implementation
+  boundary that add-ons are template-scoped only and registration-question
+  schemas are not exposed yet.
+- `src/server/effect/rpc/handlers/templates.handlers.spec.ts` and
+  `src/app/templates/template-details/template-details.component.spec.ts` cover
+  the current reusable add-on read model and detail-surface labels without
+  requiring Browser/runtime setup.
+- `tests/specs/seed/seed-baseline.test.ts` now treats seeded reusable template
+  add-ons as part of the reset-from-zero contract for template detail review.
 - The generic `tests/docs/template.doc.ts` discovery placeholder was removed; product template documentation lives in `tests/docs/templates/templates.doc.ts`.
 - Permission matrix coverage checks template create link visibility plus direct route denial for template create/edit/create-event routes. `src/app/templates/templates.routes.spec.ts` keeps the guarded template write-route manifest explicit. Server unit coverage proves template RPC denial, template offset ordering, tenant-owned template category/role validation, and template location schema rejection.
 
@@ -692,22 +774,36 @@ the current working direction until a product decision overrides them.
 
 - **Addressed in this stabilization pass:** client and server permission checks now share `includesPermission`, including dependency expansion, wildcard checks, and the legacy `admin:manageTaxes` -> `admin:tax` alias. Legacy header-based handlers, `RpcAccess.ensurePermission`, tax-rate visibility, event visibility/edit checks, and finance receipt helpers all route through the shared evaluator.
 - **Addressed in this stabilization pass:** admin role, user, settings, tax-rate, and event-review child routes now have route-level permission guards, and the admin shell requires at least one admin-child capability.
+- **Addressed in this stabilization pass:** denied permission guards now route to the root `/403` page instead of a child-relative `403` path, so direct admin/finance/template denials render a clear not-allowed page instead of an empty feature shell.
 - **Addressed in this stabilization pass:** `admin.roles.findMany` now requires `admin:manageRoles`; permission-bearing role records are no longer exposed to every authenticated tenant user.
 - **Addressed in this stabilization pass:** shared role selection and template default-role queries now use lookup-only `roles.findMany` / `roles.findOne` RPCs. The lookup API returns only id, name, and default-role flags and is available to event/template authoring permissions plus role admins.
 - **Addressed in stabilization pass:** role create/update now writes `displayInHub` and `collapseMembersInHup`, and the role form uses the same `displayInHub` field that `findHubRoles` reads. The legacy `showInHub` role field has been removed from the Drizzle schema and admin role RPC records, leaving `displayInHub` as the canonical hub-visibility field.
 - **Addressed in stabilization pass:** `users:assignRoles` is now labeled as a future/migration permission in the role form metadata, the user list explicitly says existing-user role assignment is deferred for relaunch, and the roles doc records the read-only user-list behavior.
 - **Addressed in stabilization pass:** the user list no longer shows placeholder selection or "Edit template" actions for user-role assignment.
 - **Addressed in stabilization pass:** permission metadata now has explicit admin-facing labels and descriptions in the shared permission source, the role form renders those descriptions, and shared tests require every visible permission to keep non-empty metadata.
+- **Addressed in stabilization pass:** role-form dependent-permission copy now uses shared admin-facing permission labels instead of raw permission keys, and the generated permission reference keeps both the label and key visible.
+- **Addressed in this stabilization pass:** role create/edit submits now share a tested disabled guard across the role form template and submit handler, and parent create/update handlers ignore duplicate submit events while the role write is pending.
+- **Addressed in stabilization pass:** the tenant event-review queue now shares
+  one tested action guard between Approve/Reject buttons and the handler, so a
+  pending review mutation cannot open another rejection dialog or submit a
+  second review write.
 - **Acceptable for now:** roles are tenant-scoped in schema and role-management write queries include tenant boundaries.
 
 ### Test and Documentation Quality
 
 - `src/shared/permissions/permissions.spec.ts` covers direct permissions, dependency expansion, legacy tax aliases, wildcard checks, and rejection of unrelated permissions. `RpcAccess` and tax-rate handler unit tests prove server use of the shared evaluator.
+- `src/shared/permissions/permissions.spec.ts` covers shared permission labels used by role-form dependency copy and falls back to raw keys only for technical permissions not shown in normal role management.
+- `src/app/core/guards/permission.guard.spec.ts` covers denied route redirects to the root not-allowed page and positive permission allow behavior, preventing child-route denials such as `/admin/roles` from resolving to an empty feature shell.
+- `src/app/admin/components/role-form/role-form.component.spec.ts` covers role
+  submit disabling for invalid, submitting, and mutation-pending states.
+- `src/app/admin/event-reviews/event-reviews.component.spec.ts` covers the
+  tenant event-review queue guard that disables Approve/Reject while a review
+  mutation is pending.
 - Permission matrix coverage checks admin tax-rate, role-management, user-list, settings, and template write route denial. `src/app/admin/admin.routes.spec.ts` keeps the guarded admin route manifest explicit. Role lookup UI behavior still needs Browser/E2E coverage once runtime review is available.
 - `tests/docs/roles/roles.doc.ts` documents role creation, dependent permissions, and the explicit deferral of existing-user role assignment for relaunch.
 - `tests/docs/roles/about-permissions.doc.ts` generates the `/docs/about-permissions` source from shared permission metadata, including group labels, permission keys/descriptions, dependent permissions, and the tenant-role/global-admin distinction.
 - `tests/docs/roles/roles.doc.ts` links to `/docs/about-permissions` for permission reference details.
-- Server unit coverage proves role lookup permissions, lookup-only result shaping, tenant-scoped lookup filters, role lookup not-found errors, and admin role list denial without `admin:manageRoles`.
+- Server unit coverage proves role lookup permissions, lookup-only result shaping, tenant-scoped lookup filters for both list and single-role lookup, role lookup not-found errors, and admin role list denial without `admin:manageRoles`.
 - `src/server/effect/rpc/handlers/users.handlers.spec.ts` verifies `users.findMany` aggregates role names into the RPC contract shape without leaking the joined `role` column.
 - `src/shared/permissions/permissions.spec.ts` requires explicit labels and descriptions for every permission shown in role management.
 - `src/db/schema/legacy-stabilization-fields.spec.ts` proves the active role schema exposes `displayInHub` instead of `showInHub`, and guards the global migration step that drops physical `roles.showInHub`, `event_registrations.paymentStatus`, and the unused `payment_status` enum before tenant-scoped migration work.
@@ -724,6 +820,8 @@ the current working direction until a product decision overrides them.
 
 - Keep permission checks routed through `includesPermission` or `RpcAccess.ensurePermission`; avoid reintroducing direct `.includes(...)` authorization checks.
 - Keep route-manifest specs and permission-matrix route-denial cases aligned as admin, finance, template, and global-admin route trees change.
+- Keep role create/edit submit guards aligned with the actual mutation
+  lifecycle, not only the signal-form submit callback.
 - Add UI/E2E coverage that least-privilege organizers can search/select tenant roles in event/template eligibility forms once Browser/runtime review is available.
 - Keep `migration/steps/004_drop_legacy_stabilization_fields.ts` in the
   production migration path so any existing physical `showInHub`,
@@ -752,7 +850,8 @@ the current working direction until a product decision overrides them.
 
 - Stripe is the payment source of truth; local state should mirror Stripe lifecycle and must not fake successful payment state.
 - Users should receive registration confirmation and QR code only after successful registration; for paid events, after successful payment.
-- Organizers may submit receipts after an event.
+- Organizers may submit receipts before, during, or after an event so pre-event
+  spending can be recorded without waiting for the event end time.
 - Receipts are reviewed and reimbursed; the first version does not need sophisticated budgeting or receipt categories.
 - Receipt review should support email notification when a receipt is reviewed.
 - Finance and payment flows are high-risk and should be permission-safe, tenant-safe, and payment-safe.
@@ -765,10 +864,18 @@ the current working direction until a product decision overrides them.
 - **Addressed in this stabilization pass:** receipt media upload now includes the target `eventId`, checks tenant event existence for authorized callers, and requires `canSubmitEventReceipts` before object storage is touched. A signed-in user without receipt-submit access can no longer create orphan receipt objects through the upload RPC.
 - **Addressed in stabilization pass:** manual receipt reimbursement is now labeled as recording a reimbursement in the finance overview, reimbursement list, receipt submit hint, profile payout fields, visible server messages, docs, and Playwright coverage. The reimbursement queue now explicitly says Evorto only records the finance transaction and money must be transferred manually through the selected payout method. Reimbursement transaction comments no longer copy the full payout reference into free text. The legacy route path, permission name, RPC name, receipt status, and transaction type still use "refund" internally until a broader data/API migration is worthwhile.
 - **Addressed in stabilization pass:** receipt submission and review now reject tax amounts greater than the total amount, matching the existing deposit/alcohol amount consistency guard.
-- **Addressed in stabilization pass:** receipt submission now requires the target event to have ended before the server inserts a submitted receipt. The receipt Playwright flow uses the deterministic past event fixture for submission/review setup.
+- **Addressed in stabilization pass:** receipt submission now follows the
+  pre-event spending decision. The server still verifies the target event exists
+  and the caller can submit receipts for it, but it no longer blocks submission
+  only because the event end time is in the future.
 - **Addressed in stabilization pass:** profile and user-event summaries no longer read `event_registrations.paymentStatus`; payment display is derived from registration transaction rows. Seed and webhook-replay setup stopped writing `paymentStatus` for new fixture registrations, and the legacy payment-status column/enum have been removed from the application schema.
 - **Addressed in stabilization pass:** receipt review records status locally, and the review detail page, success feedback, and finance docs explicitly tell finance reviewers that submitter notification is manual until a real delivery path exists.
 - **Addressed in this stabilization pass:** finance receipt approval and reimbursement lists now prefer the user's editable notification email over the Auth0 login email when rendering submitter contact details.
+- **Addressed in this stabilization pass:** the event organizer receipt action now stays disabled while the original receipt upload is pending, not only while the final submit mutation is pending, and the click handler shares the same guard.
+- **Addressed in stabilization pass:** receipt reimbursement recording now
+  shares one disabled guard between the queue button and handler so missing
+  selections, missing payout details, and mutation-pending writes cannot record
+  duplicate reimbursement transactions on slow networks.
 - **Acceptable for now:** receipt review/reimbursement queries are tenant-scoped, and receipt reimbursement creation uses a transaction plus status preconditions to avoid reimbursing the wrong submitter or already-reimbursed receipts.
 
 ### Test and Documentation Quality
@@ -778,9 +885,15 @@ the current working direction until a product decision overrides them.
 - **Addressed in stabilization pass:** `tests/specs/finance/receipts-flows.spec.ts` now hard-fails when the seeded pending receipt, refundable receipt group, row checkbox, enabled reimbursement action, or tenant "Other" country option is missing.
 - Finance overview docs now describe the current navigation-style finance UI, current finance capability names, and the manual submitter-notification caveat before and after receipt review.
 - **Addressed in stabilization pass:** `tests/docs/finance/receipt-review-reimbursement.doc.ts` now walks the receipt approval queue, approval detail page, manual submitter-notification caveat, reimbursement queue, payout-detail selection, and manual reimbursement recording.
-- `src/app/finance/receipt-refund-list/receipt-refund-list.component.spec.ts` pins the reimbursement queue's manual money-movement notice, and the receipt reimbursement doc/spec assert that notice on the page.
+- `src/app/finance/receipt-refund-list/receipt-refund-list.component.spec.ts` pins the reimbursement queue's manual money-movement notice, payout-detail gating, payout-detail labels, selected-total math, and reimbursement record disabled guard. The receipt reimbursement doc/spec assert the manual-money notice on the page.
+- `src/app/finance/receipt-approval-detail/receipt-approval-detail.component.spec.ts`
+  pins the approval/rejection action guard for invalid forms, loading receipt
+  details, and mutation-pending review writes.
 - Tax-rate docs and specs provide better active coverage for `admin:tax` and inclusive Stripe tax-rate import/selection.
 - Server finance unit tests are still thin, but now include transaction-list permission denial, receipt-media upload preflight denial/success coverage, profile `finance.receipts.my` output normalization, submitter notification-email fallback, and tax-amount consistency rejection on receipt submit/review.
+- Event organize app coverage pins the receipt submission disabled state while
+  the event has not loaded yet and across upload-pending and submit-pending
+  phases.
 
 ### Product Questions Answered Above
 
@@ -789,7 +902,9 @@ the current working direction until a product decision overrides them.
 - Which finance capability should gate the transaction list: `finance:viewTransactions`, `finance:manageReceipts`, or a broader finance overview permission?
 - Should receipt uploads be created only after submit authorization succeeds, or should upload sessions be issued from a receipt-submit preflight?
 - Should receipt reimbursement remain a manual ledger action, or will it eventually integrate with a payout provider?
-- Should receipts be restricted to event end dates, or is pre-event spending intentionally allowed? Current behavior restricts submitted receipts to events whose end time has passed.
+- Should receipts be restricted to event end dates, or is pre-event spending
+  intentionally allowed? Answered locally: pre-event spending and submission are
+  allowed once the event exists and the caller has receipt-submit access.
 
 ### Recommended Cleanup Actions
 
@@ -835,6 +950,9 @@ the current working direction until a product decision overrides them.
 - **Addressed in stabilization pass:** scanner URL parsing now explicitly accepts absolute URLs from any origin by product decision, but only when the path is exactly `/scan/registration/:registrationId`; malformed payloads and extra path segments are rejected before navigation.
 - **Addressed in stabilization pass:** scanner camera startup is awaited and maps denied permission, missing devices, and busy devices into visible retryable error messages. The scanner also shows a starting state and keeps a retry button available after camera startup failures.
 - **Addressed in stabilization pass:** scanner guest-quantity behavior is explicit. Organizers can choose how many remaining guests to check in with the buyer, and later scans can record additional guest arrivals without re-counting the buyer.
+- **Addressed in this stabilization pass:** scanner guest-count input handling now has focused app coverage that clamps blank, invalid, negative, and over-limit guest selections before the check-in mutation payload is built.
+- **Addressed in stabilization pass:** scanned-registration check-in copy now uses readable singular/plural spot labels, a lower-noise pending label, and clearer future-event warning wording.
+- **Addressed in this stabilization pass:** the scanned-registration check-in action now stays disabled after a successful local check-in while the refreshed scan state catches up, so slow refetches do not briefly expose another write action.
 - **Acceptable for now:** QR code display is limited to confirmed registrations in the active registration UI, so pending paid registrations do not show the ticket card there.
 
 ### Test and Documentation Quality
@@ -844,6 +962,8 @@ the current working direction until a product decision overrides them.
 - Server unit coverage proves scan-read denial for unauthorized tenant users, check-in counter updates for organizer access, selected guest check-in behavior, remaining-guest scan behavior after buyer check-in, idempotent duplicate check-in behavior, and same-user check-in denial.
 - `src/server/http/qr-code.web-handler.spec.ts` covers unauthenticated QR denial, owner access, same-event organizer access, other-user denial, and pending-registration denial.
 - `src/app/scanning/scanner/scanner.component.spec.ts` covers scanner URL parsing for current-origin tickets, other-origin tenant tickets, malformed payloads, and non-exact scan paths.
+- `src/app/scanning/handle-registration/handle-registration.component.spec.ts` covers scanned-registration check-in button and spot-count labels.
+- `src/app/scanning/handle-registration/handle-registration.component.spec.ts` also covers the local check-in action guard for unavailable, completed, pending, and empty spot-count states, plus guest-count input clamping before mutation payload creation.
 - Server unit coverage proves future-event timing disables scan check-in and rejects direct check-in writes before the pre-start window opens. Server unit coverage also proves pending, cancelled, and waitlisted registrations disable scan check-in and reject direct check-in writes.
 - `tests/docs/events/register.doc.ts` documents that the ticket QR code is available after registration/payment and no longer claims QR email delivery exists in the current relaunch flow.
 - `tests/docs/events/event-management.doc.ts` documents the organizer-facing QR scan/check-in flow, including scan warnings, check-in authorization, buyer-plus-selected-guests checked-in count updates, and selected guest-quantity check-in.
@@ -892,14 +1012,21 @@ the current working direction until a product decision overrides them.
 ### Issues and Risks
 
 - **Addressed in stabilization pass:** create-account stores `communicationEmail`, and profile now shows the Auth0 login email separately from the editable notification email. Profile edit updates `communicationEmail` alongside name and reimbursement fields.
-- **Addressed in stabilization pass:** profile event cards now link to event details and show registration status, selected option, guest quantity when applicable, payment state, and check-in time when available. Profile still leaves QR/ticket display, cancellation/refund action, and transfer/resale workflows to the event-detail flow or future work while exposing pending checkout continuation directly.
+- **Addressed in stabilization pass:** profile event cards now link to event details and show registration status, selected option, guest quantity when applicable, payment state, and check-in time when available. Profile still leaves QR/ticket display, cancellation action, and unpaid transfer workflows to the event-detail flow while exposing pending checkout continuation directly.
 - **Addressed in stabilization pass:** profile event cards now label their event-details action as "Open event page" instead of implying that the profile card itself renders the ticket; confirmed ticket access remains on the event detail surface.
-- **Addressed in stabilization pass:** profile event cards now point pending checkout registrations at the implemented profile-level recovery action, route ticket, cancellation, and waitlist details back to the event page, and keep automatic refunds plus transfer/resale visibly out of the current implemented profile scope.
+- **Addressed in stabilization pass:** profile event cards now point pending checkout registrations at the implemented profile-level recovery action, route ticket, cancellation, unpaid transfer, and waitlist details back to the event page, and no longer carry deferred automatic-refund, paid-transfer, or resale copy.
+- **Addressed in stabilization pass:** checked-in profile event cards no longer advertise cancellation or transfer as available detail-page actions.
 - **Addressed in stabilization pass:** profile reimbursement fields are global user fields by product decision, and the profile copy now labels them as optional global reimbursement details used for manual receipt reimbursements across tenants.
+- **Addressed in stabilization pass:** profile edit now shares one tested
+  update-pending guard between the Edit profile button and handler, so a
+  profile update in flight cannot open another edit dialog on slow networks.
 - **Addressed in stabilization pass:** ESNcard save, refresh, and remove actions now clear stale errors, show visible pending button states, and map mutation failures through `getErrorMessage(...)` instead of rendering raw error objects.
+- **Addressed in this stabilization pass:** ESNcard save, refresh, and remove actions now share one in-flight guard so slow validation, refresh, or removal requests cannot overlap with another profile discount-card write.
+- **Addressed in this stabilization pass:** profile discount-card rows now render readable ESNcard status labels instead of raw persisted status values.
 - **Addressed in stabilization pass:** ESNcard validation now uses a bounded provider request and distinguishes provider unavailability from invalid/expired card results. Save/refresh mutations surface provider outages as retryable bad-request errors instead of collapsing them into card validation status.
 - **Addressed in stabilization pass:** create-account mutation failures now render a visible retryable error on the form instead of failing silently after the submit attempt.
 - **Addressed in stabilization pass:** the create-account form labels `communicationEmail` as "Notification email" so the UI, generated docs, and profile terminology agree that Auth0 login email and user-managed notification email are separate concepts.
+- **Addressed in this stabilization pass:** create-account submit handling now shares the same invalid/submitting/mutation-pending guard as the button disabled state, so duplicate submit events on slow account creation writes are ignored.
 - **Acceptable for now:** profile receipt reads are tenant-scoped and user-scoped through `finance.receipts.my`.
 - **Acceptable for now:** event price reads and registration writes both require a verified ESNcard in the current tenant before applying the ESNcard discount.
 
@@ -907,15 +1034,19 @@ the current working direction until a product decision overrides them.
 
 - `tests/docs/profile/user-profile.doc.ts` documents navigation, profile display, edit dialog validation, notification email persistence, event cards, and the receipts tab.
 - `src/app/profile/user-profile/edit-profile-dialog.component.spec.ts` covers profile edit payload normalization for notification email and optional global reimbursement details before the update mutation receives the dialog result.
-- `src/app/profile/user-profile/user-profile.component.spec.ts` covers profile event action, guest-quantity, deferred-action notes, payment-continuation next-step copy, payment-state, registration-status labels, submitted-receipt status labels, ESNcard upsert payload normalization, and readable ESNcard mutation error fallback/provider messages.
+- `src/app/profile/user-profile/user-profile.component.spec.ts` covers profile event action routing, payment-continuation visibility, guest-quantity, checked-in action copy, implemented-action notes, payment-continuation next-step copy, payment-state, registration-status labels, submitted-receipt status and amount labels, ESNcard action/status labels, ESNcard save disabled state, ESNcard upsert payload normalization, and readable ESNcard mutation error fallback/provider messages.
+- Profile app coverage pins that profile edit is disabled while the profile
+  update mutation is pending.
+- Profile app coverage also pins that ESNcard save, refresh, and remove actions
+  all stay disabled while any ESNcard write is pending.
 - **Addressed in stabilization pass:** the profile doc no longer uses a fixed stabilization wait before the profile screenshot, now saves and verifies notification email persistence, and opens the Events section to document event-card semantics.
 - `tests/docs/profile/discounts.doc.ts` documents the discount-card section and current pending/error behavior, but does not add, refresh, remove, or assert any ESNcard validation outcome.
 - `tests/specs/discounts/esn-discounts.test.ts` verifies a seeded verified ESNcard affects paid event price labels and the register button copy.
-- No reviewed Playwright spec proves profile discount-card management itself, browser-level account creation fallback behavior without Auth0 Management credentials, profile event action rendering, or submitted receipt visibility after receipt submission.
+- No reviewed Playwright spec proves profile discount-card management itself, browser-level account creation fallback behavior without Auth0 Management credentials, profile event action rendering, or submitted receipt visibility after receipt submission. Local helper/server coverage now pins the visible profile/account copy and action states that can be verified without page-backed runtime.
 - `tests/docs/users/create-account.doc.ts` is integration-tagged and skips without Auth0 Management credentials, so baseline docs do not prove the account-creation path.
 - `tests/docs/users/create-account.doc.ts` asserts the account form exposes the editable address as "Notification email" when the integration path can run.
 - `src/app/app.routes.spec.ts` pins the relaunch route contract that public event browsing uses only account-assignment checks, feature areas require assigned authenticated accounts, `/create-account` stays auth-only for tenantless authenticated users, and `/global-admin` remains auth-only before tenant assignment checks.
-- `src/app/core/create-account/create-account.helpers.spec.ts` covers Auth0-data prefill fallback, explicit email-verification gating, create-account submit payload normalization, and create-account error message mapping without needing Auth0 Management credentials.
+- `src/app/core/create-account/create-account.helpers.spec.ts` covers Auth0-data prefill fallback, explicit email-verification gating, create-account submit payload normalization, retryable submit disabled state, and create-account error message mapping without needing Auth0 Management credentials.
 - `src/shared/rpc-contracts/app-rpcs/users.rpcs.spec.ts` covers notification email format validation at the account-creation and profile-update RPC boundary, matching the create-account and profile-edit form validation.
 - `src/server/discounts/providers/index.spec.ts` covers ESNcard provider validation parsing and provider-unavailable distinction without hitting the external provider.
 - `src/server/effect/rpc/handlers/discounts.handlers.spec.ts` covers global-per-user ESNcard reads, updating an existing global user card from another tenant context, refresh revalidation persistence, and current-user/type-scoped card removal.
@@ -935,7 +1066,7 @@ the current working direction until a product decision overrides them.
 - Keep Browser-backed profile edit persistence coverage aligned with notification email behavior.
 - Add Browser-backed profile event-card coverage for event links and registration/guest/payment/check-in state once runtime review is available.
 - Add Browser-backed profile discount-card tests for add/refresh/remove and provider validation outcomes once runtime review is available. Local app/server coverage already proves upsert payload normalization, readable mutation errors, global card reads/upserts, refresh persistence, and scoped removal.
-- Add profile/account tests for account creation retry/tenant-join behavior, profile edit persistence, ESNcard add/refresh/remove, profile event action rendering, and submitted receipt visibility.
+- Add Browser-backed profile/account coverage for account creation retry/tenant-join behavior, profile edit persistence, ESNcard add/refresh/remove, profile event action rendering, and submitted receipt visibility once local runtime review is available. Local helper/server coverage already covers account creation retry/tenant join, profile edit payload persistence, ESNcard action labels/errors/payloads, profile event labels/actions, and submitted receipt status/amount/server rows.
 
 ## Tenant/Global Admin
 
@@ -943,12 +1074,12 @@ the current working direction until a product decision overrides them.
 
 - Tenants are resolved from request host first. On local hosts, the `evorto-tenant` cookie can select the tenant domain; otherwise the host domain is authoritative.
 - If tenant resolution fails, SSR and RPC requests fail closed with a 404. A local probe with `Host: no-such-tenant.invalid` returned 404.
-- Tenant records currently store one unique `domain`, name, currency, locale, timezone, theme, default location, Stripe account id, receipt settings, discount provider settings, SEO title/description, tenant legal links, hosted legal text, and externally hosted logo/favicon URLs.
+- Tenant records currently store one unique `domain`, name, currency, locale, timezone, theme, default location, Stripe account id, receipt settings, discount provider settings, SEO title/description, tenant legal links, hosted legal text, and app-origin or externally hosted logo/favicon URLs.
 - Client config loads the current tenant and permission list through RPC and applies `theme-${tenant.theme}` to the document root.
-- Tenant admin "General settings" shows a read-only identity summary with tenant name, primary domain, currency, locale, timezone, and Stripe connection state. It lets tenant admins change default location, site theme, externally hosted logo/favicon URLs, SEO title/description, legal links or hosted legal text, receipt countries/allow-other, and ESNcard provider enablement plus buy URL. Configured legal URLs appear in the public app footer as off-site links; configured hosted legal text appears through public `/legal/*` pages. Configured favicon URLs update the browser tab icon.
+- Tenant admin "General settings" shows a read-only identity summary with tenant name, primary domain, currency, locale, timezone, and Stripe connection state including the connected account id when configured. It lets tenant admins change default location, site theme, uploaded or externally hosted logo/favicon URLs, SEO title/description, legal links or hosted legal text, receipt countries/allow-other, and ESNcard provider enablement plus buy URL. Configured legal URLs appear in the public app footer as off-site links; configured hosted legal text appears through public `/legal/*` pages. Configured favicon URLs update the browser tab icon.
 - Tenant settings writes are tenant-scoped and require `admin:changeSettings`; tax-rate admin reads/writes require `admin:tax`.
 - `/global-admin` is guarded by authentication at the app route and by `globalAdmin:manageTenants` in the global-admin route config. The navigation link is hidden behind `globalAdmin:*`, and the tenant list RPC requires `globalAdmin:manageTenants`.
-- Global admin currently exposes a searchable tenant list and read-only tenant detail review with non-sensitive operational tenant state. There is no tenant create/edit/custom-domain/impersonation flow.
+- Global admin currently exposes a searchable tenant list, tenant create/edit flows for the one active primary domain and operational tenant settings, and tenant detail review with non-sensitive operational tenant state. Custom-domain verification, multi-domain automation, and impersonation remain deferred.
 - Global-admin permissions are derived from Auth0 app metadata `evorto.app/app_metadata.globalAdmin === true` independently from current-tenant membership. Tenant user context still requires a current-tenant assignment.
 - Anonymous direct `/global-admin` redirects to Auth0. Stored auth states were stale, so authenticated global-admin UI was not reverified through Playwright in this pass.
 
@@ -964,19 +1095,33 @@ the current working direction until a product decision overrides them.
 
 - **Addressed in stabilization pass:** root product and architecture docs now state the relaunch domain scope honestly: one active primary domain per tenant, with automated multi-domain/custom-domain verification deferred to later tenant-onboarding work.
 - **Addressed in stabilization pass:** tenant general settings now expose tenant name, primary domain, and Stripe connection state as read-only operator context.
-- **Addressed in stabilization pass:** tenant general settings now include a visible deferred-settings summary for custom-domain verification, logo/favicon uploads beyond externally hosted URLs, email sender name, review/publishing settings, registration limits, and Stripe account management. These fields are still not editable unless explicitly called out below.
+- **Addressed in this stabilization pass:** tenant general-settings identity rows now include the connected Stripe account id when present, matching the support lookup detail already exposed in global-admin tenant review.
+- **Addressed in stabilization pass:** tenant general settings now include a visible deferred-settings summary for custom-domain verification, email sender name, review/publishing settings, registration limits, and Stripe account management. These fields are still not editable unless explicitly called out below.
 - **Addressed in this stabilization pass:** supported tenant currency, locale, and timezone values are now editable from general settings, persisted through `admin.tenant.updateSettings`, and validated against the shared Tenant relaunch policy before the RPC responds.
 - **Addressed in this stabilization pass:** general settings reloads the app after saved currency, locale, or timezone changes so Angular's bootstrap-level currency and locale providers are refreshed instead of leaving the current session on stale formatting defaults.
 - **Addressed in stabilization pass:** tenant logo and favicon URLs are now part of the `Tenant` RPC schema, editable from general settings, validated by `admin.tenant.updateSettings`, persisted with empty values normalized to `null`, and the configured favicon updates the browser tab icon.
+- **Addressed in stabilization pass:** tenant logo and favicon uploads now use the app's object-storage path and return stable app-origin `/tenant-assets/*` URLs that can be saved through the existing tenant settings form. Logo uploads accept PNG, JPEG, WebP, or GIF files; favicon uploads also accept ICO files. SVG uploads stay unsupported for this path.
+- **Addressed in this stabilization pass:** tenant logo and favicon upload actions now stay disabled while any brand asset upload is active or the upload mutation is pending, and duplicate file-change events are ignored instead of starting another upload.
 - **Addressed in stabilization pass:** tenant SEO title and description are now part of the `Tenant` RPC schema, editable from general settings, persisted by `admin.tenant.updateSettings`, and used as the tenant-level document title/meta description when configured.
 - **Addressed in stabilization pass:** tenant imprint/legal notice, privacy policy, and terms URLs are now part of the `Tenant` RPC schema, editable from general settings, validated by `admin.tenant.updateSettings`, persisted with empty values normalized to `null`, and rendered in the public app footer when configured.
 - **Addressed in stabilization pass:** tenant-admin child routes now have route-level guards. Settings require `admin:changeSettings`, roles require `admin:manageRoles`, users require `users:viewAll`, tax rates require `admin:tax`, and event reviews require `events:review`.
 - **Addressed in stabilization pass:** tenant settings saves now show a success notification and map failed updates through the shared readable error-message helper instead of relying only on mutation state.
+- **Addressed in this stabilization pass:** tenant general-settings save actions now stay disabled while the update mutation is pending, and the submit handler ignores duplicate submit events during the in-flight settings write.
 - **Addressed in stabilization pass:** tenant general-settings documentation now covers the implemented relaunch surface and explicitly calls out deferred domain, branding upload, email sender, review policy, registration limit, and Stripe-account settings.
 - **Addressed in stabilization pass:** tenant-hosted legal text is now editable alongside external legal URLs. The public footer links to external URLs when configured, otherwise it links to hosted `/legal/imprint`, `/legal/privacy`, and `/legal/terms` pages when tenant text exists.
 - **Addressed in stabilization pass:** the tenant settings RPC payload schema is now exported and covered by a focused contract spec, including the current editable fields and the fact that deferred branding/domain fields are outside the update payload.
 - **Addressed in stabilization pass:** tenant general-settings payload shaping is now extracted and covered locally, including trim/blank normalization for editable URLs/SEO/ESNcard fields before the RPC call.
-- **Addressed in stabilization pass:** the global-admin tenant list and read-only detail page render the tenant operational state returned by the RPC, and generated docs describe the current searchable list plus detail-review global tenant administration surface.
+- **Addressed in stabilization pass:** the global-admin tenant list and read-only detail page render the tenant operational state returned by the RPC, including connected Stripe account ids for support lookup, and generated docs describe the current searchable list plus detail-review global tenant administration surface.
+- **Addressed in stabilization pass:** global-admin tenant create/edit now supports the relaunch one-domain tenant administration surface: name, primary domain, theme, locale, currency, timezone, and connected Stripe account id.
+- **Addressed in stabilization pass:** global-admin tenant create/edit normalizes the primary-domain form value to the same single-host shape enforced by the server and keeps the one-domain/custom-domain-automation deferral visible in the form.
+- **Addressed in this stabilization pass:** global-admin tenant create/edit now
+  shows the relaunch tenant scope as a visible form notice: one active primary
+  domain, deferred custom-domain verification and multi-domain automation, and
+  no tenant-admin impersonation from the form.
+- **Addressed in stabilization pass:** global-admin tenant create/edit submit
+  actions now stay disabled while the create/update mutation is pending and
+  the submit handlers ignore duplicate submit events during the in-flight
+  mutation.
 - **Acceptable for now:** tenant settings writes are scoped to the current tenant id and validate the returned tenant shape before responding.
 - **Acceptable for now:** unknown host requests fail closed with 404 instead of guessing a tenant.
 - **Acceptable for now:** RPC request-context headers are overwritten server-side before handler execution, so client-supplied `x-evorto-*` headers are not trusted as the source of tenant/user context.
@@ -988,14 +1133,21 @@ the current working direction until a product decision overrides them.
 - `src/app/core/effect-rpc-angular-client.spec.ts` covers SSR RPC origin selection from incoming URL and forwarded headers.
 - `tests/specs/auth/storage-state-refresh.test.ts` covers stale/wrong tenant cookies in saved Playwright storage state, not runtime tenant resolution.
 - `tests/specs/permissions/tenant-isolation-tax-rates.spec.ts` checks seeded tenant tax-rate isolation directly in the database, but does not exercise the RPC/UI tenant context switch.
-- `tests/specs/permissions/matrix.spec.ts` covers route denial for `/admin/settings`, `/admin/roles`, `/admin/users`, `/admin/tax-rates`, `/finance/transactions`, `/finance/receipts-approval`, `/finance/receipts-refunds`, and template write routes. `tests/specs/finance/tax-rates/admin-import-tax-rates.spec.ts` adds focused tax-rate route denial coverage. Route-manifest unit specs cover admin, finance, template, and global-admin guard declarations without requiring page-backed runtime. `tests/specs/permissions/global-admin-route-guard.spec.ts` covers direct `/global-admin` and `/global-admin/tenants/:tenantId` allow/deny behavior once page-backed runtime is available.
-- `tests/docs/admin/general-settings.doc.ts` documents the current tenant general-settings page, including the deferred-settings summary, read-only tenant identity summary, editable locale/money policy plus reload behavior, editable brand asset URLs, editable tenant legal links or hosted text, and public footer/favicon exposure, and records which branding/domain settings are not editable yet.
-- `tests/docs/admin/global-admin.doc.ts` documents the current searchable global-admin tenant list and read-only tenant detail review, and records that tenant creation/editing, custom-domain verification, and impersonation workflows are not implemented yet.
+- `tests/specs/permissions/matrix.spec.ts` covers route denial for `/admin/settings`, `/admin/roles`, `/admin/users`, `/admin/tax-rates`, `/finance/transactions`, `/finance/receipts-approval`, `/finance/receipts-refunds`, and template write routes. `tests/specs/finance/tax-rates/admin-import-tax-rates.spec.ts` adds focused tax-rate route denial coverage. Route-manifest unit specs cover admin, finance, template, and global-admin guard declarations without requiring page-backed runtime. `tests/specs/permissions/global-admin-route-guard.spec.ts` covers direct `/global-admin`, `/global-admin/tenants/create`, `/global-admin/tenants/:tenantId`, and `/global-admin/tenants/:tenantId/edit` allow/deny behavior once page-backed runtime is available.
+- `tests/docs/admin/general-settings.doc.ts` documents the current tenant general-settings page, including the deferred-settings summary, read-only tenant identity summary with Stripe account support lookup detail, editable locale/money policy plus reload behavior, uploaded or externally hosted brand asset URLs, editable tenant legal links or hosted text, and public footer/favicon exposure, and records which domain/operations settings are not editable yet.
+- `tests/docs/admin/global-admin.doc.ts` documents the current searchable global-admin tenant list, tenant create/edit workflow, visible relaunch tenant-scope notice, and tenant detail review, and records that custom-domain verification, multi-domain automation, and impersonation workflows are not implemented yet.
 - `tests/docs/finance/inclusive-tax-rates.doc.ts` documents tenant tax-rate management.
+- `src/app/admin/components/import-tax-rates-dialog/import-tax-rates-dialog.component.spec.ts` covers the local Stripe tax-rate import guard so empty selections and pending imports cannot submit duplicate tax-rate writes.
 - `src/shared/rpc-contracts/app-rpcs/admin.rpcs.spec.ts` covers the tenant settings update payload scope.
 - `src/app/admin/general-settings/general-settings.payload.spec.ts` covers the client-side tenant-settings payload sent by the form, including trimmed optional editable fields and blank-to-undefined normalization.
-- `src/app/global-admin/global-admin.routes.spec.ts` covers route-level global-admin permission requirements.
-- `src/server/effect/rpc/handlers/global-admin.handlers.spec.ts` covers explicit `globalAdmin:manageTenants` authorization, `globalAdmin:*` dependency authorization, and fail-closed forbidden/unauthorized tenant-list reads before querying tenants.
+- `src/app/admin/general-settings/general-settings.component.spec.ts` covers
+  tenant settings save disabling for invalid, submitting, and mutation-pending
+  states, plus brand-asset upload disabling while any upload is active or
+  mutation-pending.
+- `src/app/global-admin/global-admin.routes.spec.ts` covers route-level global-admin permission requirements for list, create, detail, and edit routes.
+- `src/app/global-admin/tenant-form/tenant-form.model.spec.ts` covers create/edit payload shaping, including primary-domain normalization and path rejection before the RPC call, plus disabled submit state for invalid, submitting, and mutation-pending tenant writes.
+- `src/app/global-admin/tenant-list/tenant-list.rows.spec.ts` covers global-admin tenant operational rows, readable Stripe account labels, and search across support fields including connected Stripe account ids.
+- `src/server/effect/rpc/handlers/global-admin.handlers.spec.ts` covers explicit `globalAdmin:manageTenants` authorization, `globalAdmin:*` dependency authorization, tenant create/update normalization, and fail-closed forbidden/unauthorized tenant-list reads before querying tenants.
 - `src/server/context/request-context-resolver.spec.ts` covers host-first tenant resolution, localhost tenant-cookie fallback, stale localhost tenant-cookie fallback, unknown-host failure, global-admin permissions resolving without a tenant user assignment, and tenant-user context failing closed when the Auth0 user has no current-tenant assignment.
 - Playwright browser probing was limited because the bundled Playwright browser was not installed and stored auth states were stale; system Chrome confirmed anonymous/global-admin redirects to Auth0.
 
@@ -1012,9 +1164,12 @@ the current working direction until a product decision overrides them.
 
 - Keep one-domain-per-tenant documented and visible as the relaunch scope; leave
   automated multi-domain/custom-domain management for later work.
-- Keep generated global-admin tenant-management documentation aligned if the surface expands beyond the current read-only list/detail review.
+- Keep generated global-admin tenant-management documentation aligned as tenant create/edit, custom-domain verification, multi-domain automation, or impersonation support changes.
 - Keep tenant settings save feedback aligned with the shared notification/error-message pattern.
+- Keep tenant settings save guards aligned with the actual mutation lifecycle,
+  not only the signal-form submit callback.
 - Keep tenant SEO title/description, legal links, and hosted legal text aligned between the Tenant RPC schema, general settings, public footer/pages, and generated documentation.
+- Keep tenant brand-asset upload guards aligned with the actual upload mutation lifecycle, not only the visible upload button state.
 
 ## Generated Documentation and Playwright Coverage
 
@@ -1022,7 +1177,7 @@ the current working direction until a product decision overrides them.
 
 - Playwright has separate baseline spec and docs projects. Baseline specs exclude `tests/docs/**`; docs baseline runs `tests/docs/**/*.doc.ts`; integration-only docs are selected with `@needs-*` tags.
 - Local docs/spec discovery is runnable again after replacing stale Effect config APIs in `playwright.config.ts` and Playwright support files, and Auth0 Management credentials are no longer required just to import baseline fixtures.
-- `bun run test:e2e -- --list` discovers 81 baseline tests across 23 files,
+- `bun run test:e2e -- --list` discovers 86 baseline tests across 24 files,
   including setup projects, without requiring local Auth0/Stripe secrets.
 - `bun run test:e2e:docs -- --list` discovers 25 baseline docs/setup tests
   across 18 files without requiring local Auth0/Stripe secrets.
@@ -1050,10 +1205,10 @@ the current working direction until a product decision overrides them.
 - **Addressed in stabilization pass:** participant-facing event registration cards now receive tax-rate label metadata from `events.findOne`, render paid option prices through the shared inclusive tax label component, and have page-level Playwright assertions for the seeded inclusive-price states.
 - **Should fix before relaunch:** page-backed Playwright specs still fail in this checkout because the configured Chromium binary is missing. `tests/specs/screenshot/doc-screenshot.test.ts` seeds data and then fails at browser launch.
 - **Addressed in stabilization pass:** `tests/test-inventory.md` now maps current Playwright specs/docs by suite ownership, records intentional fixme and credential-gated paths, and lists the Browser-backed coverage still needed from the remaining stabilization gaps.
-- **Addressed in stabilization pass:** the remaining `test.skip` audit removed the dead mobile skip from `tests/specs/permissions/override.test.ts`, corrected the inventory entry for that spec, made the Auth0 Management doc skip name the required credentials explicitly, and moved Stripe webhook replay's credential gate to a file-level skip before page/database fixtures are requested.
+- **Addressed in stabilization pass:** the remaining `test.skip` audit removed the dead mobile skip from `tests/specs/permissions/override.test.ts`, corrected the inventory entry for that spec, made the Auth0 Management doc skip name the required credentials explicitly, moved Stripe webhook replay's credential gate to a file-level skip before page/database fixtures are requested, and keeps the skip/fixme allowlist tied to explicit local reasons.
 - **Addressed in stabilization pass:** global-admin route guard coverage now has a direct Playwright spec for the global-admin allow path and signed-in non-global-admin deny path.
 - **Addressed in stabilization pass:** scanning/check-in docs now describe the dedicated QR scanner, scan warnings, authorization, checked-in count updates, and selected guest-quantity check-in. The remaining scanner follow-up is Browser-backed organizer aggregate assertion, not missing product documentation.
-- **Should fix before relaunch:** docs coverage is still missing or thin for tenant/global-admin settings beyond the current list/settings pages, account creation outside Auth0-management integration, profile discount add/refresh/remove flows, role assignment/user management, and registration negative paths.
+- **Should fix before relaunch:** page-backed docs coverage is still missing or thin for tenant/global-admin settings beyond the current list/settings pages, account creation outside Auth0-management integration, profile discount add/refresh/remove flows, role assignment/user management, and registration negative paths. Local unit/server coverage exists for several of those surfaces, but it does not replace Browser-backed docs for the full user journeys.
 - **Addressed in stabilization pass:** the generic `tests/docs/template.doc.ts` discovery placeholder was removed; current template documentation lives in `tests/docs/templates/templates.doc.ts`.
 - **Addressed in stabilization pass:** the focused `docScreenshot` helper now resolves `DOCS_IMG_OUT_DIR` at call time instead of import time, so tests and docs jobs can set output paths per run. Some docs journeys still contain fixed waits and should be tightened as those flows are revisited.
 - **Addressed in stabilization pass:** `tests/docs/events/event-management.doc.ts` now waits on concrete headings instead of fixed one-second delays before its major screenshots.
@@ -1091,7 +1246,7 @@ the current working direction until a product decision overrides them.
 
 - Keep active price-label specs aligned with seeded event and template tax-rate data as price display behavior changes.
 - Keep event-management and finance-overview docs aligned as the live UI changes; both were rewritten during this stabilization pass and should not be treated as stale product truth.
-- Continue auditing remaining `test.skip` usage so credential/integration skips stay honest and fixture-state gaps become hard failures or explicit `test.fixme` states.
+- Continue auditing remaining `test.skip` usage so credential/integration skips stay honest and fixture-state gaps become hard failures or explicit, reason-recorded `test.fixme` states.
 - Keep docs/list commands free of reporter output cleanup, runtime secret requirements, and local browser startup.
 - Update `tests/test-inventory.md` after stale/placeholder docs are pruned.
 - Add missing docs/specs for tenant/global-admin settings, account/profile persistence, role/user management, and negative registration paths as those flows are stabilized.
@@ -1131,6 +1286,7 @@ the current working direction until a product decision overrides them.
 - **Addressed in stabilization pass:** `bun run docker:resume` now provides a non-recreating resume path for an already initialized Docker stack, while `docker:start`, `docker:start:foreground`, and `docker:start:watch` keep the explicit reset-from-zero behavior.
 - **Addressed in this stabilization pass:** `bun run docker:check` reports missing Neon Local, Auth0, Stripe, session, and Font Awesome registry variables before Docker Compose mutates local containers. Docker now writes the same Font Awesome registry scopes as the checked-in `.npmrc`, so premium and brand icon packages can use the same build-secret token path. It also reports local tool readiness and warns when Playwright browsers are missing without blocking Docker start. The Compose-managed Stripe CLI listener writes its generated webhook signing secret into a shared volume and the app reads it through `STRIPE_WEBHOOK_SECRET_FILE`, so a static `STRIPE_WEBHOOK_SECRET` is no longer a Docker-start blocker. The current worktree is missing `NEON_API_KEY`, `CLIENT_SECRET`, and `STRIPE_API_KEY`, so a fresh full Docker start is intentionally blocked until those secrets are provided.
 - **Addressed in stabilization pass:** `helpers/testing/runtime-preflight.spec.ts` now pins that destructive Docker start scripts call `docker:check` first, required runtime variables are wired into Compose services, and Font Awesome registry access remains available to Docker through the same secret path for premium and brand icon packages.
+- **Addressed in this stabilization pass:** remaining Angular Material icon usage for app action icons was removed from the role, event-review, template-list, and template-category surfaces. App source coverage now keeps Angular app icons on the Font Awesome component path, so premium and brand icon packages continue using the same package/token mechanic instead of a separate Material icon registry path.
 - **Addressed in stabilization pass:** `specs/seed/seed-baseline.test.ts` now treats the reset-from-zero seed as a runtime contract: default user/organizer roles, every template seed family, paid/free registration options, paid tax-rate wiring, open/closed/draft/past scenario handles, confirmed registrations, and scanner aggregate data must all exist after seeding.
 - **Addressed in stabilization pass:** `.env.example` is now a checked-in
   no-secret checklist for Docker-required local secrets, and runtime preflight
@@ -1181,19 +1337,21 @@ the current working direction until a product decision overrides them.
 
 ### Should Fix Before Relaunch
 
-1. Implement transfer/resale; keep automatic refund handling visible until the finance flow is implemented.
+1. Implement paid transfer/resale money movement, resale-specific workflows, and automatic refund handling. Participant and organizer-assisted unpaid transfer now exist for confirmed, not checked-in registrations.
 2. Run the active negative-registration Playwright coverage once local runtime
    is available; `specs/events/negative-registration-states.spec.ts` now covers
    closed registration windows, role-ineligible direct links, and waitlist
    affordances.
-3. Keep simple-mode templates as the primary authoring UI, but expand reusable template support for discounts, add-ons, and questions where practical. Organizer planning tips are now exposed as the first private organizer-notes field.
-4. Execute the covered legacy-field migration path during production cut-over so
-   any existing physical `showInHub`, `paymentStatus`, and `payment_status`
-   artifacts are dropped now that active schema/API code no longer uses them.
-5. Add Browser-backed scanner/organizer aggregate review once local runtime is available.
-6. Add Browser-backed profile coverage for payment-continuation, ticket/cancellation routing, waitlist messaging, and ESNcard provider failure semantics once local runtime is available.
-7. Fill the remaining tenant settings implementation gap for branding uploads and onboarding/domain workflows. The current general-settings page exposes SEO fields, externally hosted logo/favicon URLs, tenant legal links or hosted legal text, editable supported locale/currency/timezone values, read-only runtime identity, and a visible deferred-settings summary. The current global-admin surface supports a searchable tenant list plus read-only tenant detail review, while tenant creation/editing, custom-domain verification, and impersonation remain out of scope.
-8. Keep `docker:start` reset behavior intentional, use `docker:resume` only for existing local stacks, and ensure seeded data is sufficient to get going from zero.
+3. Keep simple-mode templates as the primary authoring UI, but expand reusable
+   template support for discounts, add-ons, and questions where practical.
+   Organizer planning tips are now exposed as the first private organizer-notes
+   field, and existing reusable template add-ons are now visible on template
+   detail. Add-on authoring/copying and registration questions remain separate
+   fuller product/runtime slices.
+4. Add Browser-backed scanner/organizer aggregate review once local runtime is available.
+5. Add Browser-backed profile coverage for payment-continuation, ticket/cancellation routing, waitlist messaging, and ESNcard provider failure semantics once local runtime is available.
+6. Fill the remaining tenant settings implementation gap for automated onboarding/domain workflows. The current general-settings page exposes SEO fields, uploaded or externally hosted logo/favicon URLs, tenant legal links or hosted legal text, editable supported locale/currency/timezone values, read-only runtime identity, and a visible deferred-settings summary. The current global-admin surface supports a searchable tenant list, tenant create/edit, and tenant detail review, while custom-domain verification, multi-domain automation, and impersonation remain out of scope.
+7. Keep `docker:start` reset behavior intentional, use `docker:resume` only for existing local stacks, and ensure seeded data is sufficient to get going from zero.
 
 ### Acceptable For Now
 
@@ -1261,6 +1419,9 @@ implement those decisions or explicitly revise them there before changing code.
   the users RPC contract boundary.
 - Profile/account route-contract pass: added root route-manifest coverage so `/create-account` remains reachable to authenticated users without a tenant assignment while protected feature routes keep assigned-account and auth guards.
 - Permission reference docs pass: added a generated about-permissions documentation source backed by shared permission metadata so the role-creation docs no longer link to a missing checked-in source.
+- Role form submit-guard pass: shared a tested role submit-disabled helper
+  between the role-form template and submit handler, and guarded parent
+  create/edit handlers against duplicate in-flight role writes.
 - Template tax-rate coverage pass: covered the compatible active/inclusive current-tenant tax-rate query and paid missing-tax-rate submit normalization so the remaining fixme is narrowed to page-level simple-mode UI assertions.
 - Scanner aggregate coverage pass: extracted organizer overview stat aggregation and covered the checked-in total against registration-option `checkedInSpots`, keeping local app logic aligned with scanner mutation counters while Browser aggregate review remains blocked.
 - Profile edit-dialog coverage pass: covered profile edit payload normalization so notification email and optional global reimbursement details are trimmed/null-normalized before persistence.
@@ -1288,10 +1449,28 @@ implement those decisions or explicitly revise them there before changing code.
 - Receipt reimbursement wording pass: renamed finance-facing receipt reimbursement copy away from "refund" for manual ledger actions while leaving legacy internal route/API/database names for a later migration.
 - Receipt amount validation pass: rejected receipt submit/review payloads where tax exceeds the total amount and added focused server coverage for both write paths.
 - Payment-status deprecation pass: stopped active profile/user-event reads and fixture setup from relying on `event_registrations.paymentStatus`; user-facing payment state now derives from registration transaction rows, and the legacy field/enum have been removed from the application schema.
-- Receipt timing pass: restricted receipt submission to events whose end time has passed and pointed receipt Playwright setup at the deterministic past event fixture.
-- Receipt timing backlog cleanup: removed the stale relaunch checklist item that still treated pre-event receipt submission policy as undecided after the server rule, Playwright setup, and finance notes had already settled on post-event submission.
+- Receipt timing pass: aligned receipt submission with the pre-event spending
+  decision by removing the event-end-time gate while keeping event existence,
+  tenant scoping, and receipt-submit authorization checks in place.
+- Receipt timing backlog cleanup: replaced the stale post-event submission note
+  with the current pre-event spending/submission decision and server coverage.
+- Receipt submission guard pass: kept the organizer Add receipt action disabled
+  during both upload and submit mutations, with the template and handler sharing
+  the same tested helper.
+- Receipt review action guard pass: shared the receipt approval/rejection
+  disabled state and handler early return so invalid, loading, and
+  mutation-pending review writes cannot double-submit.
+- Receipt reimbursement action guard pass: shared the reimbursement record
+  disabled state and handler early return so missing payout inputs and
+  mutation-pending writes cannot duplicate reimbursement transactions.
+- Scanner action guard pass: kept the scanned-registration check-in action
+  disabled after a successful local write while the scan-result query refetches,
+  with the template and handler sharing the same tested helper.
 - Scanner status-coverage pass: added focused scan-read and direct-check-in coverage for pending, cancelled, and waitlisted registrations.
 - Tenant settings feedback pass: added explicit success and readable error notifications for general settings saves.
+- Tenant settings save-guard pass: shared a tested save-disabled helper between
+  the general-settings template and submit handler so invalid, submitting, and
+  mutation-pending settings writes cannot double-submit on slow networks.
 - Tenant SEO settings pass: exposed stored tenant SEO title/description through the Tenant RPC schema, general settings UI, admin settings persistence, and tenant-level document metadata.
 - Tenant domain-scope docs pass: aligned root product/architecture docs with the current one-active-domain relaunch model and left automated multi-domain/custom-domain verification as later tenant-onboarding work.
 - Tenant locale/timezone contract pass: narrowed the shared Tenant contract to
@@ -1356,9 +1535,23 @@ implement those decisions or explicitly revise them there before changing code.
   route, and UI so platform admins can review one tenant's operational state
   from the searchable tenant list without introducing tenant editing or
   impersonation semantics.
+- Global-admin tenant-create/edit pass: added guarded platform-admin tenant
+  create/edit RPCs and routes for the one-domain relaunch model, covering
+  tenant name, primary domain, theme, locale, currency, timezone, and connected
+  Stripe account id while keeping custom-domain verification and impersonation
+  deferred.
+- Global-admin tenant-submit guard pass: kept tenant create/edit submit actions
+  disabled while the create/update mutation is pending and ignored duplicate
+  submit events during in-flight writes.
+- Global-admin tenant-scope notice pass: showed the one-domain relaunch scope,
+  deferred custom-domain/multi-domain automation, and absent impersonation flow
+  directly in tenant create/edit forms, with local form-model coverage and docs
+  alignment.
 - Global-admin route-guard coverage pass: extended the page-backed direct-route
-  guard spec and inventory notes to cover `/global-admin/tenants/:tenantId` in
-  addition to the global-admin shell route.
+  guard spec and inventory notes to cover `/global-admin/tenants/create`,
+  `/global-admin/tenants/:tenantId`, and
+  `/global-admin/tenants/:tenantId/edit` in addition to the global-admin shell
+  route.
 - User-list pagination pass: fixed the read-only tenant user list to paginate
   tenant-user assignments before loading role rows, so users with multiple
   roles no longer consume multiple page slots.
@@ -1373,6 +1566,11 @@ implement those decisions or explicitly revise them there before changing code.
   scripts remain gated by `docker:check`, Compose consumes the required runtime
   variables, and the Font Awesome build secret path continues to support both
   premium and brand icon packages.
+- Profile action-helper coverage pass: moved the profile pending-checkout
+  continuation rule into a tested helper so the card only renders the external
+  payment action for pending registrations with a checkout URL while all event
+  states continue routing users back to the event page for ticket,
+  cancellation, and waitlist details.
 - Migration docs alignment pass: refreshed `migration/README.md` to document
   the current global migration-step phase, including idempotent DDL cleanup for
   legacy physical fields, and removed stale conductor/track guidance.
@@ -1409,6 +1607,43 @@ implement those decisions or explicitly revise them there before changing code.
   waitlist registration before event start, decrementing `waitlistSpots`
   transactionally and exposing **Leave waitlist** copy on the active
   registration card.
+- Registration cancellation counter coverage pass: routed cancellation counter
+  rollback through the shared buyer-plus-guest spot-count helper and covered
+  pending and confirmed guest cancellations so reserved/confirmed spot
+  decrement behavior stays pinned without Browser/runtime setup.
+- Template create-event submit-guard pass: shared the create-event-from-template
+  submit disabled state and handler early return so invalid, submitting, and
+  mutation-pending writes cannot duplicate event creation.
+- Tenant event-review queue guard pass: shared the Approve/Reject disabled
+  state and handler early return so mutation-pending reviews cannot open a
+  second rejection dialog or submit another lifecycle write.
+- Organizer-assisted transfer primitive pass: added
+  `events.findTransferTargets` and `events.transferEventRegistration` RPCs for
+  confirmed, not checked-in, unpaid registrations, gated them to event
+  organizers or `events:organizeAll`, required the target user to belong to the
+  current tenant and remain eligible for the registration option, rejected
+  duplicate active target registrations, and kept paid transfer blocked until
+  refund/resale money movement exists.
+- Organizer-assisted transfer UI pass: exposed the unpaid transfer primitive on
+  the organizer overview for not-yet-checked-in participant registrations,
+  added an eligible-member lookup dialog, refreshed organizer/event data after
+  successful transfer, and updated generated event-management docs to separate
+  organizer-assisted unpaid transfer from participant self-service resale and
+  paid money movement.
+- Organizer action guard pass: shared the organizer overview checked-in and
+  mutation-pending guard across cancellation and organizer-assisted transfer
+  buttons plus handlers, keeping duplicate or already-checked-in participant
+  mutations blocked locally.
+- Event review action guard pass: shared event detail review and
+  submit-for-review guards between template disabled state and handler early
+  returns, keeping pending review writes from double-triggering on slow
+  networks.
+- Participant unpaid transfer pass: added `events.transferMyRegistration` so a
+  participant can transfer their own confirmed, not checked-in, unpaid
+  registration to an existing eligible tenant user by email, exposed the action
+  on active registration cards only when the server marks the registration
+  transferable, and updated profile/event docs to route unpaid transfer details
+  through the event page while keeping paid transfer/resale and refunds honest.
 - Profile payment next-step coverage pass: extracted the profile event-card
   pending-checkout next-step copy into a helper and covered that it only appears
   when a pending registration has an actual checkout URL.
@@ -1448,16 +1683,92 @@ implement those decisions or explicitly revise them there before changing code.
   stabilization field guard, and the focused registration copy/deferred-action
   component specs before pruning completed organizer/helper signup and skip
   audit action wording from the prioritized backlog.
+- Tenant branding upload pass: added admin logo/favicon upload support backed by
+  object storage and app-origin `/tenant-assets/*` delivery URLs, keeping
+  externally hosted asset URLs available and leaving automated domain onboarding
+  as the remaining tenant-settings implementation gap.
+- Legacy migration backlog cleanup: removed the stale relaunch backlog item for
+  `showInHub`, `paymentStatus`, and `payment_status` cleanup after confirming
+  the idempotent global migration step and schema guard specs already cover the
+  cut-over path.
+- Template add-on boundary refresh: corrected the richer-template backlog notes
+  to match the current schema surface and added a schema guard for the fact that
+  add-ons are template-scoped only while registration-question schemas are not
+  exposed yet.
+- Template-to-event mapping pass: extracted the create-event-from-template form
+  mapper and pinned copied event defaults, registration source option ids,
+  offset-derived registration windows, and the current boundary that organizer
+  planning tips remain private to template detail instead of flowing into event
+  instances.
+- Registration-mode label pass: centralized readable registration-mode labels
+  and wired event/template authoring selects plus template detail summaries to
+  show "First come, first served" instead of raw `fcfs` storage values.
+- Event edit submit-guard pass: shared the event edit Save Changes disabled
+  state and handler early return so invalid, submitting, and mutation-pending
+  update writes cannot double-submit.
+- Template category action-guard pass: shared one create/update pending guard
+  across category buttons and handlers so category dialogs and writes cannot
+  overlap while a category mutation is in flight.
+- Create-account retry guard pass: made the create-account submit button stay
+  disabled while the account mutation is pending and pinned that invalid,
+  submitting, and mutation-pending states all block duplicate submissions
+  without requiring Auth0 Management credentials.
+- Profile receipt card coverage pass: moved submitted-receipt amount display
+  into a tested helper so the profile receipt section has local coverage for
+  both status labels and cents-to-euro amount presentation while page-backed
+  submitted-receipt visibility remains a Browser/runtime follow-up.
+- Profile ESNcard action coverage pass: moved discount-card save, refresh, and
+  remove pending labels plus save-disabled state into tested helpers, keeping
+  add/refresh/remove Browser coverage as a runtime follow-up while preserving
+  local coverage for the visible action states.
+- Profile ESNcard write-guard pass: shared one in-flight guard across save,
+  refresh, and remove so profile discount-card writes cannot overlap on slow
+  networks, and pinned that guard in local app tests.
+- Profile edit action-guard pass: shared the Edit profile disabled state and
+  handler early return so profile updates in flight cannot open overlapping
+  edit dialogs.
+- Profile/account backlog alignment pass: narrowed the remaining profile and
+  account cleanup language to page-backed runtime coverage after confirming
+  local helper/server tests already cover retry, tenant join, ESNcard action
+  states, profile event labels, and submitted receipt card labels.
+- Tax-rate import action-guard pass: shared the import dialog disabled state
+  and handler early return so empty selections and in-flight Stripe tax-rate
+  imports cannot submit overlapping tenant tax-rate writes.
+- Template create/edit submit-guard pass: shared a tested submit-disabled helper
+  across simple template create/edit buttons and handlers so mutation-pending
+  create/update writes cannot duplicate template writes on slow networks.
+- Participant registration action-guard pass: shared a tested
+  mutation-pending guard across registration and waitlist buttons plus handlers,
+  so participant event registration writes cannot double-trigger locally.
+- Template add-on read-model pass: returned existing reusable template add-ons
+  from `templates.findOne`, displayed them on template detail with pricing,
+  timing, quantity, and attached registration-option labels, and kept
+  event-side add-on fulfillment plus registration questions as explicit future
+  product/runtime slices.
+- Template add-on seed pass: added free and paid reusable add-ons to the
+  reset-from-zero template seed data and pinned their registration-option
+  attachments in the seed baseline.
+- Template create-event add-on boundary pass: showed a create-event notice when
+  a source template has reusable add-ons and pinned that current event form data
+  still copies registration options only until event add-on fulfillment exists.
+- Active-registration action-guard pass: shared tested cancellation and
+  transfer disabled-state helpers between active-registration buttons and
+  handlers so participant cancellation and unpaid transfer writes cannot
+  overlap locally.
+- Playwright metadata inventory pass: extended the local skip/fixme inventory
+  guard to also reject placeholder `@track`, `@req`, and `@doc` metadata in real
+  Playwright spec/doc titles, while keeping the reporter stripping fixture
+  isolated to its own reporter contract test.
 
 ## Review Next
 
 All ten first-pass review areas are now represented in this document. The next
 stabilization work should continue with small cleanup commits around the
 remaining relaunch gaps: Browser-backed profile action coverage, Browser-backed
-scanner aggregate review, tenant settings implementation scope around branding
-uploads, onboarding/domain workflows, and global
-tenant-admin workflows, plus the legacy-field migration path for production
-data. Normal generated docs output now stays
+scanner aggregate review, automated onboarding/domain workflows, global
+tenant-admin Browser review, and richer template support for reusable add-ons
+and questions. Normal
+generated docs output now stays
 local unless `test:e2e:docs:publish` is run intentionally. New Playwright
 skips/fixmes should be added only as explicit credential gates or honest
 Browser-backed stabilization placeholders. Receipt notification remains a

--- a/helpers/add-templates.ts
+++ b/helpers/add-templates.ts
@@ -13,11 +13,19 @@ import { getSportsTemplates } from './templates/sports-templates';
 import { getWeekendTripTemplates } from './templates/weekend-trip-templates';
 
 export interface SeedTemplate {
+  addOns: SeedTemplateAddon[];
   description: string;
   icon: { iconColor: number; iconName: string };
   id: string;
   seedKey: SeedTemplateKey;
   tenantId: string;
+  title: string;
+}
+
+export interface SeedTemplateAddon {
+  id: string;
+  isPaid: boolean;
+  registrationOptionIds: string[];
   title: string;
 }
 
@@ -269,8 +277,111 @@ export const addTemplates = async (
     `Inserted ${paidOptionValues.length} paid template registration options`,
   );
 
+  const registrationOptionByTemplateId = new Map(
+    [...registrationOptionsToAdd, ...paidOptionValues]
+      .filter((option) => !option.organizingRegistration)
+      .map((option) => [option.templateId, option]),
+  );
+  const addonTemplateCandidates = [
+    {
+      description: 'Reusable reminder for a simple packed lunch add-on.',
+      isPaid: false,
+      price: 0,
+      seedKey: 'hike' as const,
+      stripeTaxRateId: null,
+      title: 'Packed lunch',
+      totalAvailableQuantity: 30,
+    },
+    {
+      description: 'Reusable paid equipment rental add-on for sports events.',
+      isPaid: true,
+      price: 100 * 5,
+      seedKey: 'sports' as const,
+      stripeTaxRateId: defaultRate?.stripeTaxRateId ?? null,
+      title: 'Equipment rental',
+      totalAvailableQuantity: 15,
+    },
+  ];
+  const addonValues = addonTemplateCandidates.flatMap((candidate) => {
+    const template = [...createdFreeTemplates, ...createdPaidTemplates].find(
+      (createdTemplate) => createdTemplate.seedKey === candidate.seedKey,
+    );
+    if (!template) {
+      return [];
+    }
+
+    const registrationOption = registrationOptionByTemplateId.get(template.id);
+    if (!registrationOption) {
+      return [];
+    }
+
+    return [
+      {
+        allowMultiple: false,
+        allowPurchaseBeforeEvent: true,
+        allowPurchaseDuringEvent: false,
+        allowPurchaseDuringRegistration: true,
+        description: candidate.description,
+        id: getId(),
+        isPaid: candidate.isPaid,
+        maxQuantityPerUser: 1,
+        price: candidate.price,
+        stripeTaxRateId: candidate.stripeTaxRateId,
+        templateId: template.id,
+        title: candidate.title,
+        totalAvailableQuantity: candidate.totalAvailableQuantity,
+      } satisfies InferInsertModel<typeof schema.templateEventAddons>,
+    ];
+  });
+  const addonRegistrationOptionValues = addonValues.flatMap((addon) => {
+    const registrationOption = registrationOptionByTemplateId.get(
+      addon.templateId,
+    );
+    const registrationOptionId = registrationOption?.id;
+    if (!registrationOptionId) {
+      return [];
+    }
+
+    return [
+      {
+        addonId: addon.id,
+        quantity: 1,
+        registrationOptionId,
+      } satisfies InferInsertModel<
+        typeof schema.addonToTemplateRegistrationOptions
+      >,
+    ];
+  });
+  if (addonValues.length > 0) {
+    await database.insert(schema.templateEventAddons).values(addonValues);
+    await database
+      .insert(schema.addonToTemplateRegistrationOptions)
+      .values(addonRegistrationOptionValues);
+  }
+  consola.success(`Inserted ${addonValues.length} template add-ons`);
+
+  const addonByTemplateId = new Map<string, SeedTemplateAddon[]>();
+  for (const addon of addonValues) {
+    const attachedOptionIds = addonRegistrationOptionValues
+      .filter((attachment) => attachment.addonId === addon.id)
+      .flatMap((attachment) =>
+        attachment.registrationOptionId
+          ? [attachment.registrationOptionId]
+          : [],
+      );
+    const existing = addonByTemplateId.get(addon.templateId) ?? [];
+    existing.push({
+      id: addon.id,
+      isPaid: addon.isPaid,
+      registrationOptionIds: attachedOptionIds,
+      title: addon.title,
+    });
+    addonByTemplateId.set(addon.templateId, existing);
+  }
+
   return [...createdFreeTemplates, ...createdPaidTemplates].map((template) => {
     const seededTemplate = {
+      addOns: addonByTemplateId.get(template.id) ?? [],
       description: template.description,
       icon: template.icon,
       id: template.id,

--- a/helpers/seed-tenant.ts
+++ b/helpers/seed-tenant.ts
@@ -99,6 +99,12 @@ export interface SeedTenantResult {
   };
   templateCategories: { id: string; tenantId: string; title: string }[];
   templates: {
+    addOns: {
+      id: string;
+      isPaid: boolean;
+      registrationOptionIds: string[];
+      title: string;
+    }[];
     description: string;
     icon: string;
     id: string;
@@ -286,6 +292,7 @@ export async function seedTenant(
     scenario: seededEvents.scenario,
     templateCategories,
     templates: templates.map((t) => ({
+      addOns: t.addOns,
       description: t.description,
       icon: t.icon.iconName,
       id: t.id,

--- a/helpers/testing/playwright-skip-inventory.spec.ts
+++ b/helpers/testing/playwright-skip-inventory.spec.ts
@@ -6,14 +6,101 @@ import { describe, expect, it } from 'vitest';
 const repositoryRoot = new URL('../..', import.meta.url).pathname;
 const testsRoot = join(repositoryRoot, 'tests');
 
-const allowedEntries = new Set([
-  'tests/docs/users/create-account.doc.ts:20:test.skip',
-  'tests/specs/finance/stripe-webhook-replay.spec.ts:16:test.skip',
-  'tests/specs/templates/paid-option-requires-tax-rate.spec.ts:72:test.fixme',
-  'tests/specs/templates/paid-option-requires-tax-rate.spec.ts:74:test.fixme',
-]);
+const allowedPlaywrightSkipEntries = [
+  {
+    entry: 'tests/docs/events/register.doc.ts:11:test.skip',
+    reason:
+      'Stripe-backed registration docs are gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/docs/finance/receipt-review-reimbursement.doc.ts:7:test.skip',
+    reason: 'Finance receipt docs are gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/docs/profile/discounts.doc.ts:7:test.skip',
+    reason: 'Discount docs are gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/docs/roles/roles.doc.ts:7:test.skip',
+    reason: 'Role docs are gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/docs/templates/templates.doc.ts:7:test.skip',
+    reason: 'Template docs are gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/docs/users/create-account.doc.ts:20:test.skip',
+    reason:
+      'Auth0 Management credentials are required for the integration doc.',
+  },
+  {
+    entry: 'tests/specs/events/events.test.ts:8:test.skip',
+    reason: 'Event creation coverage is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/events/unlisted-visibility.test.ts:22:test.skip',
+    reason: 'Unlisted event coverage is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/events/unlisted-visibility.test.ts:42:test.skip',
+    reason: 'Unlisted event coverage is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/events/unlisted-visibility.test.ts:62:test.skip',
+    reason: 'Unlisted event coverage is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/finance/receipts-flows.spec.ts:92:test.skip',
+    reason: 'Finance receipt flow coverage is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/finance/receipts-flows.spec.ts:130:test.skip',
+    reason: 'Finance receipt flow coverage is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/finance/receipts-flows.spec.ts:186:test.skip',
+    reason: 'Finance receipt flow coverage is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/finance/stripe-webhook-replay.spec.ts:16:test.skip',
+    reason: 'A Stripe webhook signing secret is required for replay coverage.',
+  },
+  {
+    entry:
+      'tests/specs/finance/tax-rates/admin-import-tax-rates.spec.ts:8:test.skip',
+    reason: 'Tax-rate import E2E is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/permissions/matrix.spec.ts:8:describe.skip',
+    reason: 'Permission matrix E2E is gated while E2E is stabilized.',
+  },
+  {
+    entry: 'tests/specs/scanning/scanner.test.ts:12:test.skip',
+    reason: 'Scanner E2E is gated while E2E is stabilized.',
+  },
+  {
+    entry:
+      'tests/specs/templates/paid-option-requires-tax-rate.spec.ts:114:test.fixme',
+    reason: 'Bulk template operations do not have a current UI surface.',
+  },
+  {
+    entry:
+      'tests/specs/templates/paid-option-requires-tax-rate.spec.ts:116:test.fixme',
+    reason:
+      'No-compatible-tax-rate template behavior needs a page-backed UI path.',
+  },
+] as const;
+
+const allowedEntries = new Set(
+  allowedPlaywrightSkipEntries.map((entry) => entry.entry),
+);
 
 const skipPattern = /\b(?:test|it|describe)\.(skip|fixme)\b/g;
+const placeholderMetadataPattern = /@(track|req|doc)\(/g;
+
+const allowedPlaceholderMetadataFiles = new Set([
+  'tests/specs/reporting/reporter-paths.test.ts',
+]);
 
 const collectTypeScriptFiles = (directory: string): string[] =>
   readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -39,10 +126,38 @@ const collectPlaywrightSkipEntries = () =>
     );
   });
 
+const collectPlaceholderMetadataEntries = () =>
+  collectTypeScriptFiles(testsRoot).flatMap((path) => {
+    const relativePath = relative(repositoryRoot, path).replaceAll('\\', '/');
+
+    if (allowedPlaceholderMetadataFiles.has(relativePath)) {
+      return [];
+    }
+
+    const source = readFileSync(path, 'utf8');
+    const lines = source.split('\n');
+
+    return lines.flatMap((line, index) =>
+      [...line.matchAll(placeholderMetadataPattern)].map(
+        (match) => `${relativePath}:${index + 1}:${match[0]}`,
+      ),
+    );
+  });
+
 describe('Playwright skip inventory', () => {
   it('keeps every skip and fixme explicitly classified', () => {
     const entries = collectPlaywrightSkipEntries().sort();
 
     expect(entries).toEqual([...allowedEntries].sort());
+  });
+
+  it('keeps every allowed skip and fixme tied to a reason', () => {
+    expect(
+      allowedPlaywrightSkipEntries.every((entry) => entry.reason.trim()),
+    ).toBe(true);
+  });
+
+  it('keeps real Playwright titles free of placeholder metadata', () => {
+    expect(collectPlaceholderMetadataEntries()).toEqual([]);
   });
 });

--- a/helpers/testing/runtime-preflight.spec.ts
+++ b/helpers/testing/runtime-preflight.spec.ts
@@ -81,23 +81,22 @@ const serviceBlock = (composeFile: string, service: string): string => {
 };
 
 describe('evaluateRuntimePreflight', () => {
-  it('keeps Docker and local Font Awesome registry scopes aligned', () => {
+  it('keeps Font Awesome package installs on the private Bun registry scope', () => {
+    const bunfig = fs.readFileSync(
+      path.join(process.cwd(), 'bunfig.toml'),
+      'utf8',
+    );
     const dockerfile = fs.readFileSync(
       path.join(process.cwd(), 'Dockerfile'),
       'utf8',
     );
-    const npmrc = fs.readFileSync(path.join(process.cwd(), '.npmrc'), 'utf8');
 
-    for (const registryScope of [
-      '@fortawesome:registry=https://npm.fontawesome.com/',
-      '@awesome.me:registry=https://npm.fontawesome.com/',
-    ]) {
-      expect(dockerfile).toContain(registryScope);
-      expect(npmrc).toContain(registryScope);
-    }
-
-    expect(dockerfile).toContain('//npm.fontawesome.com/:_authToken=%s');
-    expect(npmrc).toContain('//npm.fontawesome.com/:_authToken=');
+    expect(bunfig).toContain('"@fortawesome"');
+    expect(bunfig).toContain('url = "https://npm.fontawesome.com/"');
+    expect(bunfig).toContain('token = "$FONT_AWESOME_TOKEN"');
+    expect(dockerfile).toContain(
+      'FONT_AWESOME_TOKEN="$(cat /run/secrets/FONT_AWESOME_TOKEN)" bun install',
+    );
   });
 
   it('keeps premium and brand icon packages on the Font Awesome registry path', () => {

--- a/src/app/admin/components/import-tax-rates-dialog/import-tax-rates-dialog.component.spec.ts
+++ b/src/app/admin/components/import-tax-rates-dialog/import-tax-rates-dialog.component.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { taxRateImportActionDisabled } from './import-tax-rates-dialog.component';
+
+describe('taxRateImportActionDisabled', () => {
+  it('disables import when no tax rates are selected', () => {
+    expect(
+      taxRateImportActionDisabled({
+        mutationPending: false,
+        selectedCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('disables import while an import is already pending', () => {
+    expect(
+      taxRateImportActionDisabled({
+        mutationPending: true,
+        selectedCount: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows import only when selected tax rates are idle', () => {
+    expect(
+      taxRateImportActionDisabled({
+        mutationPending: false,
+        selectedCount: 1,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/admin/components/import-tax-rates-dialog/import-tax-rates-dialog.component.ts
+++ b/src/app/admin/components/import-tax-rates-dialog/import-tax-rates-dialog.component.ts
@@ -16,6 +16,13 @@ import {
 
 import { AppRpc } from '../../../core/effect-rpc-angular-client';
 
+export function taxRateImportActionDisabled(input: {
+  mutationPending: boolean;
+  selectedCount: number;
+}) {
+  return input.mutationPending || input.selectedCount === 0;
+}
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
@@ -29,9 +36,19 @@ import { AppRpc } from '../../../core/effect-rpc-angular-client';
 })
 export class ImportTaxRatesDialogComponent {
   protected readonly selected = signal<string[]>([]);
-  protected readonly canImport = computed(() => this.selected().length > 0);
 
   private readonly rpc = AppRpc.injectClient();
+
+  private readonly importMutation = injectMutation(() =>
+    this.rpc.admin.tenant.importStripeTaxRates.mutationOptions(),
+  );
+  protected readonly canImport = computed(
+    () =>
+      !taxRateImportActionDisabled({
+        mutationPending: this.importMutation.isPending(),
+        selectedCount: this.selected().length,
+      }),
+  );
 
   protected readonly importedQuery = injectQuery(() =>
     this.rpc.admin.tenant.listImportedTaxRates.queryOptions(),
@@ -44,17 +61,20 @@ export class ImportTaxRatesDialogComponent {
   protected readonly ratesQuery = injectQuery(() =>
     this.rpc.admin.tenant.listStripeTaxRates.queryOptions(),
   );
+
   private readonly dialogRef = inject(
     MatDialogRef<ImportTaxRatesDialogComponent>,
   );
 
-  private readonly importMutation = injectMutation(() =>
-    this.rpc.admin.tenant.importStripeTaxRates.mutationOptions(),
-  );
-
   protected importSelected() {
     const ids = this.selected();
-    if (ids.length === 0) return;
+    if (
+      taxRateImportActionDisabled({
+        mutationPending: this.importMutation.isPending(),
+        selectedCount: ids.length,
+      })
+    )
+      return;
     this.importMutation.mutate(
       { ids },
       {

--- a/src/app/admin/components/role-form/role-form.component.html
+++ b/src/app/admin/components/role-form/role-form.component.html
@@ -58,7 +58,7 @@
                 @if (getDependentPermissions(permission.key).length > 0) {
                   <div class="text-on-surface-variant ml-6 text-xs">
                     Includes:
-                    {{ getDependentPermissions(permission.key).join(", ") }}
+                    {{ getDependentPermissionLabels(permission.key) }}
                   </div>
                 }
               </div>
@@ -71,7 +71,13 @@
   <button
     type="submit"
     mat-button
-    [disabled]="form().invalid() || form().submitting() || isSubmitting()"
+    [disabled]="
+      roleFormSubmitDisabled({
+        formInvalid: form().invalid(),
+        formSubmitting: form().submitting(),
+        mutationPending: isSubmitting(),
+      })
+    "
   >
     {{ submitLabel() }}
   </button>

--- a/src/app/admin/components/role-form/role-form.component.spec.ts
+++ b/src/app/admin/components/role-form/role-form.component.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { roleFormSubmitDisabled } from './role-form.component';
+
+describe('roleFormSubmitDisabled', () => {
+  it('blocks role submits while invalid, submitting, or mutation-pending', () => {
+    expect(
+      roleFormSubmitDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      roleFormSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      roleFormSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      roleFormSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/admin/components/role-form/role-form.component.ts
+++ b/src/app/admin/components/role-form/role-form.component.ts
@@ -18,12 +18,23 @@ import {
   Permission,
   PERMISSION_DEPENDENCIES,
   PERMISSION_GROUPS,
+  permissionLabel,
 } from '../../../../shared/permissions/permissions';
 import {
   DEPENDENT_PERMISSION_PARENTS,
   RoleFormData,
   RoleFormModel,
 } from './role-form.schema';
+
+export const roleFormSubmitDisabled = ({
+  formInvalid,
+  formSubmitting,
+  mutationPending,
+}: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean => formInvalid || formSubmitting || mutationPending;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -43,7 +54,6 @@ export class RoleFormComponent {
   public readonly roleForm = input.required<FieldTree<RoleFormModel>>();
   public readonly submitLabel = input('Save role');
   protected formSubmit = output<RoleFormData>();
-
   protected readonly permissionGroups = PERMISSION_GROUPS;
 
   protected readonly groupStates = computed(() => {
@@ -63,6 +73,8 @@ export class RoleFormComponent {
     });
   });
 
+  protected readonly roleFormSubmitDisabled = roleFormSubmitDisabled;
+
   private readonly syncDependentPermissions = effect(() => {
     const form = this.roleForm();
     for (const permission of ALL_PERMISSIONS) {
@@ -79,6 +91,17 @@ export class RoleFormComponent {
 
   async onSubmit(event: Event): Promise<void> {
     event.preventDefault();
+    const form = this.roleForm();
+    if (
+      roleFormSubmitDisabled({
+        formInvalid: form().invalid(),
+        formSubmitting: form().submitting(),
+        mutationPending: this.isSubmitting(),
+      })
+    ) {
+      return;
+    }
+
     await submit(this.roleForm(), async (formState) => {
       const formValue = formState().value();
       this.formSubmit.emit({
@@ -103,6 +126,12 @@ export class RoleFormComponent {
     }
   }
 
+  protected getDependentPermissionLabels(permission: Permission): string {
+    return this.getDependentPermissions(permission)
+      .map((dependentPermission) => permissionLabel(dependentPermission))
+      .join(', ');
+  }
+
   protected getDependentPermissions(permission: Permission): Permission[] {
     return PERMISSION_DEPENDENCIES[permission] || [];
   }
@@ -116,8 +145,10 @@ export class RoleFormComponent {
     );
     if (activeParents.length === 0) return '';
     if (activeParents.length === 1) {
-      return `Automatically granted by ${activeParents[0]}`;
+      return `Automatically granted by ${permissionLabel(activeParents[0])}`;
     }
-    return `Automatically granted by ${activeParents.join(', ')}`;
+    return `Automatically granted by ${activeParents
+      .map((permission) => permissionLabel(permission))
+      .join(', ')}`;
   }
 }

--- a/src/app/admin/event-reviews/event-reviews.component.spec.ts
+++ b/src/app/admin/event-reviews/event-reviews.component.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { eventReviewQueueActionDisabled } from './event-reviews.component';
+
+describe('eventReviewQueueActionDisabled', () => {
+  it('blocks review queue actions while a review mutation is pending', () => {
+    expect(
+      eventReviewQueueActionDisabled({
+        mutationPending: false,
+      }),
+    ).toBe(false);
+    expect(
+      eventReviewQueueActionDisabled({
+        mutationPending: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/app/admin/event-reviews/event-reviews.component.spec.ts
+++ b/src/app/admin/event-reviews/event-reviews.component.spec.ts
@@ -6,12 +6,20 @@ describe('eventReviewQueueActionDisabled', () => {
   it('blocks review queue actions while a review mutation is pending', () => {
     expect(
       eventReviewQueueActionDisabled({
+        actionPending: false,
         mutationPending: false,
       }),
     ).toBe(false);
     expect(
       eventReviewQueueActionDisabled({
+        actionPending: false,
         mutationPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      eventReviewQueueActionDisabled({
+        actionPending: true,
+        mutationPending: false,
       }),
     ).toBe(true);
   });

--- a/src/app/admin/event-reviews/event-reviews.component.ts
+++ b/src/app/admin/event-reviews/event-reviews.component.ts
@@ -1,5 +1,10 @@
 import { DatePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
@@ -23,10 +28,12 @@ import { NotificationService } from '../../core/notification.service';
 import { EventReviewDialogComponent } from '../../events/event-review-dialog/event-review-dialog.component';
 
 export const eventReviewQueueActionDisabled = ({
+  actionPending,
   mutationPending,
 }: {
+  actionPending: boolean;
   mutationPending: boolean;
-}): boolean => mutationPending;
+}): boolean => actionPending || mutationPending;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -86,6 +93,7 @@ export const eventReviewQueueActionDisabled = ({
                     (click)="reviewEvent(event.id, event.title, false)"
                     [disabled]="
                       eventReviewQueueActionDisabled({
+                        actionPending: reviewActionPending(),
                         mutationPending: reviewEventMutation.isPending(),
                       })
                     "
@@ -97,6 +105,7 @@ export const eventReviewQueueActionDisabled = ({
                     (click)="reviewEvent(event.id, event.title, true)"
                     [disabled]="
                       eventReviewQueueActionDisabled({
+                        actionPending: reviewActionPending(),
                         mutationPending: reviewEventMutation.isPending(),
                       })
                     "
@@ -140,6 +149,7 @@ export class EventReviewsComponent {
   protected readonly pendingReviewsQuery = injectQuery(() =>
     this.rpc.events.getPendingReviews.queryOptions(),
   );
+  protected readonly reviewActionPending = signal(false);
   protected readonly reviewEventMutation = injectMutation(() =>
     this.rpc.events.reviewEvent.mutationOptions(),
   );
@@ -163,12 +173,14 @@ export class EventReviewsComponent {
   ): Promise<void> {
     if (
       eventReviewQueueActionDisabled({
+        actionPending: this.reviewActionPending(),
         mutationPending: this.reviewEventMutation.isPending(),
       })
     ) {
       return;
     }
 
+    this.reviewActionPending.set(true);
     try {
       if (approved) {
         await this.reviewEventMutation.mutateAsync({ approved, eventId });
@@ -188,6 +200,8 @@ export class EventReviewsComponent {
       this.notifications.showEventReviewed(approved, eventTitle);
     } catch (error) {
       await this.handleReviewActionError(error);
+    } finally {
+      this.reviewActionPending.set(false);
     }
   }
 

--- a/src/app/admin/event-reviews/event-reviews.component.ts
+++ b/src/app/admin/event-reviews/event-reviews.component.ts
@@ -3,12 +3,12 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
-import { MatIconModule } from '@angular/material/icon';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import {
   faArrowLeft,
   faArrowUpRightFromSquare,
+  faRotateRight,
 } from '@fortawesome/duotone-regular-svg-icons';
 import {
   injectMutation,
@@ -22,15 +22,15 @@ import { getErrorMessage } from '../../core/error-message';
 import { NotificationService } from '../../core/notification.service';
 import { EventReviewDialogComponent } from '../../events/event-review-dialog/event-review-dialog.component';
 
+export const eventReviewQueueActionDisabled = ({
+  mutationPending,
+}: {
+  mutationPending: boolean;
+}): boolean => mutationPending;
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    MatButtonModule,
-    MatIconModule,
-    RouterLink,
-    FontAwesomeModule,
-    DatePipe,
-  ],
+  imports: [MatButtonModule, RouterLink, FontAwesomeModule, DatePipe],
   selector: 'app-event-reviews',
   standalone: true,
   template: `
@@ -50,7 +50,7 @@ import { EventReviewDialogComponent } from '../../events/event-review-dialog/eve
         (click)="pendingReviewsQuery.refetch()"
         aria-label="Refresh pending reviews"
       >
-        <mat-icon>refresh</mat-icon>
+        <fa-duotone-icon [icon]="faRotateRight" />
       </button>
     </div>
 
@@ -84,14 +84,22 @@ import { EventReviewDialogComponent } from '../../events/event-review-dialog/eve
                   <button
                     mat-stroked-button
                     (click)="reviewEvent(event.id, event.title, false)"
-                    [disabled]="reviewEventMutation.isPending()"
+                    [disabled]="
+                      eventReviewQueueActionDisabled({
+                        mutationPending: reviewEventMutation.isPending(),
+                      })
+                    "
                   >
                     Reject
                   </button>
                   <button
                     mat-flat-button
                     (click)="reviewEvent(event.id, event.title, true)"
-                    [disabled]="reviewEventMutation.isPending()"
+                    [disabled]="
+                      eventReviewQueueActionDisabled({
+                        mutationPending: reviewEventMutation.isPending(),
+                      })
+                    "
                   >
                     Approve
                   </button>
@@ -123,8 +131,11 @@ import { EventReviewDialogComponent } from '../../events/event-review-dialog/eve
   `,
 })
 export class EventReviewsComponent {
+  protected readonly eventReviewQueueActionDisabled =
+    eventReviewQueueActionDisabled;
   protected readonly faArrowLeft = faArrowLeft;
   protected readonly faArrowUpRightFromSquare = faArrowUpRightFromSquare;
+  protected readonly faRotateRight = faRotateRight;
   private readonly rpc = AppRpc.injectClient();
   protected readonly pendingReviewsQuery = injectQuery(() =>
     this.rpc.events.getPendingReviews.queryOptions(),
@@ -150,6 +161,14 @@ export class EventReviewsComponent {
     eventTitle: string,
     approved: boolean,
   ): Promise<void> {
+    if (
+      eventReviewQueueActionDisabled({
+        mutationPending: this.reviewEventMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     try {
       if (approved) {
         await this.reviewEventMutation.mutateAsync({ approved, eventId });

--- a/src/app/admin/general-settings/general-settings.component.html
+++ b/src/app/admin/general-settings/general-settings.component.html
@@ -108,8 +108,8 @@
 
       <h3 class="title-small mb-2 mt-6">Brand assets</h3>
       <p class="text-on-surface-variant mb-3 text-sm">
-        Configure externally hosted tenant assets. The favicon updates the
-        browser tab icon.
+        Upload tenant assets or paste externally hosted URLs. The favicon
+        updates the browser tab icon.
       </p>
       <mat-form-field>
         <mat-label>Logo URL</mat-label>
@@ -119,6 +119,26 @@
           placeholder="https://section.example.org/logo.svg"
         />
       </mat-form-field>
+      <input
+        #logoAssetInput
+        type="file"
+        class="hidden"
+        aria-label="Upload tenant logo file"
+        accept="image/png,image/jpeg,image/webp,image/gif"
+        (change)="uploadBrandAsset('logo', $event)"
+      />
+      <button
+        mat-stroked-button
+        type="button"
+        class="mb-4 w-fit"
+        [disabled]="brandAssetUploadDisabled()"
+        (click)="logoAssetInput.click()"
+      >
+        <fa-duotone-icon [icon]="faUpload" class="mr-2" />
+        {{
+          uploadingBrandAsset() === "logo" ? "Uploading logo" : "Upload logo"
+        }}
+      </button>
       <mat-form-field>
         <mat-label>Favicon URL</mat-label>
         <input
@@ -127,6 +147,28 @@
           placeholder="https://section.example.org/favicon.ico"
         />
       </mat-form-field>
+      <input
+        #faviconAssetInput
+        type="file"
+        class="hidden"
+        aria-label="Upload tenant favicon file"
+        accept="image/png,image/jpeg,image/webp,image/gif,image/x-icon,image/vnd.microsoft.icon"
+        (change)="uploadBrandAsset('favicon', $event)"
+      />
+      <button
+        mat-stroked-button
+        type="button"
+        class="w-fit"
+        [disabled]="brandAssetUploadDisabled()"
+        (click)="faviconAssetInput.click()"
+      >
+        <fa-duotone-icon [icon]="faUpload" class="mr-2" />
+        {{
+          uploadingBrandAsset() === "favicon"
+            ? "Uploading favicon"
+            : "Upload favicon"
+        }}
+      </button>
 
       <h3 class="title-small mb-2 mt-6">Search preview</h3>
       <p class="text-on-surface-variant mb-3 text-sm">
@@ -254,7 +296,13 @@
       <button
         mat-flat-button
         type="submit"
-        [disabled]="settingsForm().invalid() || settingsForm().submitting()"
+        [disabled]="
+          generalSettingsSaveDisabled({
+            formInvalid: settingsForm().invalid(),
+            formSubmitting: settingsForm().submitting(),
+            mutationPending: updateSettingsMutation.isPending(),
+          })
+        "
       >
         Save
       </button>

--- a/src/app/admin/general-settings/general-settings.component.spec.ts
+++ b/src/app/admin/general-settings/general-settings.component.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generalSettingsBrandAssetUploadDisabled,
+  generalSettingsSaveDisabled,
+} from './general-settings.component';
+
+describe('generalSettingsSaveDisabled', () => {
+  it('blocks tenant settings saves while invalid, submitting, or mutation-pending', () => {
+    expect(
+      generalSettingsSaveDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      generalSettingsSaveDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      generalSettingsSaveDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      generalSettingsSaveDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('generalSettingsBrandAssetUploadDisabled', () => {
+  it('blocks brand asset uploads while any upload is active or mutation-pending', () => {
+    expect(
+      generalSettingsBrandAssetUploadDisabled({
+        mutationPending: false,
+        uploadingBrandAsset: 'logo',
+      }),
+    ).toBe(true);
+    expect(
+      generalSettingsBrandAssetUploadDisabled({
+        mutationPending: true,
+        uploadingBrandAsset: null,
+      }),
+    ).toBe(true);
+    expect(
+      generalSettingsBrandAssetUploadDisabled({
+        mutationPending: false,
+        uploadingBrandAsset: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/admin/general-settings/general-settings.component.ts
+++ b/src/app/admin/general-settings/general-settings.component.ts
@@ -1,3 +1,5 @@
+import type { AdminTenantBrandAssetKind } from '@shared/rpc-contracts/app-rpcs/admin.rpcs';
+
 import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
@@ -16,7 +18,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faArrowLeft } from '@fortawesome/duotone-regular-svg-icons';
+import { faArrowLeft, faUpload } from '@fortawesome/duotone-regular-svg-icons';
 import {
   DEFAULT_RECEIPT_COUNTRIES,
   RECEIPT_COUNTRY_OPTIONS,
@@ -47,6 +49,37 @@ import {
   requiresLocaleMoneyRuntimeReload,
 } from './general-settings.payload';
 
+export const generalSettingsSaveDisabled = ({
+  formInvalid,
+  formSubmitting,
+  mutationPending,
+}: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean => formInvalid || formSubmitting || mutationPending;
+
+export const generalSettingsBrandAssetUploadDisabled = ({
+  mutationPending,
+  uploadingBrandAsset,
+}: {
+  mutationPending: boolean;
+  uploadingBrandAsset: AdminTenantBrandAssetKind | null;
+}): boolean => uploadingBrandAsset !== null || mutationPending;
+
+const tenantBrandAssetClientMaxSizeBytes = 5 * 1024 * 1024;
+const tenantBrandAssetClientMimeTypes = {
+  favicon: new Set([
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'image/vnd.microsoft.icon',
+    'image/webp',
+    'image/x-icon',
+  ]),
+  logo: new Set(['image/gif', 'image/jpeg', 'image/png', 'image/webp']),
+} satisfies Record<AdminTenantBrandAssetKind, ReadonlySet<string>>;
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
@@ -66,6 +99,18 @@ import {
   templateUrl: './general-settings.component.html',
 })
 export class GeneralSettingsComponent {
+  protected readonly uploadingBrandAsset =
+    signal<AdminTenantBrandAssetKind | null>(null);
+  private readonly rpc = AppRpc.injectClient();
+  private readonly uploadBrandAssetMutation = injectMutation(() =>
+    this.rpc.admin.tenant.uploadBrandAsset.mutationOptions(),
+  );
+  protected readonly brandAssetUploadDisabled = computed(() =>
+    generalSettingsBrandAssetUploadDisabled({
+      mutationPending: this.uploadBrandAssetMutation.isPending(),
+      uploadingBrandAsset: this.uploadingBrandAsset(),
+    }),
+  );
   protected readonly currencyOptions = supportedTenantCurrencies;
   protected readonly deferredTenantSettingsRows = deferredTenantSettingsRows;
   protected readonly settingsModel = signal<GeneralSettingsModel>({
@@ -93,6 +138,8 @@ export class GeneralSettingsComponent {
     () => this.settingsModel().esnCardEnabled,
   );
   protected readonly faArrowLeft = faArrowLeft;
+  protected readonly faUpload = faUpload;
+  protected readonly generalSettingsSaveDisabled = generalSettingsSaveDisabled;
   protected readonly localeOptions = supportedTenantLocales;
   protected readonly receiptCountryOptions = RECEIPT_COUNTRY_OPTIONS;
   protected readonly settingsForm = form(this.settingsModel);
@@ -101,14 +148,13 @@ export class GeneralSettingsComponent {
     tenantIdentityRows(this.configService.tenant),
   );
   protected readonly timezoneOptions = supportedTenantTimezones;
-  private readonly document = inject(DOCUMENT);
-  private readonly notifications = inject(NotificationService);
-  private readonly queryClient = inject(QueryClient);
-  private readonly rpc = AppRpc.injectClient();
-
-  private updateSettingsMutation = injectMutation(() =>
+  protected readonly updateSettingsMutation = injectMutation(() =>
     this.rpc.admin.tenant.updateSettings.mutationOptions(),
   );
+  private readonly document = inject(DOCUMENT);
+
+  private readonly notifications = inject(NotificationService);
+  private readonly queryClient = inject(QueryClient);
 
   constructor() {
     effect(() => {
@@ -147,6 +193,16 @@ export class GeneralSettingsComponent {
 
   async saveSettings(event: Event) {
     event.preventDefault();
+    if (
+      generalSettingsSaveDisabled({
+        formInvalid: this.settingsForm().invalid(),
+        formSubmitting: this.settingsForm().submitting(),
+        mutationPending: this.updateSettingsMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     await submit(this.settingsForm, async (formState) => {
       const settings = formState().value();
       const reloadRequired = requiresLocaleMoneyRuntimeReload(
@@ -188,5 +244,93 @@ export class GeneralSettingsComponent {
       ...current,
       esnCardEnabled: checked,
     }));
+  }
+
+  protected async uploadBrandAsset(
+    kind: AdminTenantBrandAssetKind,
+    event: Event,
+  ): Promise<void> {
+    const input = event.target as HTMLInputElement | undefined;
+    const file = input?.files?.[0] ?? null;
+    if (!file) {
+      return;
+    }
+    if (this.brandAssetUploadDisabled()) {
+      if (input) {
+        input.value = '';
+      }
+      return;
+    }
+    if (!tenantBrandAssetClientMimeTypes[kind].has(file.type)) {
+      this.notifications.showError(
+        kind === 'favicon'
+          ? 'Favicons must be PNG, JPEG, WebP, GIF, or ICO files'
+          : 'Logos must be PNG, JPEG, WebP, or GIF files',
+      );
+      if (input) {
+        input.value = '';
+      }
+      return;
+    }
+    if (file.size <= 0 || file.size > tenantBrandAssetClientMaxSizeBytes) {
+      this.notifications.showError(
+        'Brand asset file must be between 1 byte and 5 MB',
+      );
+      if (input) {
+        input.value = '';
+      }
+      return;
+    }
+
+    this.uploadingBrandAsset.set(kind);
+    try {
+      const uploaded = await this.uploadBrandAssetMutation.mutateAsync({
+        fileBase64: await this.readFileAsBase64(file),
+        fileName: file.name,
+        fileSizeBytes: file.size,
+        kind,
+        mimeType: file.type,
+      });
+      this.settingsModel.update((current) => ({
+        ...current,
+        [kind === 'logo' ? 'logoUrl' : 'faviconUrl']: uploaded.assetUrl,
+      }));
+      this.notifications.showSuccess(
+        kind === 'logo'
+          ? 'Logo uploaded. Save settings to publish it.'
+          : 'Favicon uploaded. Save settings to publish it.',
+      );
+    } catch (error) {
+      this.notifications.showError(
+        getErrorMessage(error, 'Failed to upload brand asset'),
+      );
+    } finally {
+      this.uploadingBrandAsset.set(null);
+      if (input) {
+        input.value = '';
+      }
+    }
+  }
+
+  private async readFileAsBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.addEventListener('error', () => {
+        reject(new Error('Failed to read brand asset'));
+      });
+      reader.addEventListener('load', () => {
+        if (typeof reader.result !== 'string') {
+          reject(new Error('Invalid brand asset payload'));
+          return;
+        }
+        const commaIndex = reader.result.indexOf(',');
+        if (commaIndex === -1) {
+          reject(new Error('Invalid brand asset data URL'));
+          return;
+        }
+        resolve(reader.result.slice(commaIndex + 1));
+      });
+      reader.readAsDataURL(file);
+    });
   }
 }

--- a/src/app/admin/general-settings/general-settings.component.ts
+++ b/src/app/admin/general-settings/general-settings.component.ts
@@ -99,15 +99,20 @@ const tenantBrandAssetClientMimeTypes = {
   templateUrl: './general-settings.component.html',
 })
 export class GeneralSettingsComponent {
+  private readonly rpc = AppRpc.injectClient();
+  protected readonly updateSettingsMutation = injectMutation(() =>
+    this.rpc.admin.tenant.updateSettings.mutationOptions(),
+  );
   protected readonly uploadingBrandAsset =
     signal<AdminTenantBrandAssetKind | null>(null);
-  private readonly rpc = AppRpc.injectClient();
   private readonly uploadBrandAssetMutation = injectMutation(() =>
     this.rpc.admin.tenant.uploadBrandAsset.mutationOptions(),
   );
   protected readonly brandAssetUploadDisabled = computed(() =>
     generalSettingsBrandAssetUploadDisabled({
-      mutationPending: this.uploadBrandAssetMutation.isPending(),
+      mutationPending:
+        this.uploadBrandAssetMutation.isPending() ||
+        this.updateSettingsMutation.isPending(),
       uploadingBrandAsset: this.uploadingBrandAsset(),
     }),
   );
@@ -148,9 +153,6 @@ export class GeneralSettingsComponent {
     tenantIdentityRows(this.configService.tenant),
   );
   protected readonly timezoneOptions = supportedTenantTimezones;
-  protected readonly updateSettingsMutation = injectMutation(() =>
-    this.rpc.admin.tenant.updateSettings.mutationOptions(),
-  );
   private readonly document = inject(DOCUMENT);
 
   private readonly notifications = inject(NotificationService);

--- a/src/app/admin/general-settings/general-settings.identity.spec.ts
+++ b/src/app/admin/general-settings/general-settings.identity.spec.ts
@@ -11,7 +11,7 @@ describe('tenantIdentityRows', () => {
       tenantIdentityRows({
         currency: 'EUR',
         domain: 'tenant.example.com',
-        locale: 'de-DE',
+        locale: 'en-GB',
         name: 'Example Tenant',
         stripeAccountId: 'acct_123',
         timezone: 'Europe/Berlin',
@@ -20,7 +20,7 @@ describe('tenantIdentityRows', () => {
       { label: 'Tenant name', value: 'Example Tenant' },
       { label: 'Primary domain', value: 'tenant.example.com' },
       { label: 'Currency', value: 'EUR' },
-      { label: 'Locale', value: 'de-DE' },
+      { label: 'Locale', value: 'en-GB' },
       { label: 'Timezone', value: 'Europe/Berlin' },
       { label: 'Stripe account', value: 'Connected (acct_123)' },
     ]);
@@ -30,7 +30,7 @@ describe('tenantIdentityRows', () => {
     const rows = tenantIdentityRows({
       currency: 'EUR',
       domain: 'tenant.example.com',
-      locale: 'de-DE',
+      locale: 'en-GB',
       name: 'Example Tenant',
       stripeAccountId: null,
       timezone: 'Europe/Berlin',
@@ -46,7 +46,7 @@ describe('tenantIdentityRows', () => {
     const rows = tenantIdentityRows({
       currency: 'EUR',
       domain: 'tenant.example.com',
-      locale: 'de-DE',
+      locale: 'en-GB',
       name: 'Example Tenant',
       stripeAccountId: undefined,
       timezone: 'Europe/Berlin',

--- a/src/app/admin/general-settings/general-settings.identity.spec.ts
+++ b/src/app/admin/general-settings/general-settings.identity.spec.ts
@@ -22,7 +22,7 @@ describe('tenantIdentityRows', () => {
       { label: 'Currency', value: 'EUR' },
       { label: 'Locale', value: 'de-DE' },
       { label: 'Timezone', value: 'Europe/Berlin' },
-      { label: 'Stripe account', value: 'Connected' },
+      { label: 'Stripe account', value: 'Connected (acct_123)' },
     ]);
   });
 
@@ -70,7 +70,7 @@ describe('deferredTenantSettingsRows', () => {
       {
         label: 'Brand assets',
         value:
-          'Logo and favicon URLs are editable below; file uploads are not implemented yet.',
+          'Logo and favicon uploads or externally hosted URLs are editable below.',
       },
       {
         label: 'Legal pages',

--- a/src/app/admin/general-settings/general-settings.identity.ts
+++ b/src/app/admin/general-settings/general-settings.identity.ts
@@ -1,11 +1,9 @@
-export interface TenantIdentity {
-  currency: string;
-  domain: string;
-  locale: string;
-  name: string;
-  stripeAccountId?: null | string | undefined;
-  timezone: string;
-}
+import type { Tenant } from '../../../types/custom/tenant';
+
+export type TenantIdentity = Pick<
+  Tenant,
+  'currency' | 'domain' | 'locale' | 'name' | 'stripeAccountId' | 'timezone'
+>;
 
 export const tenantIdentityRows = (tenant: TenantIdentity) => [
   { label: 'Tenant name', value: tenant.name },

--- a/src/app/admin/general-settings/general-settings.identity.ts
+++ b/src/app/admin/general-settings/general-settings.identity.ts
@@ -15,7 +15,9 @@ export const tenantIdentityRows = (tenant: TenantIdentity) => [
   { label: 'Timezone', value: tenant.timezone },
   {
     label: 'Stripe account',
-    value: tenant.stripeAccountId ? 'Connected' : 'Not connected',
+    value: tenant.stripeAccountId
+      ? `Connected (${tenant.stripeAccountId})`
+      : 'Not connected',
   },
 ];
 
@@ -28,7 +30,7 @@ export const deferredTenantSettingsRows = [
   {
     label: 'Brand assets',
     value:
-      'Logo and favicon URLs are editable below; file uploads are not implemented yet.',
+      'Logo and favicon uploads or externally hosted URLs are editable below.',
   },
   {
     label: 'Legal pages',

--- a/src/app/admin/role-create/role-create.component.ts
+++ b/src/app/admin/role-create/role-create.component.ts
@@ -43,6 +43,10 @@ export class RoleCreateComponent {
   private readonly router = inject(Router);
 
   protected async onSubmit(role: RoleFormData): Promise<void> {
+    if (this.createRoleMutation.isPending()) {
+      return;
+    }
+
     this.createRoleMutation.mutate(
       { ...role },
       {

--- a/src/app/admin/role-details/role-details.component.ts
+++ b/src/app/admin/role-details/role-details.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faArrowLeft, faEdit } from '@fortawesome/duotone-regular-svg-icons';
@@ -16,15 +15,8 @@ import { getErrorMessage } from '../../core/error-message';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    FontAwesomeModule,
-    MatButtonModule,
-    MatCardModule,
-    MatIconModule,
-    RouterLink,
-  ],
+  imports: [FontAwesomeModule, MatButtonModule, MatCardModule, RouterLink],
   selector: 'app-role-details',
-  standalone: true,
   templateUrl: './role-details.component.html',
 })
 export class RoleDetailsComponent {

--- a/src/app/admin/role-edit/role-edit.component.ts
+++ b/src/app/admin/role-edit/role-edit.component.ts
@@ -58,6 +58,10 @@ export class RoleEditComponent {
   private readonly router = inject(Router);
 
   onSubmit(role: RoleFormData) {
+    if (this.updateRoleMutation.isPending()) {
+      return;
+    }
+
     this.updateRoleMutation.mutate(
       { ...role, id: this.roleId() },
       {

--- a/src/app/admin/role-list/role-list.component.html
+++ b/src/app/admin/role-list/role-list.component.html
@@ -6,7 +6,7 @@
 </div>
 
 <a routerLink="create" class="fab-fixed" mat-fab extended>
-  <mat-icon svgIcon="faPlus" />
+  <fa-duotone-icon [icon]="faPlus" />
   Create role
 </a>
 <div class="grid grid-cols-1 gap-4">

--- a/src/app/admin/role-list/role-list.component.ts
+++ b/src/app/admin/role-list/role-list.component.ts
@@ -1,9 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faArrowLeft } from '@fortawesome/duotone-regular-svg-icons';
+import { faArrowLeft, faPlus } from '@fortawesome/duotone-regular-svg-icons';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import { AppRpc } from '../../core/effect-rpc-angular-client';
@@ -11,13 +10,14 @@ import { getErrorMessage } from '../../core/error-message';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FontAwesomeModule, MatButtonModule, RouterLink, MatIconModule],
+  imports: [FontAwesomeModule, MatButtonModule, RouterLink],
   selector: 'app-role-list',
   styles: ``,
   templateUrl: './role-list.component.html',
 })
 export class RoleListComponent {
   protected readonly faArrowLeft = faArrowLeft;
+  protected readonly faPlus = faPlus;
   private readonly rpc = AppRpc.injectClient();
   protected readonly roleQuery = injectQuery(() =>
     this.rpc.admin.roles.findMany.queryOptions({}),

--- a/src/app/core/create-account/create-account.component.html
+++ b/src/app/core/create-account/create-account.component.html
@@ -56,7 +56,13 @@
         <button
           mat-flat-button
           type="submit"
-          [disabled]="accountForm().invalid() || accountForm().submitting()"
+          [disabled]="
+            createAccountSubmitDisabled({
+              formInvalid: accountForm().invalid(),
+              formSubmitting: accountForm().submitting(),
+              mutationPending: createAccountMutation.isPending(),
+            })
+          "
         >
           Create Account
         </button>

--- a/src/app/core/create-account/create-account.component.ts
+++ b/src/app/core/create-account/create-account.component.ts
@@ -27,6 +27,7 @@ import {
   createAccountErrorMessage,
   createAccountModelFromAuthData,
   createAccountPayloadFromModel,
+  createAccountSubmitDisabled,
   isAuthEmailVerifiedForAccountCreation,
 } from './create-account.helpers';
 
@@ -54,11 +55,12 @@ export class CreateAccountComponent {
   protected readonly authDataQuery = injectQuery(() =>
     this.rpc.users.authData.queryOptions(),
   );
-  protected readonly isAuthEmailVerifiedForAccountCreation =
-    isAuthEmailVerifiedForAccountCreation;
-  private readonly createAccountMutation = injectMutation(() =>
+  protected readonly createAccountMutation = injectMutation(() =>
     this.rpc.users.createAccount.mutationOptions(),
   );
+  protected readonly createAccountSubmitDisabled = createAccountSubmitDisabled;
+  protected readonly isAuthEmailVerifiedForAccountCreation =
+    isAuthEmailVerifiedForAccountCreation;
   private readonly queryClient = inject(QueryClient);
   private readonly router = inject(Router);
 
@@ -75,6 +77,16 @@ export class CreateAccountComponent {
 
   async onSubmit(event: Event) {
     event.preventDefault();
+    if (
+      createAccountSubmitDisabled({
+        formInvalid: this.accountForm().invalid(),
+        formSubmitting: this.accountForm().submitting(),
+        mutationPending: this.createAccountMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     await submit(this.accountForm, async () => {
       const payload = createAccountPayloadFromModel(this.accountModel());
       this.accountError.set('');

--- a/src/app/core/create-account/create-account.helpers.spec.ts
+++ b/src/app/core/create-account/create-account.helpers.spec.ts
@@ -4,6 +4,7 @@ import {
   createAccountErrorMessage,
   createAccountModelFromAuthData,
   createAccountPayloadFromModel,
+  createAccountSubmitDisabled,
   isAuthEmailVerifiedForAccountCreation,
 } from './create-account.helpers';
 
@@ -95,5 +96,38 @@ describe('createAccountErrorMessage', () => {
 
   it('falls back to account creation copy for unknown failures', () => {
     expect(createAccountErrorMessage(null)).toBe('Failed to create account');
+  });
+});
+
+describe('createAccountSubmitDisabled', () => {
+  it('keeps account creation disabled while invalid, submitting, or awaiting the mutation', () => {
+    expect(
+      createAccountSubmitDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      createAccountSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      createAccountSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      createAccountSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/app/core/create-account/create-account.helpers.ts
+++ b/src/app/core/create-account/create-account.helpers.ts
@@ -33,5 +33,15 @@ export const createAccountPayloadFromModel = (
   lastName: model.lastName.trim(),
 });
 
+export const createAccountSubmitDisabled = ({
+  formInvalid,
+  formSubmitting,
+  mutationPending,
+}: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean => formInvalid || formSubmitting || mutationPending;
+
 export const createAccountErrorMessage = (error: unknown): string =>
   getErrorMessage(error, 'Failed to create account');

--- a/src/app/core/guards/permission.guard.spec.ts
+++ b/src/app/core/guards/permission.guard.spec.ts
@@ -67,4 +67,30 @@ describe('permissionGuard', () => {
 
     expect(result).toBe(true);
   });
+
+  it('fails closed when permission metadata is malformed', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: PermissionsService,
+          useValue: {
+            hasPermissionSync: () => true,
+          } satisfies Pick<PermissionsService, 'hasPermissionSync'>,
+        },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() =>
+      permissionGuard(
+        routeWithData({ permissions: 'admin:manageRoles' }),
+        routerState('/admin/roles'),
+      ),
+    );
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(TestBed.inject(Router).serializeUrl(result as UrlTree)).toBe(
+      '/403?originalPath=%2Fadmin%2Froles',
+    );
+  });
 });

--- a/src/app/core/guards/permission.guard.spec.ts
+++ b/src/app/core/guards/permission.guard.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  provideRouter,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { describe, expect, it } from 'vitest';
+
+import { PermissionsService } from '../permissions.service';
+import { permissionGuard } from './permission.guard';
+
+const routeWithData = (
+  data: ActivatedRouteSnapshot['data'],
+): ActivatedRouteSnapshot => ({ data }) as ActivatedRouteSnapshot;
+
+const routerState = (url: string): RouterStateSnapshot =>
+  ({ url }) as RouterStateSnapshot;
+
+describe('permissionGuard', () => {
+  it('redirects denied child routes to the root not-allowed page', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: PermissionsService,
+          useValue: {
+            hasPermissionSync: () => false,
+          } satisfies Pick<PermissionsService, 'hasPermissionSync'>,
+        },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() =>
+      permissionGuard(
+        routeWithData({ permissions: ['admin:manageRoles'] }),
+        routerState('/admin/roles'),
+      ),
+    );
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(TestBed.inject(Router).serializeUrl(result as UrlTree)).toBe(
+      '/403?originalPath=%2Fadmin%2Froles',
+    );
+  });
+
+  it('allows routes when every required permission is available', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: PermissionsService,
+          useValue: {
+            hasPermissionSync: () => true,
+          } satisfies Pick<PermissionsService, 'hasPermissionSync'>,
+        },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() =>
+      permissionGuard(
+        routeWithData({ permissions: ['admin:manageRoles'] }),
+        routerState('/admin/roles'),
+      ),
+    );
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/app/core/guards/permission.guard.ts
+++ b/src/app/core/guards/permission.guard.ts
@@ -10,14 +10,26 @@ const logger = consola.withTag('app/permission-guard');
 const isPermission = (value: unknown): value is Permission =>
   typeof value === 'string';
 
-const readPermissions = (value: unknown): Permission[] =>
-  Array.isArray(value) ? value.filter(isPermission) : [];
+const readPermissions = (value: unknown): null | Permission[] =>
+  Array.isArray(value) && value.every(isPermission) ? value : null;
 
 export const permissionGuard: CanActivateFn = (route, state) => {
   const permissionsService = inject(PermissionsService);
   const router = inject(Router);
-  const permissions = readPermissions(route.data['permissions']);
-  const anyPermissions = readPermissions(route.data['anyPermissions']);
+  const hasPermissionsData = Object.hasOwn(route.data, 'permissions');
+  const hasAnyPermissionsData = Object.hasOwn(route.data, 'anyPermissions');
+  const permissions = hasPermissionsData
+    ? readPermissions(route.data['permissions'])
+    : [];
+  const anyPermissions = hasAnyPermissionsData
+    ? readPermissions(route.data['anyPermissions'])
+    : [];
+  if (permissions === null || anyPermissions === null) {
+    logger.warn('Invalid permissions data');
+    return router.createUrlTree(['/403'], {
+      queryParams: { originalPath: state.url },
+    });
+  }
   if (permissions.length === 0 && anyPermissions.length === 0) {
     logger.warn('No permissions data');
     return true;

--- a/src/app/core/guards/permission.guard.ts
+++ b/src/app/core/guards/permission.guard.ts
@@ -1,8 +1,11 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
+import consola from 'consola/browser';
 
 import { Permission } from '../../../shared/permissions/permissions';
 import { PermissionsService } from '../permissions.service';
+
+const logger = consola.withTag('app/permission-guard');
 
 const isPermission = (value: unknown): value is Permission =>
   typeof value === 'string';
@@ -16,7 +19,7 @@ export const permissionGuard: CanActivateFn = (route, state) => {
   const permissions = readPermissions(route.data['permissions']);
   const anyPermissions = readPermissions(route.data['anyPermissions']);
   if (permissions.length === 0 && anyPermissions.length === 0) {
-    console.warn('No permissions data');
+    logger.warn('No permissions data');
     return true;
   }
   const hasPermission =
@@ -27,8 +30,10 @@ export const permissionGuard: CanActivateFn = (route, state) => {
         permissionsService.hasPermissionSync(permission),
       ));
   if (!hasPermission) {
-    console.warn('No permission', { anyPermissions, permissions });
-    return router.createUrlTree(['403', { originalPath: state.url }]);
+    logger.warn('No permission', { anyPermissions, permissions });
+    return router.createUrlTree(['/403'], {
+      queryParams: { originalPath: state.url },
+    });
   }
   return hasPermission;
 };

--- a/src/app/core/not-allowed/not-allowed.component.html
+++ b/src/app/core/not-allowed/not-allowed.component.html
@@ -1,1 +1,0 @@
-<p>not-allowed works!</p>

--- a/src/app/core/not-allowed/not-allowed.component.ts
+++ b/src/app/core/not-allowed/not-allowed.component.ts
@@ -5,6 +5,13 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   imports: [],
   selector: 'app-not-allowed',
   styles: ``,
-  templateUrl: './not-allowed.component.html',
+  template: `
+    <div class="mx-auto max-w-screen-md p-8 text-center">
+      <h1 class="headline-large mb-2">Access not allowed</h1>
+      <p class="body-large text-outline">
+        Your account does not have permission to open this page.
+      </p>
+    </div>
+  `,
 })
 export class NotAllowedComponent {}

--- a/src/app/events/event-active-registration/event-active-registration.component.html
+++ b/src/app/events/event-active-registration/event-active-registration.component.html
@@ -78,10 +78,34 @@
             mat-stroked-button
             (click)="cancelRegistration(registration)"
             [disabled]="
-              cancelRegistrationMutation.isPending() || !cancellation.canCancel
+              registrationCancellationActionDisabled({
+                cancellationPending: cancelRegistrationMutation.isPending(),
+                transferPending: transferRegistrationMutation.isPending(),
+              }) || !cancellation.canCancel
             "
           >
             {{ cancellation.buttonLabel }}
+          </button>
+        </div>
+      }
+      @if (transferActionCopy(registration); as transferAction) {
+        <div class="flex flex-col items-start gap-2 lg:col-span-2">
+          <p class="body-small text-on-surface-variant">
+            {{ transferAction.helperText }}
+          </p>
+          <button
+            mat-stroked-button
+            type="button"
+            (click)="transferRegistration(registration)"
+            [disabled]="
+              registrationTransferActionDisabled({
+                cancellationPending: cancelRegistrationMutation.isPending(),
+                transferAvailable: registration.transferAvailable,
+                transferPending: transferRegistrationMutation.isPending(),
+              })
+            "
+          >
+            {{ transferAction.buttonLabel }}
           </button>
         </div>
       }
@@ -97,5 +121,11 @@
   <div class="bg-error text-on-error mt-4 flex flex-col gap-2 rounded-2xl p-4">
     <h3 class="title-medium">Registration cancellation failed</h3>
     <p>{{ errorMessage(cancelRegistrationMutation.error()) }}</p>
+  </div>
+}
+@if (transferRegistrationMutation.isError()) {
+  <div class="bg-error text-on-error mt-4 flex flex-col gap-2 rounded-2xl p-4">
+    <h3 class="title-medium">Registration transfer failed</h3>
+    <p>{{ transferErrorMessage(transferRegistrationMutation.error()) }}</p>
   </div>
 }

--- a/src/app/events/event-active-registration/event-active-registration.component.spec.ts
+++ b/src/app/events/event-active-registration/event-active-registration.component.spec.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  registrationCancellationActionDisabled,
   registrationCancellationCopy,
   registrationDeferredActionCopy,
+  registrationTransferActionCopy,
+  registrationTransferActionDisabled,
 } from './event-active-registration.component';
+import { normalizeRegistrationTransferTargetEmail } from './event-registration-transfer-dialog.component';
 
 describe('registrationCancellationCopy', () => {
   it('describes pending payment cancellation as releasing the reserved spot', () => {
@@ -115,10 +119,8 @@ describe('registrationCancellationCopy', () => {
 });
 
 describe('registrationDeferredActionCopy', () => {
-  it('keeps transfer and resale visibly unavailable for confirmed registrations', () => {
-    expect(registrationDeferredActionCopy({ status: 'CONFIRMED' })).toBe(
-      'Transfer/resale is not implemented yet. Contact the organizers if someone else should take your spot.',
-    );
+  it('does not show deferred transfer copy for confirmed registrations', () => {
+    expect(registrationDeferredActionCopy({ status: 'CONFIRMED' })).toBeNull();
   });
 
   it('keeps transfer and resale unavailable for pending or waitlist registrations', () => {
@@ -132,5 +134,116 @@ describe('registrationDeferredActionCopy', () => {
 
   it('does not show deferred transfer copy after cancellation', () => {
     expect(registrationDeferredActionCopy({ status: 'CANCELLED' })).toBeNull();
+  });
+});
+
+describe('registrationTransferActionCopy', () => {
+  it('exposes self-service transfer for eligible confirmed registrations', () => {
+    expect(
+      registrationTransferActionCopy({
+        status: 'CONFIRMED',
+        transferAvailable: true,
+      }),
+    ).toEqual({
+      buttonLabel: 'Transfer registration',
+      helperText:
+        'You can transfer this unpaid registration to another eligible tenant member by email.',
+    });
+  });
+
+  it('keeps paid or otherwise blocked confirmed transfers honest', () => {
+    expect(
+      registrationTransferActionCopy({
+        status: 'CONFIRMED',
+        transferAvailable: false,
+      }),
+    ).toEqual({
+      buttonLabel: 'Transfer unavailable',
+      helperText:
+        'Self-service transfer is only available for unpaid, not-yet-checked-in registrations before the event starts. Paid registration transfer and resale are not automatic yet.',
+    });
+  });
+
+  it('does not expose transfer actions for pending or waitlist registrations', () => {
+    expect(
+      registrationTransferActionCopy({
+        status: 'PENDING',
+        transferAvailable: false,
+      }),
+    ).toBeNull();
+    expect(
+      registrationTransferActionCopy({
+        status: 'WAITLIST',
+        transferAvailable: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('active registration action guards', () => {
+  it('disables cancellation while cancellation or transfer writes are pending', () => {
+    expect(
+      registrationCancellationActionDisabled({
+        cancellationPending: true,
+        transferPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      registrationCancellationActionDisabled({
+        cancellationPending: false,
+        transferPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows cancellation only when no active registration action write is pending', () => {
+    expect(
+      registrationCancellationActionDisabled({
+        cancellationPending: false,
+        transferPending: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('disables transfer when unavailable or when cancellation or transfer writes are pending', () => {
+    expect(
+      registrationTransferActionDisabled({
+        cancellationPending: false,
+        transferAvailable: false,
+        transferPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      registrationTransferActionDisabled({
+        cancellationPending: true,
+        transferAvailable: true,
+        transferPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      registrationTransferActionDisabled({
+        cancellationPending: false,
+        transferAvailable: true,
+        transferPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows transfer only when available and no active registration action write is pending', () => {
+    expect(
+      registrationTransferActionDisabled({
+        cancellationPending: false,
+        transferAvailable: true,
+        transferPending: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('normalizeRegistrationTransferTargetEmail', () => {
+  it('normalizes participant-entered target emails before submit', () => {
+    expect(
+      normalizeRegistrationTransferTargetEmail(' Target@Example.COM '),
+    ).toBe('target@example.com');
   });
 });

--- a/src/app/events/event-active-registration/event-active-registration.component.ts
+++ b/src/app/events/event-active-registration/event-active-registration.component.ts
@@ -8,13 +8,19 @@ import {
   input,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 import {
   injectMutation,
   QueryClient,
 } from '@tanstack/angular-query-experimental';
+import { firstValueFrom } from 'rxjs';
 
 import { AppRpc } from '../../core/effect-rpc-angular-client';
 import { getErrorMessage } from '../../core/error-message';
+import {
+  EventRegistrationTransferDialogComponent,
+  EventRegistrationTransferDialogResult,
+} from './event-registration-transfer-dialog.component';
 
 export const registrationCancellationCopy = (registration: {
   cancellationClosed: boolean;
@@ -82,10 +88,6 @@ export const registrationCancellationCopy = (registration: {
 export const registrationDeferredActionCopy = (registration: {
   status: EventsRegistrationStatus;
 }): null | string => {
-  if (registration.status === 'CONFIRMED') {
-    return 'Transfer/resale is not implemented yet. Contact the organizers if someone else should take your spot.';
-  }
-
   if (registration.status === 'PENDING') {
     return 'Transfer/resale is not available for pending registrations.';
   }
@@ -96,6 +98,46 @@ export const registrationDeferredActionCopy = (registration: {
 
   return null;
 };
+
+export const registrationTransferActionCopy = (registration: {
+  status: EventsRegistrationStatus;
+  transferAvailable: boolean;
+}): null | {
+  buttonLabel: string;
+  helperText: string;
+} => {
+  if (registration.status !== 'CONFIRMED') {
+    return null;
+  }
+
+  if (registration.transferAvailable) {
+    return {
+      buttonLabel: 'Transfer registration',
+      helperText:
+        'You can transfer this unpaid registration to another eligible tenant member by email.',
+    };
+  }
+
+  return {
+    buttonLabel: 'Transfer unavailable',
+    helperText:
+      'Self-service transfer is only available for unpaid, not-yet-checked-in registrations before the event starts. Paid registration transfer and resale are not automatic yet.',
+  };
+};
+
+export const registrationCancellationActionDisabled = (input: {
+  cancellationPending: boolean;
+  transferPending: boolean;
+}): boolean => input.cancellationPending || input.transferPending;
+
+export const registrationTransferActionDisabled = (input: {
+  cancellationPending: boolean;
+  transferAvailable: boolean;
+  transferPending: boolean;
+}): boolean =>
+  !input.transferAvailable ||
+  input.cancellationPending ||
+  input.transferPending;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -119,6 +161,7 @@ export class EventActiveRegistrationComponent {
       registeredDescription?: null | string | undefined;
       registrationOptionTitle: string;
       status: EventsRegistrationStatus;
+      transferAvailable: boolean;
     }[]
   >();
   private readonly rpc = AppRpc.injectClient();
@@ -126,13 +169,76 @@ export class EventActiveRegistrationComponent {
     this.rpc.events.cancelRegistration.mutationOptions(),
   );
   protected readonly deferredActionCopy = registrationDeferredActionCopy;
+  protected readonly registrationCancellationActionDisabled =
+    registrationCancellationActionDisabled;
+  protected readonly registrationTransferActionDisabled =
+    registrationTransferActionDisabled;
+  protected readonly transferActionCopy = registrationTransferActionCopy;
+  protected readonly transferRegistrationMutation = injectMutation(() =>
+    this.rpc.events.transferMyRegistration.mutationOptions(),
+  );
 
+  private readonly dialog = inject(MatDialog);
   private readonly queryClient = inject(QueryClient);
 
   cancelRegistration(registration: { id: string }) {
+    if (
+      registrationCancellationActionDisabled({
+        cancellationPending: this.cancelRegistrationMutation.isPending(),
+        transferPending: this.transferRegistrationMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     this.cancelRegistrationMutation.mutate(
       {
         registrationId: registration.id,
+      },
+      {
+        onSuccess: async () => {
+          await this.queryClient.invalidateQueries(
+            this.rpc.queryFilter(['events', 'getRegistrationStatus']),
+          );
+          await this.queryClient.invalidateQueries(
+            this.rpc.queryFilter(['events', 'findOne']),
+          );
+        },
+      },
+    );
+  }
+
+  async transferRegistration(registration: {
+    id: string;
+    transferAvailable: boolean;
+  }): Promise<void> {
+    if (
+      registrationTransferActionDisabled({
+        cancellationPending: this.cancelRegistrationMutation.isPending(),
+        transferAvailable: registration.transferAvailable,
+        transferPending: this.transferRegistrationMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
+    const dialogReference = this.dialog.open<
+      EventRegistrationTransferDialogComponent,
+      undefined,
+      EventRegistrationTransferDialogResult
+    >(EventRegistrationTransferDialogComponent, {
+      width: '520px',
+    });
+
+    const result = await firstValueFrom(dialogReference.afterClosed());
+    if (!result) {
+      return;
+    }
+
+    this.transferRegistrationMutation.mutate(
+      {
+        registrationId: registration.id,
+        targetEmail: result.targetEmail,
       },
       {
         onSuccess: async () => {
@@ -159,5 +265,9 @@ export class EventActiveRegistrationComponent {
 
   protected errorMessage(error: unknown): string {
     return getErrorMessage(error, 'Cancellation failed');
+  }
+
+  protected transferErrorMessage(error: unknown): string {
+    return getErrorMessage(error, 'Transfer failed');
   }
 }

--- a/src/app/events/event-active-registration/event-registration-transfer-dialog.component.html
+++ b/src/app/events/event-active-registration/event-registration-transfer-dialog.component.html
@@ -1,0 +1,34 @@
+<h1 mat-dialog-title>Transfer registration</h1>
+<form (submit)="submit($event)">
+  <mat-dialog-content class="grid gap-4">
+    <p class="text-on-surface-variant text-sm">
+      Transfer this unpaid registration to another eligible tenant member by
+      email.
+    </p>
+
+    <mat-form-field class="w-full">
+      <mat-label>New participant email</mat-label>
+      <input
+        matInput
+        type="email"
+        autocomplete="email"
+        placeholder="person@example.com"
+        [formField]="transferForm.targetEmail"
+      />
+      <mat-hint>
+        The target account must already exist in this tenant and be eligible for
+        this registration option.
+      </mat-hint>
+    </mat-form-field>
+
+    @if (errorMessage()) {
+      <p class="text-error text-sm">{{ errorMessage() }}</p>
+    }
+  </mat-dialog-content>
+  <mat-dialog-actions align="end" class="gap-2">
+    <button mat-button mat-dialog-close type="button">Cancel</button>
+    <button mat-raised-button color="primary" type="submit">
+      Transfer registration
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/src/app/events/event-active-registration/event-registration-transfer-dialog.component.html
+++ b/src/app/events/event-active-registration/event-registration-transfer-dialog.component.html
@@ -27,7 +27,12 @@
   </mat-dialog-content>
   <mat-dialog-actions align="end" class="gap-2">
     <button mat-button mat-dialog-close type="button">Cancel</button>
-    <button mat-raised-button color="primary" type="submit">
+    <button
+      mat-raised-button
+      color="primary"
+      type="submit"
+      [disabled]="submitting()"
+    >
       Transfer registration
     </button>
   </mat-dialog-actions>

--- a/src/app/events/event-active-registration/event-registration-transfer-dialog.component.ts
+++ b/src/app/events/event-active-registration/event-registration-transfer-dialog.component.ts
@@ -51,6 +51,7 @@ export class EventRegistrationTransferDialogComponent {
       this.transferForm().value().targetEmail,
     ),
   );
+  protected readonly submitting = signal(false);
   private readonly dialogRef = inject(
     MatDialogRef<
       EventRegistrationTransferDialogComponent,
@@ -60,6 +61,9 @@ export class EventRegistrationTransferDialogComponent {
 
   protected submit(event: Event): void {
     event.preventDefault();
+    if (this.submitting()) {
+      return;
+    }
     this.errorMessage.set('');
 
     const targetEmail = this.normalizedTargetEmail();
@@ -70,6 +74,7 @@ export class EventRegistrationTransferDialogComponent {
       return;
     }
 
+    this.submitting.set(true);
     this.dialogRef.close({ targetEmail });
   }
 }

--- a/src/app/events/event-active-registration/event-registration-transfer-dialog.component.ts
+++ b/src/app/events/event-active-registration/event-registration-transfer-dialog.component.ts
@@ -1,0 +1,75 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { email, form, FormField, required } from '@angular/forms/signals';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+export interface EventRegistrationTransferDialogResult {
+  targetEmail: string;
+}
+
+export const normalizeRegistrationTransferTargetEmail = (email: string) =>
+  email.trim().toLocaleLowerCase();
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    FormField,
+    MatButtonModule,
+    MatDialogActions,
+    MatDialogClose,
+    MatDialogContent,
+    MatDialogTitle,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  selector: 'app-event-registration-transfer-dialog',
+  templateUrl: './event-registration-transfer-dialog.component.html',
+})
+export class EventRegistrationTransferDialogComponent {
+  protected readonly errorMessage = signal('');
+  protected readonly transferModel = signal({ targetEmail: '' });
+  protected readonly transferForm = form(this.transferModel, (schema) => {
+    email(schema.targetEmail);
+    required(schema.targetEmail);
+  });
+  protected readonly normalizedTargetEmail = computed(() =>
+    normalizeRegistrationTransferTargetEmail(
+      this.transferForm().value().targetEmail,
+    ),
+  );
+  private readonly dialogRef = inject(
+    MatDialogRef<
+      EventRegistrationTransferDialogComponent,
+      EventRegistrationTransferDialogResult
+    >,
+  );
+
+  protected submit(event: Event): void {
+    event.preventDefault();
+    this.errorMessage.set('');
+
+    const targetEmail = this.normalizedTargetEmail();
+    if (!targetEmail || this.transferForm.targetEmail().invalid()) {
+      this.errorMessage.set(
+        'Enter a valid email address for the new participant.',
+      );
+      return;
+    }
+
+    this.dialogRef.close({ targetEmail });
+  }
+}

--- a/src/app/events/event-details/event-details.component.html
+++ b/src/app/events/event-details/event-details.component.html
@@ -16,7 +16,7 @@
           class="lg:hidden! block"
           aria-label="Back to events"
         >
-          <fa-icon [icon]="faArrowLeft" />
+          <fa-duotone-icon [icon]="faArrowLeft" />
         </a>
         <div class="grow"></div>
         <button
@@ -26,7 +26,7 @@
           [matMenuTriggerFor]="menu"
           aria-label="Open event actions"
         >
-          <fa-icon [icon]="faEllipsisVertical" />
+          <fa-duotone-icon [icon]="faEllipsisVertical" />
         </button>
         <mat-menu #menu="matMenu">
           <button mat-menu-item (click)="updateVisibility()">

--- a/src/app/events/event-details/event-details.component.html
+++ b/src/app/events/event-details/event-details.component.html
@@ -107,14 +107,26 @@
               <button
                 matButton="outlined"
                 (click)="reviewEvent(false)"
-                [disabled]="reviewMutation.isPending()"
+                [disabled]="
+                  eventReviewActionDisabled({
+                    canReview: canReview(),
+                    mutationPending: reviewMutation.isPending(),
+                    status: eventQuery.data().status,
+                  })
+                "
               >
                 Reject
               </button>
               <button
                 matButton="filled"
                 (click)="reviewEvent(true)"
-                [disabled]="reviewMutation.isPending()"
+                [disabled]="
+                  eventReviewActionDisabled({
+                    canReview: canReview(),
+                    mutationPending: reviewMutation.isPending(),
+                    status: eventQuery.data().status,
+                  })
+                "
               >
                 Approve
               </button>
@@ -132,7 +144,13 @@
               <button
                 matButton="filled"
                 (click)="submitForReview()"
-                [disabled]="submitForReviewMutation.isPending()"
+                [disabled]="
+                  eventSubmitForReviewActionDisabled({
+                    canEdit: canEdit(),
+                    mutationPending: submitForReviewMutation.isPending(),
+                    status: eventQuery.data().status,
+                  })
+                "
               >
                 Submit for Review
               </button>

--- a/src/app/events/event-details/event-details.component.spec.ts
+++ b/src/app/events/event-details/event-details.component.spec.ts
@@ -3,7 +3,11 @@ import { readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { registrationOptionsState } from './event-details.component';
+import {
+  eventReviewActionDisabled,
+  eventSubmitForReviewActionDisabled,
+  registrationOptionsState,
+} from './event-details.component';
 
 const readSource = (sourcePath: string): string =>
   readFileSync(nodePath.join(process.cwd(), sourcePath), 'utf8');
@@ -34,6 +38,79 @@ describe('registrationOptionsState', () => {
         registrationOptionsHiddenByEligibility: false,
       }),
     ).toBe('none');
+  });
+});
+
+describe('eventReviewActionDisabled', () => {
+  it('allows review actions only for reviewers on pending events without an in-flight review', () => {
+    expect(
+      eventReviewActionDisabled({
+        canReview: true,
+        mutationPending: false,
+        status: 'PENDING_REVIEW',
+      }),
+    ).toBe(false);
+    expect(
+      eventReviewActionDisabled({
+        canReview: false,
+        mutationPending: false,
+        status: 'PENDING_REVIEW',
+      }),
+    ).toBe(true);
+    expect(
+      eventReviewActionDisabled({
+        canReview: true,
+        mutationPending: true,
+        status: 'PENDING_REVIEW',
+      }),
+    ).toBe(true);
+    expect(
+      eventReviewActionDisabled({
+        canReview: true,
+        mutationPending: false,
+        status: 'APPROVED',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('eventSubmitForReviewActionDisabled', () => {
+  it('allows editable draft and rejected events to be submitted while no submit is pending', () => {
+    expect(
+      eventSubmitForReviewActionDisabled({
+        canEdit: true,
+        mutationPending: false,
+        status: 'DRAFT',
+      }),
+    ).toBe(false);
+    expect(
+      eventSubmitForReviewActionDisabled({
+        canEdit: true,
+        mutationPending: false,
+        status: 'REJECTED',
+      }),
+    ).toBe(false);
+    expect(
+      eventSubmitForReviewActionDisabled({
+        canEdit: false,
+        mutationPending: false,
+        status: 'DRAFT',
+      }),
+    ).toBe(true);
+    expect(
+      eventSubmitForReviewActionDisabled({
+        canEdit: true,
+        mutationPending: true,
+        status: 'DRAFT',
+      }),
+    ).toBe(true);
+    expect(
+      eventSubmitForReviewActionDisabled({
+        canEdit: true,
+        mutationPending: false,
+        status: 'PENDING_REVIEW',
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/app/events/event-details/event-details.component.ts
+++ b/src/app/events/event-details/event-details.component.ts
@@ -8,6 +8,7 @@ import {
   inject,
   input,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatMenuModule } from '@angular/material/menu';
@@ -26,7 +27,7 @@ import {
   QueryClient,
 } from '@tanstack/angular-query-experimental';
 import { convert } from 'html-to-text';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, interval, map } from 'rxjs';
 
 import { ConfigService } from '../../core/config.service';
 import { AppRpc } from '../../core/effect-rpc-angular-client';
@@ -186,9 +187,13 @@ export class EventDetailsComponent {
   protected readonly faArrowLeft = faArrowLeft;
 
   protected readonly faEllipsisVertical = faEllipsisVertical;
+  private readonly currentTime = toSignal(
+    interval(60_000).pipe(map(() => new Date())),
+    { initialValue: new Date() },
+  );
   protected readonly registrationCancellationClosed = computed(() => {
     const event = this.eventQuery.data();
-    return event ? new Date(event.start) <= new Date() : false;
+    return event ? new Date(event.start) <= this.currentTime() : false;
   });
   protected readonly registrationOptionsState = computed(() => {
     const event = this.eventQuery.data();

--- a/src/app/events/event-details/event-details.component.ts
+++ b/src/app/events/event-details/event-details.component.ts
@@ -1,3 +1,5 @@
+import type { EventReviewStatus } from '@shared/rpc-contracts/app-rpcs/events.rpcs';
+
 import {
   ChangeDetectionStrategy,
   Component,
@@ -55,6 +57,27 @@ export const registrationOptionsState = (event: {
     ? 'hiddenByEligibility'
     : 'none';
 };
+
+export const eventReviewActionDisabled = ({
+  canReview,
+  mutationPending,
+  status,
+}: {
+  canReview: boolean;
+  mutationPending: boolean;
+  status: EventReviewStatus;
+}): boolean => !canReview || status !== 'PENDING_REVIEW' || mutationPending;
+
+export const eventSubmitForReviewActionDisabled = ({
+  canEdit,
+  mutationPending,
+  status,
+}: {
+  canEdit: boolean;
+  mutationPending: boolean;
+  status: EventReviewStatus;
+}): boolean =>
+  !canEdit || (status !== 'DRAFT' && status !== 'REJECTED') || mutationPending;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -157,6 +180,9 @@ export class EventDetailsComponent {
     }
     return event.icon.iconColor;
   });
+  protected readonly eventReviewActionDisabled = eventReviewActionDisabled;
+  protected readonly eventSubmitForReviewActionDisabled =
+    eventSubmitForReviewActionDisabled;
   protected readonly faArrowLeft = faArrowLeft;
 
   protected readonly faEllipsisVertical = faEllipsisVertical;
@@ -220,6 +246,18 @@ export class EventDetailsComponent {
   }
 
   protected async reviewEvent(approved: boolean): Promise<void> {
+    const event = this.eventQuery.data();
+    if (
+      !event ||
+      eventReviewActionDisabled({
+        canReview: this.canReview(),
+        mutationPending: this.reviewMutation.isPending(),
+        status: event.status,
+      })
+    ) {
+      return;
+    }
+
     try {
       if (approved) {
         await this.reviewMutation.mutateAsync({
@@ -254,6 +292,18 @@ export class EventDetailsComponent {
   }
 
   protected async submitForReview(): Promise<void> {
+    const event = this.eventQuery.data();
+    if (
+      !event ||
+      eventSubmitForReviewActionDisabled({
+        canEdit: this.canEdit(),
+        mutationPending: this.submitForReviewMutation.isPending(),
+        status: event.status,
+      })
+    ) {
+      return;
+    }
+
     try {
       const dialogReference = this.dialog.open(SubmitEventDialogComponent);
       const confirmed = await firstValueFrom(dialogReference.afterClosed());

--- a/src/app/events/event-edit/event-edit.html
+++ b/src/app/events/event-edit/event-edit.html
@@ -49,9 +49,11 @@
           type="submit"
           mat-button
           [disabled]="
-            editEventForm().invalid() ||
-            editEventForm().submitting() ||
-            updateEventMutation.isPending()
+            eventEditSubmitDisabled({
+              formInvalid: editEventForm().invalid(),
+              formSubmitting: editEventForm().submitting(),
+              mutationPending: updateEventMutation.isPending(),
+            })
           "
         >
           @if (updateEventMutation.isPending()) {

--- a/src/app/events/event-edit/event-edit.spec.ts
+++ b/src/app/events/event-edit/event-edit.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { eventEditSubmitDisabled } from './event-edit';
+
+describe('eventEditSubmitDisabled', () => {
+  it('blocks event edit submits while invalid, submitting, or awaiting the mutation', () => {
+    expect(
+      eventEditSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+    expect(
+      eventEditSubmitDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      eventEditSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      eventEditSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/app/events/event-edit/event-edit.ts
+++ b/src/app/events/event-edit/event-edit.ts
@@ -35,6 +35,16 @@ import { RegistrationOptionForm } from '../../shared/components/forms/registrati
 import { createRegistrationOptionFormModel } from '../../shared/components/forms/registration-option-form/registration-option-form.schema';
 import { IfAnyPermissionDirective } from '../../shared/directives/if-any-permission.directive';
 
+export const eventEditSubmitDisabled = ({
+  formInvalid,
+  formSubmitting,
+  mutationPending,
+}: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean => formInvalid || formSubmitting || mutationPending;
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
@@ -71,6 +81,7 @@ export class EventEdit {
       'enabled'
     );
   });
+  protected readonly eventEditSubmitDisabled = eventEditSubmitDisabled;
   protected readonly eventQuery = injectQuery(() =>
     this.rpc.events.findOneForEdit.queryOptions({ id: this.eventId() }),
   );
@@ -127,6 +138,16 @@ export class EventEdit {
   }
   protected async saveEvent(event: Event) {
     event.preventDefault();
+    if (
+      eventEditSubmitDisabled({
+        formInvalid: this.editEventForm().invalid(),
+        formSubmitting: this.editEventForm().submitting(),
+        mutationPending: this.updateEventMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     await submit(this.editEventForm, async (formState) => {
       const formValue = formState().value();
 

--- a/src/app/events/event-edit/event-edit.ts
+++ b/src/app/events/event-edit/event-edit.ts
@@ -140,7 +140,7 @@ export class EventEdit {
     event.preventDefault();
     if (
       eventEditSubmitDisabled({
-        formInvalid: this.editEventForm().invalid(),
+        formInvalid: false,
         formSubmitting: this.editEventForm().submitting(),
         mutationPending: this.updateEventMutation.isPending(),
       })

--- a/src/app/events/event-list/event-list.component.html
+++ b/src/app/events/event-list/event-list.component.html
@@ -61,11 +61,7 @@
             <a
               routerLink="{{ event.id }}"
               class="rounded-2xl bg-surface px-4 py-2 text-on-surface relative overflow-hidden {{
-                event.userRegistered
-                  ? 'ring-3 ring-inset ring-success'
-                  : event.userIsCreator
-                    ? 'ring-3 ring-inset ring-tertiary'
-                    : ''
+                event.userRegistered ? 'ring-3 ring-inset ring-success' : ''
               }}"
               routerLinkActive="bg-secondary-container! text-on-secondary-container!"
             >

--- a/src/app/events/event-organize/event-organize.html
+++ b/src/app/events/event-organize/event-organize.html
@@ -76,15 +76,38 @@
                   }
                 </div>
                 @if (!registrationOption.organizingRegistration) {
-                  <button
-                    mat-stroked-button
-                    (click)="cancelRegistration(user)"
-                    [disabled]="
-                      user.checkedIn || cancelRegistrationMutation.isPending()
-                    "
-                  >
-                    Cancel registration
-                  </button>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      mat-stroked-button
+                      type="button"
+                      (click)="openTransferDialog(user)"
+                      [disabled]="
+                        organizerRegistrationActionDisabled({
+                          checkedIn: user.checkedIn,
+                          mutationPending:
+                            transferRegistrationMutation.isPending() ||
+                            cancelRegistrationMutation.isPending(),
+                        })
+                      "
+                    >
+                      Transfer registration
+                    </button>
+                    <button
+                      mat-stroked-button
+                      type="button"
+                      (click)="cancelRegistration(user)"
+                      [disabled]="
+                        organizerRegistrationActionDisabled({
+                          checkedIn: user.checkedIn,
+                          mutationPending:
+                            cancelRegistrationMutation.isPending() ||
+                            transferRegistrationMutation.isPending(),
+                        })
+                      "
+                    >
+                      Cancel registration
+                    </button>
+                  </div>
                 }
               </div>
             }
@@ -146,14 +169,17 @@
             color="primary"
             (click)="openReceiptDialog()"
             [disabled]="
-              submitReceiptMutation.isPending() ||
-              !!receiptSubmissionClosedMessage()
+              receiptSubmissionActionDisabled({
+                submissionUnavailable: !!receiptSubmissionUnavailableMessage(),
+                submitPending: submitReceiptMutation.isPending(),
+                uploadPending: receiptOriginalUploadMutation.isPending(),
+              })
             "
           >
             Add receipt
           </button>
         </div>
-        @if (receiptSubmissionClosedMessage(); as message) {
+        @if (receiptSubmissionUnavailableMessage(); as message) {
           <p class="text-on-surface-variant text-sm">
             {{ message }}
           </p>

--- a/src/app/events/event-organize/event-organize.spec.ts
+++ b/src/app/events/event-organize/event-organize.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeEventOrganizeStats } from './event-organize';
+import {
+  computeEventOrganizeStats,
+  organizerRegistrationActionDisabled,
+  receiptSubmissionActionDisabled,
+} from './event-organize';
+import { transferParticipantLabel } from './registration-transfer-dialog.component';
 
 describe('computeEventOrganizeStats', () => {
   it('sums capacity, confirmed registrations, and scanner-updated checked-in spots', () => {
@@ -34,5 +39,73 @@ describe('computeEventOrganizeStats', () => {
       checkedIn: 0,
       registered: 0,
     });
+  });
+});
+
+describe('transferParticipantLabel', () => {
+  it('shows the participant identity before organizer-assisted transfer', () => {
+    expect(
+      transferParticipantLabel({
+        email: 'alex@example.com',
+        firstName: 'Alex',
+        lastName: 'Able',
+      }),
+    ).toBe('Alex Able (alex@example.com)');
+  });
+});
+
+describe('organizerRegistrationActionDisabled', () => {
+  it('blocks organizer participant mutations for checked-in rows or in-flight writes', () => {
+    expect(
+      organizerRegistrationActionDisabled({
+        checkedIn: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      organizerRegistrationActionDisabled({
+        checkedIn: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      organizerRegistrationActionDisabled({
+        checkedIn: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('receiptSubmissionActionDisabled', () => {
+  it('blocks receipt submission while unavailable, uploading, or submitting', () => {
+    expect(
+      receiptSubmissionActionDisabled({
+        submissionUnavailable: true,
+        submitPending: false,
+        uploadPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      receiptSubmissionActionDisabled({
+        submissionUnavailable: false,
+        submitPending: false,
+        uploadPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      receiptSubmissionActionDisabled({
+        submissionUnavailable: false,
+        submitPending: true,
+        uploadPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      receiptSubmissionActionDisabled({
+        submissionUnavailable: false,
+        submitPending: false,
+        uploadPending: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/app/events/event-organize/event-organize.ts
+++ b/src/app/events/event-organize/event-organize.ts
@@ -33,6 +33,11 @@ import {
   ReceiptSubmitDialogComponent,
   ReceiptSubmitDialogResult,
 } from './receipt-submit-dialog.component';
+import {
+  RegistrationTransferDialogComponent,
+  RegistrationTransferDialogData,
+  RegistrationTransferDialogResult,
+} from './registration-transfer-dialog.component';
 
 interface EventOrganizeStatsInput {
   registrationOptions?: readonly {
@@ -67,6 +72,32 @@ export const computeEventOrganizeStats = (
   };
 };
 
+export interface EventOrganizeParticipant {
+  checkedIn: boolean;
+  email: string;
+  firstName: string;
+  lastName: string;
+  registrationId: string;
+}
+
+export const organizerRegistrationActionDisabled = ({
+  checkedIn,
+  mutationPending,
+}: {
+  checkedIn: boolean;
+  mutationPending: boolean;
+}): boolean => checkedIn || mutationPending;
+
+export const receiptSubmissionActionDisabled = ({
+  submissionUnavailable,
+  submitPending,
+  uploadPending,
+}: {
+  submissionUnavailable: boolean;
+  submitPending: boolean;
+  uploadPending: boolean;
+}): boolean => submissionUnavailable || submitPending || uploadPending;
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
@@ -98,7 +129,8 @@ export class EventOrganize {
       eventId: this.eventId(),
     }),
   );
-
+  protected readonly organizerRegistrationActionDisabled =
+    organizerRegistrationActionDisabled;
   protected readonly organizerTableColumns = signal([
     'name',
     'email',
@@ -118,20 +150,24 @@ export class EventOrganize {
         ...registrationOption.users,
       ]);
   });
+
+  protected readonly receiptOriginalUploadMutation = injectMutation(() =>
+    this.rpc.finance.receiptMedia.uploadOriginal.mutationOptions(),
+  );
   protected readonly receiptsByEventQuery = injectQuery(() =>
     this.rpc.finance.receipts.byEvent.queryOptions({
       eventId: this.eventId(),
     }),
   );
-  protected readonly receiptSubmissionClosedMessage = computed(() => {
+  protected readonly receiptSubmissionActionDisabled =
+    receiptSubmissionActionDisabled;
+  protected readonly receiptSubmissionUnavailableMessage = computed(() => {
     const event = this.event();
     if (!event) {
       return 'Receipts can be added after the event has loaded.';
     }
 
-    return new Date(event.end) > new Date()
-      ? 'Receipts can be added after the event ends.'
-      : null;
+    return null;
   });
 
   protected readonly stats = computed(() =>
@@ -140,15 +176,15 @@ export class EventOrganize {
   protected readonly submitReceiptMutation = injectMutation(() =>
     this.rpc.finance.receipts.submit.mutationOptions(),
   );
+  protected readonly transferRegistrationMutation = injectMutation(() =>
+    this.rpc.events.transferEventRegistration.mutationOptions(),
+  );
   private readonly config = inject(ConfigService);
+
   private readonly dialog = inject(MatDialog);
 
   private readonly notifications = inject(NotificationService);
-
   private readonly queryClient = inject(QueryClient);
-  private readonly receiptOriginalUploadMutation = injectMutation(() =>
-    this.rpc.finance.receiptMedia.uploadOriginal.mutationOptions(),
-  );
 
   constructor() {
     effect(() => {
@@ -159,7 +195,21 @@ export class EventOrganize {
     });
   }
 
-  protected cancelRegistration(registration: { registrationId: string }) {
+  protected cancelRegistration(
+    registration: Pick<
+      EventOrganizeParticipant,
+      'checkedIn' | 'registrationId'
+    >,
+  ) {
+    if (
+      organizerRegistrationActionDisabled({
+        checkedIn: registration.checkedIn,
+        mutationPending: this.cancelRegistrationMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     this.cancelRegistrationMutation.mutate(
       {
         eventId: this.eventId(),
@@ -189,6 +239,16 @@ export class EventOrganize {
   }
 
   protected async openReceiptDialog(): Promise<void> {
+    if (
+      receiptSubmissionActionDisabled({
+        submissionUnavailable: !!this.receiptSubmissionUnavailableMessage(),
+        submitPending: this.submitReceiptMutation.isPending(),
+        uploadPending: this.receiptOriginalUploadMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     const receiptCountrySettings = resolveReceiptCountrySettings(
       this.config.tenant.receiptSettings,
     );
@@ -251,6 +311,69 @@ export class EventOrganize {
         getErrorMessage(error, 'Failed to upload receipt file'),
       );
     }
+  }
+
+  protected async openTransferDialog(
+    registration: EventOrganizeParticipant,
+  ): Promise<void> {
+    if (
+      organizerRegistrationActionDisabled({
+        checkedIn: registration.checkedIn,
+        mutationPending: this.transferRegistrationMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
+    const dialogReference = this.dialog.open<
+      RegistrationTransferDialogComponent,
+      RegistrationTransferDialogData,
+      RegistrationTransferDialogResult
+    >(RegistrationTransferDialogComponent, {
+      data: {
+        currentUser: {
+          email: registration.email,
+          firstName: registration.firstName,
+          lastName: registration.lastName,
+        },
+        eventId: this.eventId(),
+        registrationId: registration.registrationId,
+      },
+      width: '560px',
+    });
+
+    const result = await firstValueFrom(dialogReference.afterClosed());
+    if (!result) {
+      return;
+    }
+
+    this.transferRegistrationMutation.mutate(
+      {
+        eventId: this.eventId(),
+        registrationId: registration.registrationId,
+        targetUserId: result.targetUserId,
+      },
+      {
+        onError: (error) => {
+          this.notifications.showError(
+            getErrorMessage(error, 'Failed to transfer registration'),
+          );
+        },
+        onSuccess: async () => {
+          await this.queryClient.invalidateQueries({
+            queryKey: this.rpc.events.getOrganizeOverview.queryKey({
+              eventId: this.eventId(),
+            }),
+          });
+          await this.queryClient.invalidateQueries({
+            queryKey: this.rpc.events.findOne.queryKey({
+              id: this.eventId(),
+            }),
+          });
+          this.notifications.showSuccess('Registration transferred');
+        },
+      },
+    );
   }
 
   protected readonly showOrganizerRow = (

--- a/src/app/events/event-organize/event-organize.ts
+++ b/src/app/events/event-organize/event-organize.ts
@@ -136,7 +136,6 @@ export class EventOrganize {
     'email',
     'checkin',
   ]);
-
   protected readonly organizerTableContent = computed(() => {
     const overview = this.organizerOverviewQuery.data();
     if (!overview) return [];
@@ -154,6 +153,7 @@ export class EventOrganize {
   protected readonly receiptOriginalUploadMutation = injectMutation(() =>
     this.rpc.finance.receiptMedia.uploadOriginal.mutationOptions(),
   );
+
   protected readonly receiptsByEventQuery = injectQuery(() =>
     this.rpc.finance.receipts.byEvent.queryOptions({
       eventId: this.eventId(),
@@ -169,15 +169,20 @@ export class EventOrganize {
 
     return null;
   });
+  protected readonly transferRegistrationMutation = injectMutation(() =>
+    this.rpc.events.transferEventRegistration.mutationOptions(),
+  );
 
+  protected readonly registrationMutationPending = computed(
+    () =>
+      this.cancelRegistrationMutation.isPending() ||
+      this.transferRegistrationMutation.isPending(),
+  );
   protected readonly stats = computed(() =>
     computeEventOrganizeStats(this.event()),
   );
   protected readonly submitReceiptMutation = injectMutation(() =>
     this.rpc.finance.receipts.submit.mutationOptions(),
-  );
-  protected readonly transferRegistrationMutation = injectMutation(() =>
-    this.rpc.events.transferEventRegistration.mutationOptions(),
   );
   private readonly config = inject(ConfigService);
 
@@ -204,7 +209,7 @@ export class EventOrganize {
     if (
       organizerRegistrationActionDisabled({
         checkedIn: registration.checkedIn,
-        mutationPending: this.cancelRegistrationMutation.isPending(),
+        mutationPending: this.registrationMutationPending(),
       })
     ) {
       return;
@@ -319,7 +324,7 @@ export class EventOrganize {
     if (
       organizerRegistrationActionDisabled({
         checkedIn: registration.checkedIn,
-        mutationPending: this.transferRegistrationMutation.isPending(),
+        mutationPending: this.registrationMutationPending(),
       })
     ) {
       return;

--- a/src/app/events/event-organize/registration-transfer-dialog.component.html
+++ b/src/app/events/event-organize/registration-transfer-dialog.component.html
@@ -1,0 +1,54 @@
+<h1 mat-dialog-title>Transfer registration</h1>
+<mat-dialog-content class="grid gap-4">
+  <p class="text-on-surface-variant text-sm">
+    Current participant: {{ currentParticipantLabel() }}
+  </p>
+
+  <mat-form-field class="w-full">
+    <mat-label>Search eligible tenant members</mat-label>
+    <input
+      matInput
+      autocomplete="off"
+      placeholder="Name or email"
+      [formField]="searchForm.query"
+    />
+    <mat-hint>
+      Paid registrations still need manual refund or resale handling.
+    </mat-hint>
+  </mat-form-field>
+
+  @if (transferTargetsQuery.isPending()) {
+    <div class="bg-surface-container rounded-lg p-4 text-sm">
+      Loading eligible members...
+    </div>
+  } @else if (transferTargetsQuery.isError()) {
+    <div class="bg-error-container text-on-error-container rounded-lg p-4">
+      Eligible members could not be loaded.
+    </div>
+  } @else if (transferTargetsQuery.data()?.length === 0) {
+    <div class="bg-surface-container rounded-lg p-4 text-sm">
+      No eligible transfer target found.
+    </div>
+  } @else {
+    <div class="grid max-h-80 gap-2 overflow-y-auto">
+      @for (target of transferTargetsQuery.data(); track target.id) {
+        <button
+          mat-stroked-button
+          type="button"
+          class="h-auto! justify-start! py-3! text-left"
+          (click)="transferTo(target.id)"
+        >
+          <span class="grid">
+            <span>{{ target.firstName }} {{ target.lastName }}</span>
+            <span class="text-on-surface-variant text-xs">
+              {{ target.email }}
+            </span>
+          </span>
+        </button>
+      }
+    </div>
+  }
+</mat-dialog-content>
+<mat-dialog-actions align="end" class="gap-2">
+  <button mat-button mat-dialog-close type="button">Cancel</button>
+</mat-dialog-actions>

--- a/src/app/events/event-organize/registration-transfer-dialog.component.ts
+++ b/src/app/events/event-organize/registration-transfer-dialog.component.ts
@@ -1,0 +1,93 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { debounce, form, FormField } from '@angular/forms/signals';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { injectQuery } from '@tanstack/angular-query-experimental';
+
+import { AppRpc } from '../../core/effect-rpc-angular-client';
+
+export interface RegistrationTransferDialogData {
+  currentUser: {
+    email: string;
+    firstName: string;
+    lastName: string;
+  };
+  eventId: string;
+  registrationId: string;
+}
+
+export interface RegistrationTransferDialogResult {
+  targetUserId: string;
+}
+
+export const transferParticipantLabel = (participant: {
+  email: string;
+  firstName: string;
+  lastName: string;
+}) => `${participant.firstName} ${participant.lastName} (${participant.email})`;
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    FormField,
+    MatButtonModule,
+    MatDialogActions,
+    MatDialogClose,
+    MatDialogContent,
+    MatDialogTitle,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  selector: 'app-registration-transfer-dialog',
+  templateUrl: './registration-transfer-dialog.component.html',
+})
+export class RegistrationTransferDialogComponent {
+  protected readonly data =
+    inject<RegistrationTransferDialogData>(MAT_DIALOG_DATA);
+  protected readonly currentParticipantLabel = computed(() =>
+    transferParticipantLabel(this.data.currentUser),
+  );
+  protected readonly searchModel = signal({ query: '' });
+  protected readonly searchForm = form(this.searchModel, (schema) => {
+    debounce(schema, 300);
+  });
+  protected readonly searchValue = computed(
+    () => this.searchForm().value().query,
+  );
+
+  private readonly rpc = AppRpc.injectClient();
+
+  protected readonly transferTargetsQuery = injectQuery(() =>
+    this.rpc.events.findTransferTargets.queryOptions({
+      eventId: this.data.eventId,
+      registrationId: this.data.registrationId,
+      search: this.searchValue(),
+    }),
+  );
+
+  private readonly dialogRef = inject(
+    MatDialogRef<
+      RegistrationTransferDialogComponent,
+      RegistrationTransferDialogResult
+    >,
+  );
+
+  protected transferTo(targetUserId: string): void {
+    this.dialogRef.close({ targetUserId });
+  }
+}

--- a/src/app/events/event-registration-option/event-registration-option.component.html
+++ b/src/app/events/event-registration-option/event-registration-option.component.html
@@ -47,7 +47,11 @@
               (click)="joinWaitlist(registrationOption())"
               mat-flat-button
               type="button"
-              [disabled]="mutationPending()"
+              [disabled]="
+                registrationOptionWriteActionDisabled({
+                  mutationPending: mutationPending(),
+                })
+              "
             >
               Join waitlist
             </button>
@@ -76,7 +80,11 @@
               (click)="register(registrationOption())"
               mat-flat-button
               type="button"
-              [disabled]="mutationPending()"
+              [disabled]="
+                registrationOptionWriteActionDisabled({
+                  mutationPending: mutationPending(),
+                })
+              "
             >
               Pay
               {{ selectedTotalPrice() / 100 | currency }}
@@ -87,7 +95,11 @@
               (click)="register(registrationOption())"
               mat-flat-button
               type="button"
-              [disabled]="mutationPending()"
+              [disabled]="
+                registrationOptionWriteActionDisabled({
+                  mutationPending: mutationPending(),
+                })
+              "
             >
               {{ audienceCopy().primaryAction }}
             </button>

--- a/src/app/events/event-registration-option/event-registration-option.component.spec.ts
+++ b/src/app/events/event-registration-option/event-registration-option.component.spec.ts
@@ -7,6 +7,7 @@ import {
   registrationOptionCanJoinWaitlist,
   registrationOptionIsFull,
   registrationOptionSelectedTotalPrice,
+  registrationOptionWriteActionDisabled,
 } from './event-registration-option.component';
 
 describe('registrationOptionAudienceCopy', () => {
@@ -203,5 +204,19 @@ describe('registrationOptionSelectedTotalPrice', () => {
         -1,
       ),
     ).toBe(1500);
+  });
+});
+
+describe('registrationOptionWriteActionDisabled', () => {
+  it('disables registration writes while register or waitlist mutations are pending', () => {
+    expect(
+      registrationOptionWriteActionDisabled({ mutationPending: true }),
+    ).toBe(true);
+  });
+
+  it('allows registration writes while no register or waitlist mutation is pending', () => {
+    expect(
+      registrationOptionWriteActionDisabled({ mutationPending: false }),
+    ).toBe(false);
   });
 });

--- a/src/app/events/event-registration-option/event-registration-option.component.ts
+++ b/src/app/events/event-registration-option/event-registration-option.component.ts
@@ -263,6 +263,11 @@ export class EventRegistrationOptionComponent {
               eventId: registrationOption.eventId,
             }),
           });
+          await this.queryClient.invalidateQueries({
+            queryKey: this.rpc.events.findOne.queryKey({
+              id: registrationOption.eventId,
+            }),
+          });
         },
       },
     );

--- a/src/app/events/event-registration-option/event-registration-option.component.ts
+++ b/src/app/events/event-registration-option/event-registration-option.component.ts
@@ -106,6 +106,10 @@ export const registrationOptionSelectedTotalPrice = (
   return buyerPrice + option.price * Math.max(0, guestCount);
 };
 
+export const registrationOptionWriteActionDisabled = (input: {
+  mutationPending: boolean;
+}): boolean => input.mutationPending;
+
 export const registrationOptionAvailability = (
   option: Pick<
     EventRegistrationOptionView,
@@ -178,6 +182,8 @@ export class EventRegistrationOptionComponent {
       this.currentTime(),
     );
   });
+  protected readonly registrationOptionWriteActionDisabled =
+    registrationOptionWriteActionDisabled;
   protected readonly selectedGuestCount = computed(() =>
     Math.min(this.guestCount(), this.maxGuestCount()),
   );
@@ -205,6 +211,14 @@ export class EventRegistrationOptionComponent {
   private queryClient = inject(QueryClient);
 
   joinWaitlist(registrationOption: { eventId: string; id: string }) {
+    if (
+      registrationOptionWriteActionDisabled({
+        mutationPending: this.mutationPending(),
+      })
+    ) {
+      return;
+    }
+
     this.waitlistMutation.mutate(
       {
         eventId: registrationOption.eventId,
@@ -228,6 +242,14 @@ export class EventRegistrationOptionComponent {
   }
 
   register(registrationOption: { eventId: string; id: string }) {
+    if (
+      registrationOptionWriteActionDisabled({
+        mutationPending: this.mutationPending(),
+      })
+    ) {
+      return;
+    }
+
     this.registrationMutation.mutate(
       {
         eventId: registrationOption.eventId,

--- a/src/app/finance/receipt-approval-detail/receipt-approval-detail.component.html
+++ b/src/app/finance/receipt-approval-detail/receipt-approval-detail.component.html
@@ -80,7 +80,13 @@
             mat-stroked-button
             color="warn"
             (click)="reject()"
-            [disabled]="reviewMutation.isPending()"
+            [disabled]="
+              receiptReviewActionDisabled({
+                formInvalid: form.invalid,
+                mutationPending: reviewMutation.isPending(),
+                receiptPending: receiptQuery.isPending(),
+              })
+            "
             type="button"
           >
             Reject
@@ -89,7 +95,13 @@
             mat-raised-button
             color="primary"
             (click)="approve()"
-            [disabled]="reviewMutation.isPending()"
+            [disabled]="
+              receiptReviewActionDisabled({
+                formInvalid: form.invalid,
+                mutationPending: reviewMutation.isPending(),
+                receiptPending: receiptQuery.isPending(),
+              })
+            "
             type="button"
           >
             Approve

--- a/src/app/finance/receipt-approval-detail/receipt-approval-detail.component.spec.ts
+++ b/src/app/finance/receipt-approval-detail/receipt-approval-detail.component.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  receiptReviewActionDisabled,
   receiptReviewNotificationNotice,
   receiptReviewSuccessMessage,
 } from './receipt-approval-detail.component';
@@ -22,5 +23,38 @@ describe('receiptReviewSuccessMessage', () => {
     expect(receiptReviewSuccessMessage('rejected')).toBe(
       'Receipt rejected. Notify the submitter manually.',
     );
+  });
+});
+
+describe('receiptReviewActionDisabled', () => {
+  it('blocks review writes while the form is invalid, the receipt is loading, or the mutation is pending', () => {
+    expect(
+      receiptReviewActionDisabled({
+        formInvalid: false,
+        mutationPending: false,
+        receiptPending: false,
+      }),
+    ).toBe(false);
+    expect(
+      receiptReviewActionDisabled({
+        formInvalid: true,
+        mutationPending: false,
+        receiptPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      receiptReviewActionDisabled({
+        formInvalid: false,
+        mutationPending: false,
+        receiptPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      receiptReviewActionDisabled({
+        formInvalid: false,
+        mutationPending: true,
+        receiptPending: false,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/app/finance/receipt-approval-detail/receipt-approval-detail.component.ts
+++ b/src/app/finance/receipt-approval-detail/receipt-approval-detail.component.ts
@@ -39,6 +39,16 @@ export const receiptReviewSuccessMessage = (
 export const receiptReviewNotificationNotice =
   'Approving or rejecting this receipt records the review status only. Notify the submitter manually after saving.';
 
+export const receiptReviewActionDisabled = ({
+  formInvalid,
+  mutationPending,
+  receiptPending,
+}: {
+  formInvalid: boolean;
+  mutationPending: boolean;
+  receiptPending: boolean;
+}): boolean => formInvalid || receiptPending || mutationPending;
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
@@ -87,6 +97,7 @@ export class ReceiptApprovalDetailComponent {
     return receipt.attachmentMimeType === 'application/pdf';
   });
 
+  protected readonly receiptReviewActionDisabled = receiptReviewActionDisabled;
   protected readonly receiptReviewNotificationNotice =
     receiptReviewNotificationNotice;
   protected readonly rejectionReason = signal('');
@@ -149,8 +160,17 @@ export class ReceiptApprovalDetailComponent {
   }
 
   private async review(status: 'approved' | 'rejected'): Promise<void> {
-    if (this.form.invalid || this.receiptQuery.isPending()) {
-      this.form.markAllAsTouched();
+    const formInvalid = this.form.invalid;
+    if (
+      receiptReviewActionDisabled({
+        formInvalid,
+        mutationPending: this.reviewMutation.isPending(),
+        receiptPending: this.receiptQuery.isPending(),
+      })
+    ) {
+      if (formInvalid || this.receiptQuery.isPending()) {
+        this.form.markAllAsTouched();
+      }
       return;
     }
 

--- a/src/app/finance/receipt-refund-list/receipt-refund-list.component.html
+++ b/src/app/finance/receipt-refund-list/receipt-refund-list.component.html
@@ -64,8 +64,19 @@
             </mat-select>
           </mat-form-field>
           <div class="bg-surface-container rounded-xl p-3 text-sm">
-            <p>IBAN: {{ group.payout.iban || "not set" }}</p>
-            <p>PayPal: {{ group.payout.paypalEmail || "not set" }}</p>
+            <p>
+              {{
+                receiptReimbursementPayoutDetailLabel("iban", group.payout.iban)
+              }}
+            </p>
+            <p>
+              {{
+                receiptReimbursementPayoutDetailLabel(
+                  "paypal",
+                  group.payout.paypalEmail
+                )
+              }}
+            </p>
           </div>
         </div>
 
@@ -168,8 +179,10 @@
             mat-raised-button
             color="primary"
             [disabled]="
-              !canRefund(group.submittedByUserId, group.payout) ||
-              refundMutation.isPending()
+              receiptReimbursementRecordDisabled({
+                canRecord: canRefund(group.submittedByUserId, group.payout),
+                mutationPending: refundMutation.isPending(),
+              })
             "
             (click)="refundRecipient(group)"
           >

--- a/src/app/finance/receipt-refund-list/receipt-refund-list.component.spec.ts
+++ b/src/app/finance/receipt-refund-list/receipt-refund-list.component.spec.ts
@@ -1,11 +1,101 @@
 import { describe, expect, it } from 'vitest';
 
-import { receiptReimbursementManualNotice } from './receipt-refund-list.component';
+import {
+  receiptReimbursementCanRecord,
+  receiptReimbursementManualNotice,
+  receiptReimbursementPayoutDetailLabel,
+  receiptReimbursementRecordDisabled,
+  receiptReimbursementSelectedTotal,
+} from './receipt-refund-list.component';
 
 describe('receiptReimbursementManualNotice', () => {
   it('keeps reimbursement copy honest about manual money movement', () => {
     expect(receiptReimbursementManualNotice).toBe(
       'Recording a reimbursement creates the Evorto finance transaction only. Transfer the money manually through the selected payout method.',
     );
+  });
+});
+
+describe('receiptReimbursementCanRecord', () => {
+  it('requires at least one selected receipt', () => {
+    expect(
+      receiptReimbursementCanRecord(
+        [],
+        { iban: 'DE123', paypalEmail: null },
+        'iban',
+      ),
+    ).toBe(false);
+  });
+
+  it('requires the selected payout detail to exist', () => {
+    expect(
+      receiptReimbursementCanRecord(
+        ['receipt-1'],
+        { iban: null, paypalEmail: 'pay@example.com' },
+        'iban',
+      ),
+    ).toBe(false);
+    expect(
+      receiptReimbursementCanRecord(
+        ['receipt-1'],
+        { iban: null, paypalEmail: 'pay@example.com' },
+        'paypal',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('receiptReimbursementRecordDisabled', () => {
+  it('disables reimbursement recording when the selected group cannot be recorded', () => {
+    expect(
+      receiptReimbursementRecordDisabled({
+        canRecord: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('disables reimbursement recording while a refund mutation is pending', () => {
+    expect(
+      receiptReimbursementRecordDisabled({
+        canRecord: true,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows reimbursement recording only when the selection and mutation are ready', () => {
+    expect(
+      receiptReimbursementRecordDisabled({
+        canRecord: true,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('receiptReimbursementPayoutDetailLabel', () => {
+  it('labels configured and missing payout details', () => {
+    expect(receiptReimbursementPayoutDetailLabel('iban', 'DE123')).toBe(
+      'IBAN: DE123',
+    );
+    expect(receiptReimbursementPayoutDetailLabel('paypal', null)).toBe(
+      'PayPal: not set',
+    );
+  });
+});
+
+describe('receiptReimbursementSelectedTotal', () => {
+  it('sums only selected receipt rows', () => {
+    expect(
+      receiptReimbursementSelectedTotal(
+        [
+          { id: 'receipt-1', totalAmount: 1299 },
+          { id: 'receipt-2', totalAmount: 2500 },
+          { id: 'receipt-3', totalAmount: 999 },
+        ],
+        ['receipt-1', 'receipt-3'],
+      ),
+    ).toBe(2298);
   });
 });

--- a/src/app/finance/receipt-refund-list/receipt-refund-list.component.ts
+++ b/src/app/finance/receipt-refund-list/receipt-refund-list.component.ts
@@ -22,10 +22,54 @@ import { getErrorMessage } from '../../core/error-message';
 import { NotificationService } from '../../core/notification.service';
 import { ReceiptPreviewDialogComponent } from '../shared/receipt-preview-dialog/receipt-preview-dialog.component';
 
-type PayoutType = 'iban' | 'paypal';
+export type ReceiptReimbursementPayoutType = 'iban' | 'paypal';
+
+interface ReceiptReimbursementPayoutDetails {
+  iban: null | string;
+  paypalEmail: null | string;
+}
 
 export const receiptReimbursementManualNotice =
   'Recording a reimbursement creates the Evorto finance transaction only. Transfer the money manually through the selected payout method.';
+
+export function receiptReimbursementCanRecord(
+  selectedReceiptIds: readonly string[],
+  payout: ReceiptReimbursementPayoutDetails,
+  payoutType: ReceiptReimbursementPayoutType,
+): boolean {
+  if (selectedReceiptIds.length === 0) {
+    return false;
+  }
+
+  return payoutType === 'iban'
+    ? Boolean(payout.iban)
+    : Boolean(payout.paypalEmail);
+}
+
+export function receiptReimbursementPayoutDetailLabel(
+  payoutType: ReceiptReimbursementPayoutType,
+  payoutReference: null | string,
+): string {
+  const label = payoutType === 'iban' ? 'IBAN' : 'PayPal';
+  return `${label}: ${payoutReference || 'not set'}`;
+}
+
+export function receiptReimbursementRecordDisabled(input: {
+  canRecord: boolean;
+  mutationPending: boolean;
+}): boolean {
+  return !input.canRecord || input.mutationPending;
+}
+
+export function receiptReimbursementSelectedTotal(
+  receipts: readonly { id: string; totalAmount: number }[],
+  selectedReceiptIds: readonly string[],
+): number {
+  const selectedIds = new Set(selectedReceiptIds);
+  return receipts
+    .filter((receipt) => selectedIds.has(receipt.id))
+    .reduce((sum, receipt) => sum + receipt.totalAmount, 0);
+}
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -52,6 +96,10 @@ export class ReceiptRefundListComponent {
   ];
   protected readonly receiptReimbursementManualNotice =
     receiptReimbursementManualNotice;
+  protected readonly receiptReimbursementPayoutDetailLabel =
+    receiptReimbursementPayoutDetailLabel;
+  protected readonly receiptReimbursementRecordDisabled =
+    receiptReimbursementRecordDisabled;
   private readonly rpc = AppRpc.injectClient();
   protected readonly refundableReceiptsQuery = injectQuery(() =>
     this.rpc.finance.receipts.refundableGroupedByRecipient.queryOptions(),
@@ -62,9 +110,9 @@ export class ReceiptRefundListComponent {
 
   private readonly dialog = inject(MatDialog);
   private readonly notifications = inject(NotificationService);
-  private readonly payoutTypeByRecipient = signal<Record<string, PayoutType>>(
-    {},
-  );
+  private readonly payoutTypeByRecipient = signal<
+    Record<string, ReceiptReimbursementPayoutType>
+  >({});
 
   private readonly queryClient = inject(QueryClient);
   private readonly selectionByRecipient = signal<
@@ -108,21 +156,19 @@ export class ReceiptRefundListComponent {
 
   protected canRefund(
     recipientId: string,
-    payout: { iban: null | string; paypalEmail: null | string },
+    payout: ReceiptReimbursementPayoutDetails,
   ): boolean {
-    if (this.selectedReceiptIds(recipientId).length === 0) {
-      return false;
-    }
-    const payoutType = this.getPayoutType(recipientId, payout);
-    return payoutType === 'iban'
-      ? Boolean(payout.iban)
-      : Boolean(payout.paypalEmail);
+    return receiptReimbursementCanRecord(
+      this.selectedReceiptIds(recipientId),
+      payout,
+      this.getPayoutType(recipientId, payout),
+    );
   }
 
   protected getPayoutType(
     recipientId: string,
-    payout: { iban: null | string; paypalEmail: null | string },
-  ): PayoutType {
+    payout: ReceiptReimbursementPayoutDetails,
+  ): ReceiptReimbursementPayoutType {
     return (
       this.payoutTypeByRecipient()[recipientId] ??
       (payout.iban ? 'iban' : 'paypal')
@@ -184,17 +230,33 @@ export class ReceiptRefundListComponent {
     submittedByUserId: string;
   }): Promise<void> {
     const receiptIds = this.selectedReceiptIds(group.submittedByUserId);
-    if (receiptIds.length === 0) {
-      this.notifications.showError('Select at least one receipt');
-      return;
-    }
-
     const payoutType = this.getPayoutType(
       group.submittedByUserId,
       group.payout,
     );
     const payoutReference =
       payoutType === 'iban' ? group.payout.iban : group.payout.paypalEmail;
+    if (
+      receiptReimbursementRecordDisabled({
+        canRecord: receiptReimbursementCanRecord(
+          receiptIds,
+          group.payout,
+          payoutType,
+        ),
+        mutationPending: this.refundMutation.isPending(),
+      })
+    ) {
+      if (receiptIds.length === 0) {
+        this.notifications.showError('Select at least one receipt');
+        return;
+      }
+      if (this.refundMutation.isPending()) {
+        return;
+      }
+
+      this.notifications.showError('Selected payout detail is missing');
+      return;
+    }
     if (!payoutReference) {
       this.notifications.showError('Selected payout detail is missing');
       return;
@@ -256,10 +318,10 @@ export class ReceiptRefundListComponent {
     recipientId: string,
     receipts: readonly { id: string; totalAmount: number }[],
   ): number {
-    const selectedIds = new Set(this.selectedReceiptIds(recipientId));
-    return receipts
-      .filter((receipt) => selectedIds.has(receipt.id))
-      .reduce((sum, receipt) => sum + receipt.totalAmount, 0);
+    return receiptReimbursementSelectedTotal(
+      receipts,
+      this.selectedReceiptIds(recipientId),
+    );
   }
 
   protected setPayoutType(

--- a/src/app/global-admin/global-admin.routes.spec.ts
+++ b/src/app/global-admin/global-admin.routes.spec.ts
@@ -13,10 +13,12 @@ describe('GLOBAL_ADMIN_ROUTES', () => {
     });
   });
 
-  it('keeps the tenant list and detail review routes under the guarded shell', () => {
+  it('keeps tenant list, create, detail, and edit routes under the guarded shell', () => {
     const shellRoute = GLOBAL_ADMIN_ROUTES.find((route) => route.path === '');
 
     expect(shellRoute?.children?.map((route) => route.path)).toEqual([
+      'tenants/create',
+      'tenants/:tenantId/edit',
       'tenants/:tenantId',
       'tenants',
     ]);

--- a/src/app/global-admin/global-admin.routes.ts
+++ b/src/app/global-admin/global-admin.routes.ts
@@ -8,6 +8,20 @@ export const GLOBAL_ADMIN_ROUTES: Routes = [
     children: [
       {
         loadComponent: () =>
+          import('./tenant-create/tenant-create.component').then(
+            (m) => m.TenantCreateComponent,
+          ),
+        path: 'tenants/create',
+      },
+      {
+        loadComponent: () =>
+          import('./tenant-edit/tenant-edit.component').then(
+            (m) => m.TenantEditComponent,
+          ),
+        path: 'tenants/:tenantId/edit',
+      },
+      {
+        loadComponent: () =>
           import('./tenant-detail/tenant-detail.component').then(
             (m) => m.TenantDetailComponent,
           ),

--- a/src/app/global-admin/tenant-create/tenant-create.component.html
+++ b/src/app/global-admin/tenant-create/tenant-create.component.html
@@ -1,0 +1,113 @@
+<div class="mb-4 flex flex-row items-center gap-2">
+  <a
+    routerLink="/global-admin/tenants"
+    mat-icon-button
+    aria-label="Back to tenants"
+  >
+    <fa-duotone-icon [icon]="faArrowLeft" />
+  </a>
+  <h1 class="title-large">Create tenant</h1>
+  <div class="grow"></div>
+</div>
+
+<section class="bg-surface text-on-surface rounded-2xl p-4">
+  <form class="grid grid-cols-1 gap-3" (submit)="createTenant($event)">
+    <aside
+      class="border-outline-variant bg-surface-container-low text-on-surface rounded-lg border p-4"
+    >
+      <div class="flex items-start gap-3">
+        <fa-duotone-icon class="text-primary mt-1" [icon]="faCircleInfo" />
+        <div class="grid gap-2">
+          <h2 class="title-small">Relaunch tenant scope</h2>
+          <ul class="body-medium list-disc space-y-1 pl-5">
+            @for (item of relaunchScopeItems; track item) {
+              <li>{{ item }}</li>
+            }
+          </ul>
+        </div>
+      </div>
+    </aside>
+
+    <mat-form-field>
+      <mat-label>Tenant name</mat-label>
+      <input matInput [formField]="tenantForm.name" />
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Primary domain</mat-label>
+      <input
+        matInput
+        [formField]="tenantForm.domain"
+        placeholder="section.example.org"
+      />
+      <mat-hint
+        >One primary host; custom-domain automation is deferred.</mat-hint
+      >
+    </mat-form-field>
+
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <mat-form-field>
+        <mat-label>Theme</mat-label>
+        <mat-select [formField]="tenantForm.theme">
+          <mat-option value="evorto">Default theme</mat-option>
+          <mat-option value="esn">ESN theme</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Stripe account ID</mat-label>
+        <input
+          matInput
+          [formField]="tenantForm.stripeAccountId"
+          placeholder="acct_..."
+        />
+      </mat-form-field>
+    </div>
+
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+      <mat-form-field>
+        <mat-label>Currency</mat-label>
+        <mat-select [formField]="tenantForm.currency">
+          @for (currency of currencyOptions; track currency) {
+            <mat-option [value]="currency">{{ currency }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Locale</mat-label>
+        <mat-select [formField]="tenantForm.locale">
+          @for (locale of localeOptions; track locale) {
+            <mat-option [value]="locale">{{ locale }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Timezone</mat-label>
+        <mat-select [formField]="tenantForm.timezone">
+          @for (timezone of timezoneOptions; track timezone) {
+            <mat-option [value]="timezone">{{ timezone }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <div class="mt-2 flex flex-wrap gap-2">
+      <button
+        mat-flat-button
+        type="submit"
+        [disabled]="
+          tenantSubmitDisabled({
+            formInvalid: tenantForm().invalid(),
+            formSubmitting: tenantForm().submitting(),
+            mutationPending: createTenantMutation.isPending(),
+          })
+        "
+      >
+        Create tenant
+      </button>
+      <a mat-button routerLink="/global-admin/tenants">Cancel</a>
+    </div>
+  </form>
+</section>

--- a/src/app/global-admin/tenant-create/tenant-create.component.ts
+++ b/src/app/global-admin/tenant-create/tenant-create.component.ts
@@ -1,0 +1,111 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { form, FormField, required, submit } from '@angular/forms/signals';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { Router, RouterLink } from '@angular/router';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import {
+  faArrowLeft,
+  faCircleInfo,
+} from '@fortawesome/duotone-regular-svg-icons';
+import {
+  injectMutation,
+  QueryClient,
+} from '@tanstack/angular-query-experimental';
+
+import {
+  supportedTenantCurrencies,
+  supportedTenantLocales,
+  supportedTenantTimezones,
+} from '../../../types/custom/tenant';
+import { AppRpc } from '../../core/effect-rpc-angular-client';
+import { getErrorMessage } from '../../core/error-message';
+import { NotificationService } from '../../core/notification.service';
+import {
+  createGlobalAdminTenantFormModel,
+  globalAdminTenantPayloadFromForm,
+  globalAdminTenantRelaunchScopeItems,
+  globalAdminTenantSubmitDisabled,
+} from '../tenant-form/tenant-form.model';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    FontAwesomeModule,
+    FormField,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    RouterLink,
+  ],
+  selector: 'app-tenant-create',
+  templateUrl: './tenant-create.component.html',
+})
+export class TenantCreateComponent {
+  private readonly rpc = AppRpc.injectClient();
+  protected readonly createTenantMutation = injectMutation(() =>
+    this.rpc.globalAdmin.tenants.create.mutationOptions(),
+  );
+  protected readonly currencyOptions = supportedTenantCurrencies;
+  protected readonly faArrowLeft = faArrowLeft;
+  protected readonly faCircleInfo = faCircleInfo;
+  protected readonly localeOptions = supportedTenantLocales;
+  protected readonly relaunchScopeItems = globalAdminTenantRelaunchScopeItems;
+  protected readonly tenantModel = signal(createGlobalAdminTenantFormModel());
+  protected readonly tenantForm = form(this.tenantModel, (schema) => {
+    required(schema.domain);
+    required(schema.name);
+  });
+  protected readonly tenantSubmitDisabled = globalAdminTenantSubmitDisabled;
+  protected readonly timezoneOptions = supportedTenantTimezones;
+  private readonly notifications = inject(NotificationService);
+  private readonly queryClient = inject(QueryClient);
+
+  private readonly router = inject(Router);
+
+  protected async createTenant(event: Event): Promise<void> {
+    event.preventDefault();
+    if (this.createTenantMutation.isPending()) {
+      return;
+    }
+    await submit(this.tenantForm, async (formState) => {
+      const payload = (() => {
+        try {
+          return globalAdminTenantPayloadFromForm(formState().value());
+        } catch (error) {
+          this.notifications.showError(
+            getErrorMessage(error, 'Failed to create tenant'),
+          );
+          return null;
+        }
+      })();
+
+      if (!payload) {
+        return;
+      }
+
+      this.createTenantMutation.mutate(payload, {
+        onError: (error) => {
+          this.notifications.showError(
+            getErrorMessage(error, 'Failed to create tenant'),
+          );
+        },
+        onSuccess: async (tenant) => {
+          await this.queryClient.invalidateQueries(
+            this.rpc.queryFilter(['globalAdmin', 'tenants.findMany']),
+          );
+          this.notifications.showSuccess('Tenant created');
+          await this.router.navigate(['/global-admin/tenants', tenant.id]);
+        },
+      });
+    });
+  }
+}

--- a/src/app/global-admin/tenant-detail/tenant-detail.component.html
+++ b/src/app/global-admin/tenant-detail/tenant-detail.component.html
@@ -33,6 +33,9 @@
         </p>
       </div>
       <div class="grow"></div>
+      <a mat-button [routerLink]="['/global-admin/tenants', tenant.id, 'edit']">
+        Edit tenant
+      </a>
       <a
         mat-button
         [href]="'https://' + tenant.domain"

--- a/src/app/global-admin/tenant-detail/tenant-detail.component.html
+++ b/src/app/global-admin/tenant-detail/tenant-detail.component.html
@@ -1,5 +1,9 @@
 <div class="mb-4 flex flex-row items-center gap-2">
-  <a routerLink="/global-admin/tenants" mat-icon-button>
+  <a
+    routerLink="/global-admin/tenants"
+    mat-icon-button
+    aria-label="Back to tenants"
+  >
     <fa-duotone-icon [icon]="faArrowLeft" />
   </a>
   <h1 class="title-large">

--- a/src/app/global-admin/tenant-edit/tenant-edit.component.html
+++ b/src/app/global-admin/tenant-edit/tenant-edit.component.html
@@ -1,0 +1,124 @@
+<div class="mb-4 flex flex-row items-center gap-2">
+  <a [routerLink]="['/global-admin/tenants', tenantId()]" mat-icon-button>
+    <fa-duotone-icon [icon]="faArrowLeft" />
+  </a>
+  <h1 class="title-large">Edit tenant</h1>
+  <div class="grow"></div>
+</div>
+
+@if (tenantQuery.isPending()) {
+  <div
+    class="bg-surface text-on-surface flex animate-pulse cursor-progress flex-col gap-2 rounded-2xl p-4"
+  >
+    <h2 class="title-medium">Loading tenant...</h2>
+  </div>
+} @else if (tenantQuery.isError()) {
+  <div class="bg-error text-on-error rounded-2xl p-4">
+    <h2 class="title-medium mb-4">There was an error</h2>
+    <p class="body-medium">Error: {{ errorMessage(tenantQuery.error()) }}</p>
+  </div>
+} @else if (tenantQuery.data()) {
+  <section class="bg-surface text-on-surface rounded-2xl p-4">
+    <form class="grid grid-cols-1 gap-3" (submit)="updateTenant($event)">
+      <aside
+        class="border-outline-variant bg-surface-container-low text-on-surface rounded-lg border p-4"
+      >
+        <div class="flex items-start gap-3">
+          <fa-duotone-icon class="text-primary mt-1" [icon]="faCircleInfo" />
+          <div class="grid gap-2">
+            <h2 class="title-small">Relaunch tenant scope</h2>
+            <ul class="body-medium list-disc space-y-1 pl-5">
+              @for (item of relaunchScopeItems; track item) {
+                <li>{{ item }}</li>
+              }
+            </ul>
+          </div>
+        </div>
+      </aside>
+
+      <mat-form-field>
+        <mat-label>Tenant name</mat-label>
+        <input matInput [formField]="tenantForm.name" />
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Primary domain</mat-label>
+        <input matInput [formField]="tenantForm.domain" />
+        <mat-hint
+          >One primary host; custom-domain automation is deferred.</mat-hint
+        >
+      </mat-form-field>
+
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <mat-form-field>
+          <mat-label>Theme</mat-label>
+          <mat-select [formField]="tenantForm.theme">
+            <mat-option value="evorto">Default theme</mat-option>
+            <mat-option value="esn">ESN theme</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Stripe account ID</mat-label>
+          <input matInput [formField]="tenantForm.stripeAccountId" />
+        </mat-form-field>
+      </div>
+
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <mat-form-field>
+          <mat-label>Currency</mat-label>
+          <mat-select [formField]="tenantForm.currency">
+            @for (currency of currencyOptions; track currency) {
+              <mat-option [value]="currency">{{ currency }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Locale</mat-label>
+          <mat-select [formField]="tenantForm.locale">
+            @for (locale of localeOptions; track locale) {
+              <mat-option [value]="locale">{{ locale }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Timezone</mat-label>
+          <mat-select [formField]="tenantForm.timezone">
+            @for (timezone of timezoneOptions; track timezone) {
+              <mat-option [value]="timezone">{{ timezone }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      </div>
+
+      <div class="mt-2 flex flex-wrap gap-2">
+        <button
+          mat-flat-button
+          type="submit"
+          [disabled]="
+            tenantSubmitDisabled({
+              formInvalid: tenantForm().invalid(),
+              formSubmitting: tenantForm().submitting(),
+              mutationPending: updateTenantMutation.isPending(),
+            })
+          "
+        >
+          Save tenant
+        </button>
+        <a mat-button [routerLink]="['/global-admin/tenants', tenantId()]">
+          Cancel
+        </a>
+      </div>
+    </form>
+  </section>
+} @else {
+  <section class="bg-surface text-on-surface rounded-2xl p-4">
+    <h2 class="title-medium">Tenant not found</h2>
+    <p class="body-medium text-on-surface-variant">
+      This tenant either does not exist or is no longer available for global
+      admin editing.
+    </p>
+  </section>
+}

--- a/src/app/global-admin/tenant-edit/tenant-edit.component.ts
+++ b/src/app/global-admin/tenant-edit/tenant-edit.component.ts
@@ -69,14 +69,20 @@ export class TenantEditComponent {
     }),
   );
   protected readonly tenantModel = linkedSignal<
-    GlobalAdminTenantRecord | null | undefined,
+    {
+      tenant: GlobalAdminTenantRecord | null | undefined;
+      tenantId: string;
+    },
     GlobalAdminTenantFormModel
   >({
-    computation: (tenant, previous) =>
+    computation: ({ tenant }) =>
       tenant
         ? globalAdminTenantFormModelFromRecord(tenant)
-        : (previous?.value ?? createGlobalAdminTenantFormModel()),
-    source: () => this.tenantQuery.data(),
+        : createGlobalAdminTenantFormModel(),
+    source: () => ({
+      tenant: this.tenantQuery.data(),
+      tenantId: this.tenantId(),
+    }),
   });
   protected readonly tenantForm = form(this.tenantModel, (schema) => {
     required(schema.domain);

--- a/src/app/global-admin/tenant-edit/tenant-edit.component.ts
+++ b/src/app/global-admin/tenant-edit/tenant-edit.component.ts
@@ -1,0 +1,148 @@
+import type { GlobalAdminTenantRecord } from '@shared/rpc-contracts/app-rpcs/global-admin.rpcs';
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  linkedSignal,
+} from '@angular/core';
+import { form, FormField, required, submit } from '@angular/forms/signals';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { Router, RouterLink } from '@angular/router';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import {
+  faArrowLeft,
+  faCircleInfo,
+} from '@fortawesome/duotone-regular-svg-icons';
+import {
+  injectMutation,
+  injectQuery,
+  QueryClient,
+} from '@tanstack/angular-query-experimental';
+
+import {
+  supportedTenantCurrencies,
+  supportedTenantLocales,
+  supportedTenantTimezones,
+} from '../../../types/custom/tenant';
+import { AppRpc } from '../../core/effect-rpc-angular-client';
+import { getErrorMessage } from '../../core/error-message';
+import { NotificationService } from '../../core/notification.service';
+import {
+  createGlobalAdminTenantFormModel,
+  type GlobalAdminTenantFormModel,
+  globalAdminTenantFormModelFromRecord,
+  globalAdminTenantPayloadFromForm,
+  globalAdminTenantRelaunchScopeItems,
+  globalAdminTenantSubmitDisabled,
+} from '../tenant-form/tenant-form.model';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    FontAwesomeModule,
+    FormField,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    RouterLink,
+  ],
+  selector: 'app-tenant-edit',
+  templateUrl: './tenant-edit.component.html',
+})
+export class TenantEditComponent {
+  readonly tenantId = input.required<string>();
+  protected readonly currencyOptions = supportedTenantCurrencies;
+  protected readonly faArrowLeft = faArrowLeft;
+  protected readonly faCircleInfo = faCircleInfo;
+  protected readonly localeOptions = supportedTenantLocales;
+  protected readonly relaunchScopeItems = globalAdminTenantRelaunchScopeItems;
+  private readonly rpc = AppRpc.injectClient();
+  protected readonly tenantQuery = injectQuery(() =>
+    this.rpc.globalAdmin.tenants.findOne.queryOptions({
+      id: this.tenantId(),
+    }),
+  );
+  protected readonly tenantModel = linkedSignal<
+    GlobalAdminTenantRecord | null | undefined,
+    GlobalAdminTenantFormModel
+  >({
+    computation: (tenant, previous) =>
+      tenant
+        ? globalAdminTenantFormModelFromRecord(tenant)
+        : (previous?.value ?? createGlobalAdminTenantFormModel()),
+    source: () => this.tenantQuery.data(),
+  });
+  protected readonly tenantForm = form(this.tenantModel, (schema) => {
+    required(schema.domain);
+    required(schema.name);
+  });
+  protected readonly tenantSubmitDisabled = globalAdminTenantSubmitDisabled;
+  protected readonly timezoneOptions = supportedTenantTimezones;
+
+  protected readonly updateTenantMutation = injectMutation(() =>
+    this.rpc.globalAdmin.tenants.update.mutationOptions(),
+  );
+  private readonly notifications = inject(NotificationService);
+  private readonly queryClient = inject(QueryClient);
+  private readonly router = inject(Router);
+
+  protected errorMessage(error: unknown): string {
+    return getErrorMessage(error, 'Failed to load tenant');
+  }
+
+  protected async updateTenant(event: Event): Promise<void> {
+    event.preventDefault();
+    if (this.updateTenantMutation.isPending()) {
+      return;
+    }
+    await submit(this.tenantForm, async (formState) => {
+      const payload = (() => {
+        try {
+          return globalAdminTenantPayloadFromForm(formState().value());
+        } catch (error) {
+          this.notifications.showError(
+            getErrorMessage(error, 'Failed to update tenant'),
+          );
+          return null;
+        }
+      })();
+
+      if (!payload) {
+        return;
+      }
+
+      this.updateTenantMutation.mutate(
+        {
+          ...payload,
+          id: this.tenantId(),
+        },
+        {
+          onError: (error) => {
+            this.notifications.showError(
+              getErrorMessage(error, 'Failed to update tenant'),
+            );
+          },
+          onSuccess: async () => {
+            await this.queryClient.invalidateQueries(
+              this.rpc.queryFilter(['globalAdmin', 'tenants.findMany']),
+            );
+            await this.queryClient.invalidateQueries(
+              this.rpc.queryFilter(['globalAdmin', 'tenants.findOne']),
+            );
+            this.notifications.showSuccess('Tenant updated');
+            await this.router.navigate([
+              '/global-admin/tenants',
+              this.tenantId(),
+            ]);
+          },
+        },
+      );
+    });
+  }
+}

--- a/src/app/global-admin/tenant-form/tenant-form.model.spec.ts
+++ b/src/app/global-admin/tenant-form/tenant-form.model.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createGlobalAdminTenantFormModel,
+  globalAdminTenantFormModelFromRecord,
+  globalAdminTenantPayloadFromForm,
+  globalAdminTenantRelaunchScopeItems,
+  globalAdminTenantSubmitDisabled,
+  normalizeGlobalAdminTenantDomain,
+} from './tenant-form.model';
+
+describe('global admin tenant form model', () => {
+  it('starts new tenants with relaunch defaults', () => {
+    expect(createGlobalAdminTenantFormModel()).toEqual({
+      currency: 'EUR',
+      domain: '',
+      locale: 'en-GB',
+      name: '',
+      stripeAccountId: '',
+      theme: 'evorto',
+      timezone: 'Europe/Berlin',
+    });
+  });
+
+  it('keeps the visible relaunch scope aligned with the one-domain tenant workflow', () => {
+    expect(globalAdminTenantRelaunchScopeItems).toEqual([
+      'One active primary domain is managed here.',
+      'Custom-domain verification and multi-domain automation are deferred.',
+      'Tenant-admin impersonation is not available from this form.',
+    ]);
+  });
+
+  it('maps tenant records into editable form state without exposing derived values', () => {
+    expect(
+      globalAdminTenantFormModelFromRecord({
+        currency: 'AUD',
+        domain: 'tenant.example.com',
+        id: 'tenant-1',
+        locale: 'en-AU',
+        name: 'Tenant',
+        stripeAccountId: 'acct_123',
+        stripeConnected: true,
+        theme: 'esn',
+        timezone: 'Australia/Brisbane',
+      }),
+    ).toEqual({
+      currency: 'AUD',
+      domain: 'tenant.example.com',
+      locale: 'en-AU',
+      name: 'Tenant',
+      stripeAccountId: 'acct_123',
+      theme: 'esn',
+      timezone: 'Australia/Brisbane',
+    });
+  });
+
+  it('trims tenant create/edit payloads and clears blank Stripe account IDs', () => {
+    expect(
+      globalAdminTenantPayloadFromForm({
+        currency: 'CZK',
+        domain: ' section.example.org ',
+        locale: 'en-GB',
+        name: ' Section ',
+        stripeAccountId: ' ',
+        theme: 'evorto',
+        timezone: 'Europe/Prague',
+      }),
+    ).toEqual({
+      currency: 'CZK',
+      domain: 'section.example.org',
+      locale: 'en-GB',
+      name: 'Section',
+      stripeAccountId: undefined,
+      theme: 'evorto',
+      timezone: 'Europe/Prague',
+    });
+  });
+
+  it('normalizes the one-primary-domain relaunch input shape', () => {
+    expect(
+      normalizeGlobalAdminTenantDomain(' https://Section.Example.Org:443 '),
+    ).toBe('section.example.org');
+    expect(normalizeGlobalAdminTenantDomain(' LOCALHOST:4200 ')).toBe(
+      'localhost',
+    );
+  });
+
+  it('rejects domain paths before submitting tenant create/edit payloads', () => {
+    expect(() =>
+      globalAdminTenantPayloadFromForm({
+        currency: 'EUR',
+        domain: 'section.example.org/path',
+        locale: 'en-GB',
+        name: 'Section',
+        stripeAccountId: '',
+        theme: 'evorto',
+        timezone: 'Europe/Berlin',
+      }),
+    ).toThrow('Domain must be a single host name');
+  });
+
+  it('keeps tenant writes disabled while invalid, submitting, or awaiting the mutation', () => {
+    expect(
+      globalAdminTenantSubmitDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      globalAdminTenantSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      globalAdminTenantSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      globalAdminTenantSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/global-admin/tenant-form/tenant-form.model.ts
+++ b/src/app/global-admin/tenant-form/tenant-form.model.ts
@@ -33,13 +33,13 @@ export const createGlobalAdminTenantFormModel =
 export const globalAdminTenantFormModelFromRecord = (
   tenant: GlobalAdminTenantRecord,
 ): GlobalAdminTenantFormModel => ({
-  currency: tenant.currency as GlobalAdminTenantFormModel['currency'],
+  currency: tenant.currency,
   domain: tenant.domain,
-  locale: tenant.locale as GlobalAdminTenantFormModel['locale'],
+  locale: tenant.locale,
   name: tenant.name,
   stripeAccountId: tenant.stripeAccountId ?? '',
-  theme: tenant.theme as GlobalAdminTenantFormModel['theme'],
-  timezone: tenant.timezone as GlobalAdminTenantFormModel['timezone'],
+  theme: tenant.theme,
+  timezone: tenant.timezone,
 });
 
 const optionalTrimmed = (value: string): string | undefined =>

--- a/src/app/global-admin/tenant-form/tenant-form.model.ts
+++ b/src/app/global-admin/tenant-form/tenant-form.model.ts
@@ -1,0 +1,91 @@
+import type {
+  GlobalAdminTenantRecord,
+  GlobalAdminTenantWriteInput,
+} from '@shared/rpc-contracts/app-rpcs/global-admin.rpcs';
+
+export interface GlobalAdminTenantFormModel {
+  currency: GlobalAdminTenantWriteInput['currency'];
+  domain: string;
+  locale: GlobalAdminTenantWriteInput['locale'];
+  name: string;
+  stripeAccountId: string;
+  theme: GlobalAdminTenantWriteInput['theme'];
+  timezone: GlobalAdminTenantWriteInput['timezone'];
+}
+
+export const globalAdminTenantRelaunchScopeItems = [
+  'One active primary domain is managed here.',
+  'Custom-domain verification and multi-domain automation are deferred.',
+  'Tenant-admin impersonation is not available from this form.',
+] as const;
+
+export const createGlobalAdminTenantFormModel =
+  (): GlobalAdminTenantFormModel => ({
+    currency: 'EUR',
+    domain: '',
+    locale: 'en-GB',
+    name: '',
+    stripeAccountId: '',
+    theme: 'evorto',
+    timezone: 'Europe/Berlin',
+  });
+
+export const globalAdminTenantFormModelFromRecord = (
+  tenant: GlobalAdminTenantRecord,
+): GlobalAdminTenantFormModel => ({
+  currency: tenant.currency as GlobalAdminTenantFormModel['currency'],
+  domain: tenant.domain,
+  locale: tenant.locale as GlobalAdminTenantFormModel['locale'],
+  name: tenant.name,
+  stripeAccountId: tenant.stripeAccountId ?? '',
+  theme: tenant.theme as GlobalAdminTenantFormModel['theme'],
+  timezone: tenant.timezone as GlobalAdminTenantFormModel['timezone'],
+});
+
+const optionalTrimmed = (value: string): string | undefined =>
+  value.trim() || undefined;
+
+export const normalizeGlobalAdminTenantDomain = (value: string): string => {
+  const trimmedValue = value.trim().toLowerCase();
+  if (!trimmedValue) {
+    throw new Error('Domain is required');
+  }
+
+  const url = new URL(
+    trimmedValue.includes('://') ? trimmedValue : `https://${trimmedValue}`,
+  );
+  if (
+    !url.hostname ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error('Domain must be a single host name');
+  }
+
+  return url.hostname;
+};
+
+export const globalAdminTenantPayloadFromForm = (
+  model: GlobalAdminTenantFormModel,
+): GlobalAdminTenantWriteInput => ({
+  currency: model.currency,
+  domain: normalizeGlobalAdminTenantDomain(model.domain),
+  locale: model.locale,
+  name: model.name.trim(),
+  stripeAccountId: optionalTrimmed(model.stripeAccountId),
+  theme: model.theme,
+  timezone: model.timezone,
+});
+
+export const globalAdminTenantSubmitDisabled = ({
+  formInvalid,
+  formSubmitting,
+  mutationPending,
+}: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean => formInvalid || formSubmitting || mutationPending;

--- a/src/app/global-admin/tenant-list/tenant-list.component.html
+++ b/src/app/global-admin/tenant-list/tenant-list.component.html
@@ -1,6 +1,15 @@
 <div class="mb-4 flex flex-row items-center gap-2">
   <h1 class="title-large">Tenants</h1>
   <div class="grow"></div>
+  <a
+    mat-fab
+    extended
+    class="fab-fixed"
+    routerLink="/global-admin/tenants/create"
+  >
+    <fa-duotone-icon [icon]="faPlus" />
+    <span>Create tenant</span>
+  </a>
 </div>
 @if (tenantQuery.isPending()) {
   <div

--- a/src/app/global-admin/tenant-list/tenant-list.component.ts
+++ b/src/app/global-admin/tenant-list/tenant-list.component.ts
@@ -9,7 +9,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faArrowRight } from '@fortawesome/duotone-regular-svg-icons';
+import { faArrowRight, faPlus } from '@fortawesome/duotone-regular-svg-icons';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import { AppRpc } from '../../core/effect-rpc-angular-client';
@@ -34,6 +34,7 @@ import {
 })
 export class TenantListComponent {
   protected readonly faArrowRight = faArrowRight;
+  protected readonly faPlus = faPlus;
   private rpc = AppRpc.injectClient();
   protected tenantQuery = injectQuery(() =>
     this.rpc.globalAdmin.tenants.findMany.queryOptions(),

--- a/src/app/global-admin/tenant-list/tenant-list.rows.spec.ts
+++ b/src/app/global-admin/tenant-list/tenant-list.rows.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   filterGlobalAdminTenants,
+  globalAdminStripeAccountLabel,
   globalAdminTenantListErrorMessage,
   globalAdminTenantRows,
 } from './tenant-list.rows';
@@ -14,6 +15,7 @@ const tenant = {
   id: 'tenant-1',
   locale: 'en-GB',
   name: 'Tenant',
+  stripeAccountId: 'acct_123',
   stripeConnected: true,
   theme: 'esn',
   timezone: 'Europe/Berlin',
@@ -28,7 +30,7 @@ describe('globalAdminTenantRows', () => {
       { label: 'Locale', value: 'en-GB' },
       { label: 'Currency', value: 'EUR' },
       { label: 'Timezone', value: 'Europe/Berlin' },
-      { label: 'Stripe account', value: 'Connected' },
+      { label: 'Stripe account', value: 'Connected (acct_123)' },
     ]);
   });
 
@@ -63,6 +65,32 @@ describe('globalAdminTenantRows', () => {
   });
 });
 
+describe('globalAdminStripeAccountLabel', () => {
+  it('includes the connected account id when available for support lookup', () => {
+    expect(
+      globalAdminStripeAccountLabel({
+        stripeAccountId: 'acct_123',
+        stripeConnected: true,
+      }),
+    ).toBe('Connected (acct_123)');
+  });
+
+  it('keeps connection state readable when the id is absent', () => {
+    expect(
+      globalAdminStripeAccountLabel({
+        stripeAccountId: null,
+        stripeConnected: true,
+      }),
+    ).toBe('Connected');
+    expect(
+      globalAdminStripeAccountLabel({
+        stripeAccountId: 'acct_123',
+        stripeConnected: false,
+      }),
+    ).toBe('Not connected');
+  });
+});
+
 describe('filterGlobalAdminTenants', () => {
   it('returns all tenants for blank searches', () => {
     expect(filterGlobalAdminTenants([tenant], '   ')).toEqual([tenant]);
@@ -76,6 +104,7 @@ describe('filterGlobalAdminTenants', () => {
       id: 'tenant-2',
       locale: 'en-US',
       name: 'North',
+      stripeAccountId: null,
       stripeConnected: false,
       theme: 'evorto',
       timezone: 'Australia/Brisbane',
@@ -90,6 +119,9 @@ describe('filterGlobalAdminTenants', () => {
     expect(
       filterGlobalAdminTenants([tenant, secondTenant], 'not connected'),
     ).toEqual([secondTenant]);
+    expect(
+      filterGlobalAdminTenants([tenant, secondTenant], 'acct_123'),
+    ).toEqual([tenant]);
   });
 });
 

--- a/src/app/global-admin/tenant-list/tenant-list.rows.ts
+++ b/src/app/global-admin/tenant-list/tenant-list.rows.ts
@@ -11,10 +11,23 @@ const searchableTenantFields = (tenant: GlobalAdminTenantRecord): string[] => [
   tenant.id,
   tenant.locale,
   tenant.name,
+  tenant.stripeAccountId ?? '',
   tenant.theme,
   tenant.timezone,
   tenant.stripeConnected ? 'connected' : 'not connected',
 ];
+
+export const globalAdminStripeAccountLabel = (
+  tenant: Pick<GlobalAdminTenantRecord, 'stripeAccountId' | 'stripeConnected'>,
+): string => {
+  if (!tenant.stripeConnected) {
+    return 'Not connected';
+  }
+
+  return tenant.stripeAccountId
+    ? `Connected (${tenant.stripeAccountId})`
+    : 'Connected';
+};
 
 export const filterGlobalAdminTenants = (
   tenants: readonly GlobalAdminTenantRecord[],
@@ -41,6 +54,6 @@ export const globalAdminTenantRows = (tenant: GlobalAdminTenantRecord) => [
   { label: 'Timezone', value: tenant.timezone },
   {
     label: 'Stripe account',
-    value: tenant.stripeConnected ? 'Connected' : 'Not connected',
+    value: globalAdminStripeAccountLabel(tenant),
   },
 ];

--- a/src/app/profile/user-profile/user-profile.component.html
+++ b/src/app/profile/user-profile/user-profile.component.html
@@ -15,7 +15,11 @@
           <button
             mat-stroked-button
             (click)="openEditProfileDialog()"
-            [disabled]="updateProfileMutation.isPending()"
+            [disabled]="
+              profileEditActionDisabled({
+                mutationPending: updateProfileMutation.isPending(),
+              })
+            "
             id="edit-profile-btn"
           >
             <fa-duotone-icon [icon]="faPencil" class="mr-2" />
@@ -153,11 +157,12 @@
                     </p>
                     <div class="mt-2 flex flex-wrap gap-2">
                       @if (
-                        event.paymentState === "pending" && event.checkoutUrl
+                        profileEventContinuePaymentUrl(event);
+                        as continuePaymentUrl
                       ) {
                         <a
                           mat-flat-button
-                          [href]="event.checkoutUrl"
+                          [href]="continuePaymentUrl"
                           rel="noopener noreferrer"
                         >
                           Continue payment
@@ -207,7 +212,7 @@
                           }}</span>
                         </div>
                         <div class="text-sm">
-                          Status: {{ card.status }}
+                          Status: {{ esnCardStatusLabel(card.status) }}
                           @if (card.validTo) {
                             — valid until
                             {{ card.validTo | date: "mediumDate" }}
@@ -217,26 +222,40 @@
                           <button
                             mat-stroked-button
                             (click)="refreshEsnCard()"
-                            [disabled]="refreshCardMutation.isPending()"
+                            [disabled]="
+                              esnCardActionDisabled({
+                                deletePending: deleteCardMutation.isPending(),
+                                refreshPending: refreshCardMutation.isPending(),
+                                upsertPending: upsertCardMutation.isPending(),
+                              })
+                            "
                           >
-                            @if (refreshCardMutation.isPending()) {
-                              Refreshing...
-                            } @else {
-                              Refresh
-                            }
+                            {{
+                              esnCardActionLabel(
+                                "refresh",
+                                refreshCardMutation.isPending()
+                              )
+                            }}
                           </button>
                           <button
                             type="button"
                             mat-stroked-button
                             color="warn"
                             (click)="deleteEsnCard()"
-                            [disabled]="deleteCardMutation.isPending()"
+                            [disabled]="
+                              esnCardActionDisabled({
+                                deletePending: deleteCardMutation.isPending(),
+                                refreshPending: refreshCardMutation.isPending(),
+                                upsertPending: upsertCardMutation.isPending(),
+                              })
+                            "
                           >
-                            @if (deleteCardMutation.isPending()) {
-                              Removing...
-                            } @else {
-                              Remove
-                            }
+                            {{
+                              esnCardActionLabel(
+                                "remove",
+                                deleteCardMutation.isPending()
+                              )
+                            }}
                           </button>
                         </div>
                       </div>
@@ -277,16 +296,20 @@
                     color="primary"
                     type="submit"
                     [disabled]="
-                      esnCardForm().invalid() ||
-                      esnCardForm().submitting() ||
-                      upsertCardMutation.isPending()
+                      esnCardSaveDisabled({
+                        formInvalid: esnCardForm().invalid(),
+                        formSubmitting: esnCardForm().submitting(),
+                        mutationPending: esnCardActionDisabled({
+                          deletePending: deleteCardMutation.isPending(),
+                          refreshPending: refreshCardMutation.isPending(),
+                          upsertPending: upsertCardMutation.isPending(),
+                        }),
+                      })
                     "
                   >
-                    @if (upsertCardMutation.isPending()) {
-                      Checking ESN card...
-                    } @else {
-                      Save ESN card
-                    }
+                    {{
+                      esnCardActionLabel("save", upsertCardMutation.isPending())
+                    }}
                   </button>
                   @if (
                     !hasVerifiedEsnCard() && buyEsnCardUrl();
@@ -353,7 +376,7 @@
                     {{ receipt.receiptDate | date: "mediumDate" }}
                   </p>
                   <p class="text-sm">
-                    {{ receipt.totalAmount / 100 | number: "1.2-2" }} €
+                    {{ profileReceiptAmountLabel(receipt.totalAmount) }}
                   </p>
                 </article>
               }

--- a/src/app/profile/user-profile/user-profile.component.html
+++ b/src/app/profile/user-profile/user-profile.component.html
@@ -13,6 +13,7 @@
             {{ user.communicationEmail ?? user.email }}
           </p>
           <button
+            type="button"
             mat-stroked-button
             (click)="openEditProfileDialog()"
             [disabled]="

--- a/src/app/profile/user-profile/user-profile.component.spec.ts
+++ b/src/app/profile/user-profile/user-profile.component.spec.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  esnCardActionDisabled,
+  esnCardActionLabel,
   esnCardMutationErrorMessage,
+  esnCardSaveDisabled,
+  esnCardStatusLabel,
   esnCardSubmitPayloadFromIdentifier,
+  profileEditActionDisabled,
   profileEventActionNote,
+  profileEventContinuePaymentUrl,
   profileEventDetailActionLabel,
   profileEventGuestLabel,
   profileEventNextStepLabel,
+  profileReceiptAmountLabel,
   profileReceiptStatusLabel,
   profileSectionFromFragment,
   registrationPaymentLabel,
@@ -18,45 +25,62 @@ describe('profile event labels', () => {
     expect(profileEventDetailActionLabel()).toBe('Open event page');
   });
 
-  it('keeps deferred profile event actions explicit', () => {
+  it('keeps profile event actions focused on implemented paths', () => {
     expect(
       profileEventActionNote({
+        checkInTime: null,
         checkoutUrl: null,
         paymentState: 'recorded',
         status: 'CONFIRMED',
       }),
     ).toBe(
-      'Open the event page for ticket access and participant cancellation when the event still allows it. Automatic refunds and transfer/resale are not implemented yet.',
+      'Open the event page for ticket access, participant cancellation, and unpaid self-service transfer when available.',
     );
     expect(
       profileEventActionNote({
+        checkInTime: null,
         checkoutUrl: null,
         paymentState: 'notRequired',
         status: 'PENDING',
       }),
     ).toBe(
-      'Open the event page for pending-registration details and available cancellation actions. Transfer/resale is not implemented yet.',
+      'Open the event page for pending-registration details and available cancellation actions.',
     );
     expect(
       profileEventActionNote({
+        checkInTime: null,
         checkoutUrl: null,
         paymentState: 'notRequired',
         status: 'WAITLIST',
       }),
     ).toBe(
-      'Open the event page for waitlist details and the leave-waitlist action. Transfer/resale is not available for waitlist registrations.',
+      'Open the event page for waitlist details and the leave-waitlist action.',
+    );
+  });
+
+  it('does not advertise cancellation or transfer after check-in', () => {
+    expect(
+      profileEventActionNote({
+        checkInTime: '2026-02-01T10:30:00.000Z',
+        checkoutUrl: null,
+        paymentState: 'recorded',
+        status: 'CONFIRMED',
+      }),
+    ).toBe(
+      'You are checked in. Open the event page for ticket details. Cancellation and transfer are no longer available after check-in.',
     );
   });
 
   it('points pending checkout registrations at the implemented profile action', () => {
     expect(
       profileEventActionNote({
+        checkInTime: null,
         checkoutUrl: 'https://checkout.stripe.test/pay',
         paymentState: 'pending',
         status: 'PENDING',
       }),
     ).toBe(
-      'Continue payment from this card, or open the event page for registration details. Cancellation after confirmation is handled on the event page.',
+      'Continue payment from this card, or open the event page for registration details.',
     );
   });
 
@@ -75,6 +99,27 @@ describe('profile event labels', () => {
     ).toBeNull();
     expect(
       profileEventNextStepLabel({
+        checkoutUrl: 'https://checkout.stripe.test/pay',
+        paymentState: 'recorded',
+      }),
+    ).toBeNull();
+  });
+
+  it('renders the payment continuation action only for pending checkout registrations', () => {
+    expect(
+      profileEventContinuePaymentUrl({
+        checkoutUrl: 'https://checkout.stripe.test/pay',
+        paymentState: 'pending',
+      }),
+    ).toBe('https://checkout.stripe.test/pay');
+    expect(
+      profileEventContinuePaymentUrl({
+        checkoutUrl: null,
+        paymentState: 'pending',
+      }),
+    ).toBeNull();
+    expect(
+      profileEventContinuePaymentUrl({
         checkoutUrl: 'https://checkout.stripe.test/pay',
         paymentState: 'recorded',
       }),
@@ -102,6 +147,84 @@ describe('profile event labels', () => {
 });
 
 describe('profile ESN card messages', () => {
+  it('keeps ESN card action labels aligned with pending states', () => {
+    expect(esnCardActionLabel('refresh', false)).toBe('Refresh');
+    expect(esnCardActionLabel('refresh', true)).toBe('Refreshing...');
+    expect(esnCardActionLabel('remove', false)).toBe('Remove');
+    expect(esnCardActionLabel('remove', true)).toBe('Removing...');
+    expect(esnCardActionLabel('save', false)).toBe('Save ESN card');
+    expect(esnCardActionLabel('save', true)).toBe('Checking ESN card...');
+  });
+
+  it('keeps ESN card save disabled while invalid, submitting, or validating', () => {
+    expect(
+      esnCardSaveDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      esnCardSaveDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      esnCardSaveDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      esnCardSaveDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks ESN card actions while any card write is pending', () => {
+    expect(
+      esnCardActionDisabled({
+        deletePending: true,
+        refreshPending: false,
+        upsertPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      esnCardActionDisabled({
+        deletePending: false,
+        refreshPending: true,
+        upsertPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      esnCardActionDisabled({
+        deletePending: false,
+        refreshPending: false,
+        upsertPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      esnCardActionDisabled({
+        deletePending: false,
+        refreshPending: false,
+        upsertPending: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps persisted ESN card statuses readable in profile cards', () => {
+    expect(esnCardStatusLabel('expired')).toBe('Expired');
+    expect(esnCardStatusLabel('invalid')).toBe('Invalid');
+    expect(esnCardStatusLabel('unverified')).toBe('Needs verification');
+    expect(esnCardStatusLabel('verified')).toBe('Verified');
+  });
+
   it('trims the ESN card identifier before submitting the upsert mutation', () => {
     expect(esnCardSubmitPayloadFromIdentifier('  ABCD1234  ')).toEqual({
       identifier: 'ABCD1234',
@@ -135,12 +258,33 @@ describe('profile ESN card messages', () => {
   });
 });
 
+describe('profile edit actions', () => {
+  it('blocks profile edit while an update is pending', () => {
+    expect(
+      profileEditActionDisabled({
+        mutationPending: false,
+      }),
+    ).toBe(false);
+    expect(
+      profileEditActionDisabled({
+        mutationPending: true,
+      }),
+    ).toBe(true);
+  });
+});
+
 describe('profile receipt labels', () => {
   it('keeps submitted receipt statuses readable on profile cards', () => {
     expect(profileReceiptStatusLabel('approved')).toBe('Approved');
     expect(profileReceiptStatusLabel('refunded')).toBe('Reimbursed');
     expect(profileReceiptStatusLabel('rejected')).toBe('Rejected');
     expect(profileReceiptStatusLabel('submitted')).toBe('Submitted');
+  });
+
+  it('formats submitted receipt card amounts from cents', () => {
+    expect(profileReceiptAmountLabel(0)).toBe('0.00 €');
+    expect(profileReceiptAmountLabel(100)).toBe('1.00 €');
+    expect(profileReceiptAmountLabel(12_345)).toBe('123.45 €');
   });
 });
 

--- a/src/app/profile/user-profile/user-profile.component.ts
+++ b/src/app/profile/user-profile/user-profile.component.ts
@@ -1,6 +1,7 @@
+import type { DiscountCardRecord } from '@shared/rpc-contracts/app-rpcs/discounts.rpcs';
 import type { FinanceReceiptStatus } from '@shared/rpc-contracts/app-rpcs/finance.rpcs';
 
-import { DatePipe, DecimalPipe } from '@angular/common';
+import { DatePipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -83,6 +84,68 @@ export const profileUserAfterEdit = <
   paypalEmail: result.paypalEmail ?? null,
 });
 
+export const esnCardActionLabel = (
+  action: EsnCardMutationAction,
+  pending: boolean,
+): string => {
+  switch (action) {
+    case 'refresh': {
+      return pending ? 'Refreshing...' : 'Refresh';
+    }
+    case 'remove': {
+      return pending ? 'Removing...' : 'Remove';
+    }
+    case 'save': {
+      return pending ? 'Checking ESN card...' : 'Save ESN card';
+    }
+  }
+};
+
+export const esnCardSaveDisabled = ({
+  formInvalid,
+  formSubmitting,
+  mutationPending,
+}: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean => formInvalid || formSubmitting || mutationPending;
+
+export const esnCardActionDisabled = ({
+  deletePending,
+  refreshPending,
+  upsertPending,
+}: {
+  deletePending: boolean;
+  refreshPending: boolean;
+  upsertPending: boolean;
+}): boolean => deletePending || refreshPending || upsertPending;
+
+export const esnCardStatusLabel = (
+  status: DiscountCardRecord['status'],
+): string => {
+  switch (status) {
+    case 'expired': {
+      return 'Expired';
+    }
+    case 'invalid': {
+      return 'Invalid';
+    }
+    case 'unverified': {
+      return 'Needs verification';
+    }
+    case 'verified': {
+      return 'Verified';
+    }
+  }
+};
+
+export const profileEditActionDisabled = ({
+  mutationPending,
+}: {
+  mutationPending: boolean;
+}): boolean => mutationPending;
+
 export const profileEventDetailActionLabel = (): string => 'Open event page';
 
 export const profileEventGuestLabel = (guestCount: number): null | string => {
@@ -106,24 +169,40 @@ export const profileEventNextStepLabel = (event: {
   return null;
 };
 
+export const profileEventContinuePaymentUrl = (event: {
+  checkoutUrl: null | string;
+  paymentState: 'cancelled' | 'notRequired' | 'pending' | 'recorded';
+}): null | string => {
+  if (event.paymentState !== 'pending') {
+    return null;
+  }
+
+  return event.checkoutUrl;
+};
+
 export const profileEventActionNote = (event: {
+  checkInTime?: null | string;
   checkoutUrl: null | string;
   paymentState: 'cancelled' | 'notRequired' | 'pending' | 'recorded';
   status: 'CONFIRMED' | 'PENDING' | 'WAITLIST';
 }): string => {
   if (event.paymentState === 'pending' && event.checkoutUrl) {
-    return 'Continue payment from this card, or open the event page for registration details. Cancellation after confirmation is handled on the event page.';
+    return 'Continue payment from this card, or open the event page for registration details.';
   }
 
   switch (event.status) {
     case 'CONFIRMED': {
-      return 'Open the event page for ticket access and participant cancellation when the event still allows it. Automatic refunds and transfer/resale are not implemented yet.';
+      if (event.checkInTime) {
+        return 'You are checked in. Open the event page for ticket details. Cancellation and transfer are no longer available after check-in.';
+      }
+
+      return 'Open the event page for ticket access, participant cancellation, and unpaid self-service transfer when available.';
     }
     case 'PENDING': {
-      return 'Open the event page for pending-registration details and available cancellation actions. Transfer/resale is not implemented yet.';
+      return 'Open the event page for pending-registration details and available cancellation actions.';
     }
     case 'WAITLIST': {
-      return 'Open the event page for waitlist details and the leave-waitlist action. Transfer/resale is not available for waitlist registrations.';
+      return 'Open the event page for waitlist details and the leave-waitlist action.';
     }
   }
 };
@@ -182,6 +261,9 @@ export const profileReceiptStatusLabel = (
   }
 };
 
+export const profileReceiptAmountLabel = (totalAmount: number): string =>
+  `${(totalAmount / 100).toFixed(2)} €`;
+
 export const profileSectionFromFragment = (
   fragment: null | string,
   esnEnabled: boolean,
@@ -212,7 +294,6 @@ export const esnCardSubmitPayloadFromIdentifier = (
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DatePipe,
-    DecimalPipe,
     FontAwesomeModule,
     FormField,
     MatButtonModule,
@@ -253,12 +334,16 @@ export class UserProfileComponent {
   protected readonly deleteCardMutation = injectMutation(() =>
     this.rpc.discounts.deleteMyCard.mutationOptions(),
   );
+  protected readonly esnCardActionDisabled = esnCardActionDisabled;
+  protected readonly esnCardActionLabel = esnCardActionLabel;
   protected readonly esnCardErrorMessage = signal<null | string>(null);
   private readonly esnCardModel = signal({ identifier: '' });
   protected readonly esnCardForm = form(this.esnCardModel, (schemaPath) => {
     required(schemaPath.identifier);
     pattern(schemaPath.identifier, /^[A-Za-z0-9]{8,16}$/);
   });
+  protected readonly esnCardSaveDisabled = esnCardSaveDisabled;
+  protected readonly esnCardStatusLabel = esnCardStatusLabel;
   protected readonly esnEnabled = computed(() => {
     const providers = this.discountProvidersQuery.data();
     if (!providers) return false;
@@ -285,11 +370,15 @@ export class UserProfileComponent {
     this.rpc.finance.receipts.my.queryOptions(),
   );
 
+  protected readonly profileEditActionDisabled = profileEditActionDisabled;
   protected readonly profileEventActionNote = profileEventActionNote;
+  protected readonly profileEventContinuePaymentUrl =
+    profileEventContinuePaymentUrl;
   protected readonly profileEventDetailActionLabel =
     profileEventDetailActionLabel;
   protected readonly profileEventGuestLabel = profileEventGuestLabel;
   protected readonly profileEventNextStepLabel = profileEventNextStepLabel;
+  protected readonly profileReceiptAmountLabel = profileReceiptAmountLabel;
   protected readonly profileReceiptStatusLabel = profileReceiptStatusLabel;
   protected readonly userQuery = injectQuery(() =>
     this.rpc.users.self.queryOptions(),
@@ -347,6 +436,10 @@ export class UserProfileComponent {
   }
 
   protected deleteEsnCard(): void {
+    if (this.esnCardMutationPending()) {
+      return;
+    }
+
     this.esnCardErrorMessage.set(null);
     this.deleteCardMutation.mutate(
       { type: 'esnCard' },
@@ -367,6 +460,14 @@ export class UserProfileComponent {
     );
   }
   protected async openEditProfileDialog(): Promise<void> {
+    if (
+      profileEditActionDisabled({
+        mutationPending: this.updateProfileMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     const user = this.profileUser();
     if (!user) return;
     const dialogReference = this.dialog.open<
@@ -414,6 +515,10 @@ export class UserProfileComponent {
     });
   }
   protected refreshEsnCard(): void {
+    if (this.esnCardMutationPending()) {
+      return;
+    }
+
     this.esnCardErrorMessage.set(null);
     this.refreshCardMutation.mutate(
       { type: 'esnCard' },
@@ -436,6 +541,10 @@ export class UserProfileComponent {
 
   protected async saveEsnCard(event: Event): Promise<void> {
     event.preventDefault();
+    if (this.esnCardMutationPending()) {
+      return;
+    }
+
     this.esnCardErrorMessage.set(null);
     await submit(this.esnCardForm, async (formState) => {
       this.upsertCardMutation.mutate(
@@ -468,5 +577,13 @@ export class UserProfileComponent {
 
   protected setSelectedSection(section: ProfileSection): void {
     this.selectedSection.set(section);
+  }
+
+  private esnCardMutationPending(): boolean {
+    return esnCardActionDisabled({
+      deletePending: this.deleteCardMutation.isPending(),
+      refreshPending: this.refreshCardMutation.isPending(),
+      upsertPending: this.upsertCardMutation.isPending(),
+    });
   }
 }

--- a/src/app/scanning/handle-registration/handle-registration.component.html
+++ b/src/app/scanning/handle-registration/handle-registration.component.html
@@ -46,8 +46,8 @@
         <div class="bg-error text-on-error mt-2 rounded p-2">
           <p class="title-small">Event starting in the future</p>
           <p>
-            The event starts on more than one hour, on
-            {{ scanResultQuery.data().event.start | date: "medium" }}
+            The event starts more than one hour from now, at
+            {{ scanResultQuery.data().event.start | date: "medium" }}.
           </p>
         </div>
       }
@@ -110,7 +110,9 @@
         [value]="selectedGuestCheckInCount()"
         (input)="updateGuestCheckInCount($event)"
       />
-      <span matTextSuffix> {{ selectedSpotCheckInCount() }} spots now </span>
+      <span matTextSuffix>
+        {{ scanSpotCountLabel(selectedSpotCheckInCount()) }}
+      </span>
     </mat-form-field>
   }
   @if (checkInMutation.isError()) {
@@ -118,7 +120,7 @@
       <p class="title-small">Check-in failed</p>
       <p>{{ errorMessage(checkInMutation.error()) }}</p>
     </div>
-  } @else if (checkInCompleted()) {
+  } @else if (checkInMutation.isSuccess()) {
     <div
       class="bg-primary-container text-on-primary-container mt-4 rounded p-4"
     >
@@ -127,24 +129,24 @@
   }
   <button
     [disabled]="
-      !scanResultQuery.data().allowCheckin ||
-      selectedSpotCheckInCount() < 1 ||
-      checkInMutation.isPending() ||
-      checkInCompleted()
+      scanCheckInActionDisabled({
+        allowCheckin: scanResultQuery.data().allowCheckin,
+        completed: checkInCompleted(),
+        mutationPending: checkInMutation.isPending(),
+        spotCount: selectedSpotCheckInCount(),
+      })
     "
     class="mt-4 w-full"
     mat-raised-button
     type="button"
     (click)="checkIn()"
   >
-    @if (checkInMutation.isPending()) {
-      Checking in ...
-    } @else if (checkInCompleted()) {
-      Checked in
-    } @else if (selectedSpotCheckInCount() > 1) {
-      Confirm {{ selectedSpotCheckInCount() }} Check Ins
-    } @else {
-      Confirm Check In
-    }
+    {{
+      scanCheckInButtonLabel({
+        completed: checkInCompleted(),
+        pending: checkInMutation.isPending(),
+        spotCount: selectedSpotCheckInCount(),
+      })
+    }}
   </button>
 }

--- a/src/app/scanning/handle-registration/handle-registration.component.spec.ts
+++ b/src/app/scanning/handle-registration/handle-registration.component.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  scanCheckInActionDisabled,
+  scanCheckInButtonLabel,
+  scanGuestCheckInCountFromInput,
+  scanSpotCountLabel,
+} from './handle-registration.component';
+
+describe('scanCheckInActionDisabled', () => {
+  it('blocks check-in when unavailable, pending, or empty', () => {
+    expect(
+      scanCheckInActionDisabled({
+        allowCheckin: false,
+        completed: false,
+        mutationPending: false,
+        spotCount: 1,
+      }),
+    ).toBe(true);
+    expect(
+      scanCheckInActionDisabled({
+        allowCheckin: true,
+        completed: false,
+        mutationPending: true,
+        spotCount: 1,
+      }),
+    ).toBe(true);
+    expect(
+      scanCheckInActionDisabled({
+        allowCheckin: true,
+        completed: false,
+        mutationPending: false,
+        spotCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      scanCheckInActionDisabled({
+        allowCheckin: true,
+        completed: false,
+        mutationPending: false,
+        spotCount: 1,
+      }),
+    ).toBe(false);
+    expect(
+      scanCheckInActionDisabled({
+        allowCheckin: true,
+        completed: true,
+        mutationPending: false,
+        spotCount: 1,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('scan check-in copy', () => {
+  it('keeps the primary check-in action readable for one or more spots', () => {
+    expect(
+      scanCheckInButtonLabel({
+        completed: false,
+        pending: false,
+        spotCount: 1,
+      }),
+    ).toBe('Confirm check-in');
+    expect(
+      scanCheckInButtonLabel({
+        completed: false,
+        pending: false,
+        spotCount: 3,
+      }),
+    ).toBe('Confirm 3 check-ins');
+  });
+
+  it('keeps the pending action state short and active', () => {
+    expect(
+      scanCheckInButtonLabel({ completed: false, pending: true, spotCount: 3 }),
+    ).toBe('Checking in...');
+  });
+
+  it('shows the completed state after a successful check-in', () => {
+    expect(
+      scanCheckInButtonLabel({ completed: true, pending: false, spotCount: 3 }),
+    ).toBe('Checked in');
+  });
+
+  it('uses singular and plural spot suffixes for guest check-in selection', () => {
+    expect(scanSpotCountLabel(1)).toBe('1 spot now');
+    expect(scanSpotCountLabel(3)).toBe('3 spots now');
+  });
+});
+
+describe('scanGuestCheckInCountFromInput', () => {
+  it('keeps guest check-in selection within the remaining guest count', () => {
+    expect(
+      scanGuestCheckInCountFromInput({
+        inputValue: '2',
+        remainingGuestCount: 3,
+      }),
+    ).toBe(2);
+    expect(
+      scanGuestCheckInCountFromInput({
+        inputValue: '8',
+        remainingGuestCount: 3,
+      }),
+    ).toBe(3);
+  });
+
+  it('normalizes blank, invalid, and negative guest selections to zero', () => {
+    for (const inputValue of ['', 'not-a-number', '-2']) {
+      expect(
+        scanGuestCheckInCountFromInput({
+          inputValue,
+          remainingGuestCount: 3,
+        }),
+      ).toBe(0);
+    }
+  });
+});

--- a/src/app/scanning/handle-registration/handle-registration.component.ts
+++ b/src/app/scanning/handle-registration/handle-registration.component.ts
@@ -23,6 +23,58 @@ import { DateTime } from 'luxon';
 import { AppRpc } from '../../core/effect-rpc-angular-client';
 import { getErrorMessage } from '../../core/error-message';
 
+export const scanCheckInButtonLabel = ({
+  completed,
+  pending,
+  spotCount,
+}: {
+  completed: boolean;
+  pending: boolean;
+  spotCount: number;
+}): string => {
+  if (pending) {
+    return 'Checking in...';
+  }
+
+  if (completed) {
+    return 'Checked in';
+  }
+
+  return spotCount > 1 ? `Confirm ${spotCount} check-ins` : 'Confirm check-in';
+};
+
+export const scanSpotCountLabel = (spotCount: number): string =>
+  spotCount === 1 ? '1 spot now' : `${spotCount} spots now`;
+
+export const scanCheckInActionDisabled = ({
+  allowCheckin,
+  completed,
+  mutationPending,
+  spotCount,
+}: {
+  allowCheckin: boolean;
+  completed: boolean;
+  mutationPending: boolean;
+  spotCount: number;
+}): boolean => !allowCheckin || completed || mutationPending || spotCount < 1;
+
+export const scanGuestCheckInCountFromInput = ({
+  inputValue,
+  remainingGuestCount,
+}: {
+  inputValue: string;
+  remainingGuestCount: number;
+}): number => {
+  const nextGuestCount = Number.parseInt(inputValue, 10);
+  return Math.max(
+    0,
+    Math.min(
+      Number.isNaN(nextGuestCount) ? 0 : nextGuestCount,
+      remainingGuestCount,
+    ),
+  );
+};
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
@@ -39,18 +91,16 @@ import { getErrorMessage } from '../../core/error-message';
 })
 export class HandleRegistrationComponent {
   public readonly registrationId = input.required<string>();
-  protected readonly checkInCompleted = signal(false);
   private readonly rpc = AppRpc.injectClient();
   protected readonly checkInMutation = injectMutation(() =>
     this.rpc.events.checkInRegistration.mutationOptions(),
   );
-  protected readonly faArrowLeft = faArrowLeft;
-  protected readonly guestCheckInCount = signal(0);
   protected readonly scanResultQuery = injectQuery(() =>
     this.rpc.events.registrationScanned.queryOptions({
       registrationId: this.registrationId(),
     }),
   );
+  protected readonly guestCheckInCount = signal(0);
   protected readonly selectedGuestCheckInCount = computed(() => {
     const scanResult = this.scanResultQuery.data();
     if (!scanResult) {
@@ -67,6 +117,14 @@ export class HandleRegistrationComponent {
       (scanResult.attendeeCheckedIn ? 0 : 1) + this.selectedGuestCheckInCount()
     );
   });
+  protected readonly checkInCompleted = computed(
+    () =>
+      this.checkInMutation.isSuccess() && this.selectedSpotCheckInCount() === 0,
+  );
+  protected readonly faArrowLeft = faArrowLeft;
+  protected readonly scanCheckInActionDisabled = scanCheckInActionDisabled;
+  protected readonly scanCheckInButtonLabel = scanCheckInButtonLabel;
+  protected readonly scanSpotCountLabel = scanSpotCountLabel;
   protected readonly startsSoon = computed(() => {
     const scanResult = this.scanResultQuery.data();
     if (!scanResult) return false;
@@ -77,9 +135,12 @@ export class HandleRegistrationComponent {
   checkIn() {
     const scanResult = this.scanResultQuery.data();
     if (
-      !scanResult?.allowCheckin ||
-      this.selectedSpotCheckInCount() < 1 ||
-      this.checkInMutation.isPending()
+      scanCheckInActionDisabled({
+        allowCheckin: scanResult?.allowCheckin ?? false,
+        completed: this.checkInCompleted(),
+        mutationPending: this.checkInMutation.isPending(),
+        spotCount: this.selectedSpotCheckInCount(),
+      })
     )
       return;
 
@@ -90,7 +151,6 @@ export class HandleRegistrationComponent {
       },
       {
         onSuccess: async () => {
-          this.checkInCompleted.set(true);
           await this.queryClient.invalidateQueries(
             this.rpc.queryFilter(['events', 'registrationScanned']),
           );
@@ -104,17 +164,13 @@ export class HandleRegistrationComponent {
     if (!(input instanceof HTMLInputElement)) {
       return;
     }
-    const nextGuestCount = Number.parseInt(input.value, 10);
     const remainingGuestCount =
       this.scanResultQuery.data()?.remainingGuestCount ?? 0;
     this.guestCheckInCount.set(
-      Math.max(
-        0,
-        Math.min(
-          Number.isNaN(nextGuestCount) ? 0 : nextGuestCount,
-          remainingGuestCount,
-        ),
-      ),
+      scanGuestCheckInCountFromInput({
+        inputValue: input.value,
+        remainingGuestCount,
+      }),
     );
   }
 

--- a/src/app/scanning/handle-registration/handle-registration.component.ts
+++ b/src/app/scanning/handle-registration/handle-registration.component.ts
@@ -117,9 +117,12 @@ export class HandleRegistrationComponent {
       (scanResult.attendeeCheckedIn ? 0 : 1) + this.selectedGuestCheckInCount()
     );
   });
+  private readonly localCheckInCompleted = signal(false);
   protected readonly checkInCompleted = computed(
     () =>
-      this.checkInMutation.isSuccess() && this.selectedSpotCheckInCount() === 0,
+      this.localCheckInCompleted() ||
+      (this.checkInMutation.isSuccess() &&
+        this.selectedSpotCheckInCount() === 0),
   );
   protected readonly faArrowLeft = faArrowLeft;
   protected readonly scanCheckInActionDisabled = scanCheckInActionDisabled;
@@ -151,6 +154,7 @@ export class HandleRegistrationComponent {
       },
       {
         onSuccess: async () => {
+          this.localCheckInCompleted.set(true);
           await this.queryClient.invalidateQueries(
             this.rpc.queryFilter(['events', 'registrationScanned']),
           );

--- a/src/app/shared/components/forms/registration-option-form/registration-option-form.html
+++ b/src/app/shared/components/forms/registration-option-form/registration-option-form.html
@@ -7,7 +7,9 @@
       <mat-label>Registration mode</mat-label>
       <mat-select [formField]="form.registrationMode">
         @for (mode of registrationModes(); track mode) {
-          <mat-option [value]="mode">{{ mode | titlecase }} </mat-option>
+          <mat-option [value]="mode">{{
+            registrationModeLabel(mode)
+          }}</mat-option>
         }
       </mat-select>
     </mat-form-field>

--- a/src/app/shared/components/forms/registration-option-form/registration-option-form.schema.ts
+++ b/src/app/shared/components/forms/registration-option-form/registration-option-form.schema.ts
@@ -1,3 +1,5 @@
+import type { RegistrationMode } from '@shared/registration-modes';
+
 import {
   hidden,
   min,
@@ -18,7 +20,7 @@ export interface RegistrationOptionFormModel {
   organizingRegistration: boolean;
   price: number;
   registeredDescription: string;
-  registrationMode: 'application' | 'fcfs' | 'random';
+  registrationMode: RegistrationMode;
   roleIds: string[];
   spots: number;
   stripeTaxRateId: null | string;

--- a/src/app/shared/components/forms/registration-option-form/registration-option-form.ts
+++ b/src/app/shared/components/forms/registration-option-form/registration-option-form.ts
@@ -1,4 +1,4 @@
-import { CurrencyPipe, TitleCasePipe } from '@angular/common';
+import { CurrencyPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FieldTree, FormField } from '@angular/forms/signals';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -7,6 +7,10 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTimepickerModule } from '@angular/material/timepicker';
+import {
+  type RegistrationMode,
+  registrationModeLabel,
+} from '@shared/registration-modes';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import { AppRpc } from '../../../../core/effect-rpc-angular-client';
@@ -26,7 +30,6 @@ import { RegistrationOptionFormModel } from './registration-option-form.schema';
     MatTimepickerModule,
     MatFormFieldModule,
     MatInputModule,
-    TitleCasePipe,
     RoleSelectComponent,
   ],
   selector: 'app-registration-option-form',
@@ -35,9 +38,10 @@ import { RegistrationOptionFormModel } from './registration-option-form.schema';
 })
 export class RegistrationOptionForm {
   public esnEnabled = input.required<boolean>();
-  public registrationModes = input.required<readonly string[]>();
+  public registrationModes = input.required<readonly RegistrationMode[]>();
   public registrationOptionForm =
     input.required<FieldTree<RegistrationOptionFormModel>>();
+  protected readonly registrationModeLabel = registrationModeLabel;
   private readonly rpc = AppRpc.injectClient();
   protected readonly taxRatesQuery = injectQuery(() =>
     this.rpc.taxRates.listActive.queryOptions(),

--- a/src/app/shared/components/icon/font-awesome-icon-usage.spec.ts
+++ b/src/app/shared/components/icon/font-awesome-icon-usage.spec.ts
@@ -1,0 +1,40 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourceRoot = path.join(process.cwd(), 'src/app');
+const forbiddenPatterns = ['<mat-' + 'icon', 'Mat' + 'IconModule'] as const;
+
+const appSourceFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const filePath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return appSourceFiles(filePath);
+    }
+
+    if (
+      entry.isFile() &&
+      (entry.name.endsWith('.html') || entry.name.endsWith('.ts')) &&
+      entry.name !== 'font-awesome-icon-usage.spec.ts'
+    ) {
+      return [filePath];
+    }
+
+    return [];
+  });
+
+describe('Font Awesome icon usage', () => {
+  it('keeps Angular app icons on the Font Awesome component path', () => {
+    const offenders = appSourceFiles(sourceRoot).flatMap((filePath) => {
+      const source = readFileSync(filePath, 'utf8');
+      return forbiddenPatterns
+        .filter((pattern) => source.includes(pattern))
+        .map(
+          (pattern) => `${filePath.replace(sourceRoot, 'src/app')}: ${pattern}`,
+        );
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/app/templates/categories/category-list/category-list.component.html
+++ b/src/app/templates/categories/category-list/category-list.component.html
@@ -9,9 +9,10 @@
   mat-fab
   extended
   (click)="openCategoryCreationDialog()"
+  [disabled]="categoryActionDisabled()"
   class="fab-fixed"
 >
-  <mat-icon svgIcon="faPlus" />
+  <fa-duotone-icon [icon]="faPlus" />
   Create category
 </button>
 
@@ -27,7 +28,12 @@
   } @else if (templateCategoryGroupsQuery.isSuccess()) {
     @if (templateCategoryGroupsQuery.data().length === 0) {
       <p>No categories found</p>
-      <button mat-flat-button (click)="openCategoryCreationDialog()">
+      <button
+        mat-flat-button
+        type="button"
+        (click)="openCategoryCreationDialog()"
+        [disabled]="categoryActionDisabled()"
+      >
         Create a new category
       </button>
     } @else {
@@ -67,7 +73,11 @@
               Actions
             </th>
             <td mat-cell *matCellDef="let element" class="text-right">
-              <button mat-button (click)="openCategoryEditDialog(element)">
+              <button
+                mat-button
+                (click)="openCategoryEditDialog(element)"
+                [disabled]="categoryActionDisabled()"
+              >
                 Edit
               </button>
             </td>

--- a/src/app/templates/categories/category-list/category-list.component.spec.ts
+++ b/src/app/templates/categories/category-list/category-list.component.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { templateCategoryActionDisabled } from './category-list.component';
+
+describe('templateCategoryActionDisabled', () => {
+  it('blocks category actions while any category write is pending', () => {
+    expect(
+      templateCategoryActionDisabled({
+        createPending: false,
+        updatePending: false,
+      }),
+    ).toBe(false);
+    expect(
+      templateCategoryActionDisabled({
+        createPending: true,
+        updatePending: false,
+      }),
+    ).toBe(true);
+    expect(
+      templateCategoryActionDisabled({
+        createPending: false,
+        updatePending: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/app/templates/categories/category-list/category-list.component.ts
+++ b/src/app/templates/categories/category-list/category-list.component.ts
@@ -9,13 +9,13 @@ import {
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
-import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import {
   faArrowLeft,
   faEllipsisVertical,
+  faPlus,
 } from '@fortawesome/duotone-regular-svg-icons';
 import {
   injectMutation,
@@ -31,12 +31,19 @@ import { CreateEditCategoryDialogComponent } from '../create-edit-category-dialo
 
 const fallbackIcon: IconValue = { iconColor: 0, iconName: 'city' };
 
+export const templateCategoryActionDisabled = ({
+  createPending,
+  updatePending,
+}: {
+  createPending: boolean;
+  updatePending: boolean;
+}): boolean => createPending || updatePending;
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     MatButtonModule,
     FontAwesomeModule,
-    MatIconModule,
     MatTableModule,
     RouterLink,
     IconComponent,
@@ -53,6 +60,7 @@ export class CategoryListComponent {
   ]);
   protected readonly faArrowLeft = faArrowLeft;
   protected readonly faEllipsisVertical = faEllipsisVertical;
+  protected readonly faPlus = faPlus;
   protected readonly outletActive = signal(false);
   private readonly rpc = AppRpc.injectClient();
   protected templateCategoryGroupsQuery = injectQuery(() =>
@@ -73,6 +81,10 @@ export class CategoryListComponent {
   );
 
   async openCategoryCreationDialog() {
+    if (this.categoryActionDisabled()) {
+      return;
+    }
+
     const defaultIcon =
       this.templateCategoryGroupsQuery.data()?.[0]?.icon ?? fallbackIcon;
     const dialogReference = this.dialog.open<
@@ -102,6 +114,10 @@ export class CategoryListComponent {
     id: string;
     title: string;
   }) {
+    if (this.categoryActionDisabled()) {
+      return;
+    }
+
     const dialogReference = this.dialog.open(
       CreateEditCategoryDialogComponent,
       {
@@ -124,5 +140,12 @@ export class CategoryListComponent {
         this.rpc.queryFilter(['templates', 'groupedByCategory']),
       );
     }
+  }
+
+  protected categoryActionDisabled(): boolean {
+    return templateCategoryActionDisabled({
+      createPending: this.createCategoryMutation.isPending(),
+      updatePending: this.updateCategoryMutation.isPending(),
+    });
   }
 }

--- a/src/app/templates/shared/template-form/template-form.utilities.spec.ts
+++ b/src/app/templates/shared/template-form/template-form.utilities.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { templateWriteSubmitDisabled } from './template-form.utilities';
+
+describe('templateWriteSubmitDisabled', () => {
+  it('disables template writes while the form is invalid', () => {
+    expect(
+      templateWriteSubmitDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('disables template writes while the form is submitting', () => {
+    expect(
+      templateWriteSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('disables template writes while the create or update mutation is pending', () => {
+    expect(
+      templateWriteSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows template writes only when the form and mutation are idle', () => {
+    expect(
+      templateWriteSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/templates/shared/template-form/template-form.utilities.ts
+++ b/src/app/templates/shared/template-form/template-form.utilities.ts
@@ -107,3 +107,10 @@ export const mergeTemplateFormOverrides = (
     title: overrides.title ?? base.title,
   });
 };
+
+export const templateWriteSubmitDisabled = (input: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean =>
+  input.formInvalid || input.formSubmitting || input.mutationPending;

--- a/src/app/templates/shared/template-form/template-registration-option-form.component.html
+++ b/src/app/templates/shared/template-form/template-registration-option-form.component.html
@@ -5,15 +5,9 @@
 </mat-form-field>
 
 <section class="grid gap-3">
-  <label class="text-on-surface flex items-center gap-2 text-sm">
-    <input
-      class="h-4 w-4"
-      type="checkbox"
-      [checked]="form.isPaid().value()"
-      (change)="setIsPaid($event)"
-    />
-    <span>Enable payment</span>
-  </label>
+  <mat-checkbox [checked]="form.isPaid().value()" (change)="setIsPaid($event)">
+    Enable payment
+  </mat-checkbox>
 
   @if (!form.price().hidden()) {
     <div class="grid gap-4">

--- a/src/app/templates/shared/template-form/template-registration-option-form.component.html
+++ b/src/app/templates/shared/template-form/template-registration-option-form.component.html
@@ -91,7 +91,9 @@
     <mat-label>Registration Mode</mat-label>
     <mat-select [formField]="form.registrationMode">
       @for (mode of registrationModes(); track mode) {
-        <mat-option [value]="mode">{{ mode }}</mat-option>
+        <mat-option [value]="mode">{{
+          registrationModeLabel(mode)
+        }}</mat-option>
       }
     </mat-select>
     <mat-hint>How registrations are processed</mat-hint>

--- a/src/app/templates/shared/template-form/template-registration-option-form.component.ts
+++ b/src/app/templates/shared/template-form/template-registration-option-form.component.ts
@@ -1,5 +1,9 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FieldTree, FormField } from '@angular/forms/signals';
+import {
+  MatCheckboxChange,
+  MatCheckboxModule,
+} from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -21,6 +25,7 @@ import {
     DurationSelectorComponent,
     EditorComponent,
     FormField,
+    MatCheckboxModule,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
@@ -49,15 +54,16 @@ export class TemplateRegistrationOptionFormComponent {
     field.markAsDirty();
   }
 
-  protected setIsPaid(event: Event): void {
+  protected setIsPaid(event: MatCheckboxChange): void {
     const field = this.registrationForm().isPaid();
-    field.value.set((event.target as HTMLInputElement).checked);
+    field.value.set(event.checked);
     field.markAsDirty();
   }
 
   protected setPrice(event: Event): void {
+    const rawValue = (event.target as HTMLInputElement).value;
     const field = this.registrationForm().price();
-    field.value.set(Number((event.target as HTMLInputElement).value));
+    field.value.set(rawValue === '' ? '' : Number(rawValue));
     field.markAsDirty();
   }
 

--- a/src/app/templates/shared/template-form/template-registration-option-form.component.ts
+++ b/src/app/templates/shared/template-form/template-registration-option-form.component.ts
@@ -3,6 +3,7 @@ import { FieldTree, FormField } from '@angular/forms/signals';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { registrationModeLabel } from '@shared/registration-modes';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import { AppRpc } from '../../../core/effect-rpc-angular-client';
@@ -34,6 +35,7 @@ export class TemplateRegistrationOptionFormComponent {
     input.required<FieldTree<TemplateRegistrationFormModel>>();
   public readonly registrationModes =
     input.required<readonly RegistrationMode[]>();
+  protected readonly registrationModeLabel = registrationModeLabel;
 
   private readonly rpc = AppRpc.injectClient();
   protected readonly taxRatesQuery = injectQuery(() =>

--- a/src/app/templates/shared/template-form/template-registration-option-form.schema.ts
+++ b/src/app/templates/shared/template-form/template-registration-option-form.schema.ts
@@ -33,7 +33,6 @@ export const templateRegistrationOptionFormSchema =
     hidden(form.stripeTaxRateId, ({ valueOf }) => !valueOf(form.isPaid));
     min(form.closeRegistrationOffset, 0);
     min(form.openRegistrationOffset, 0);
-    min(form.price, 0);
     min(form.spots, 1);
     minLength(form.roleIds, 1);
     required(form.closeRegistrationOffset);
@@ -65,10 +64,24 @@ export const templateRegistrationOptionFormSchema =
           message: 'Discounted price must be non-negative.',
         };
       }
-      if (discountedPrice > valueOf(form.price)) {
+      const price = valueOf(form.price);
+      if (price !== '' && discountedPrice > price) {
         return {
           kind: 'max',
           message: 'Discounted price cannot exceed the base price.',
+        };
+      }
+      return;
+    });
+    validate(form.price, ({ value }) => {
+      const price = value();
+      if (price === '') {
+        return;
+      }
+      if (price < 0) {
+        return {
+          kind: 'min',
+          message: 'Price must be non-negative.',
         };
       }
       return;

--- a/src/app/templates/shared/template-form/template-registration-option-form.utilities.ts
+++ b/src/app/templates/shared/template-form/template-registration-option-form.utilities.ts
@@ -1,4 +1,4 @@
-export type RegistrationMode = 'application' | 'fcfs' | 'random';
+import type { RegistrationMode } from '@shared/registration-modes';
 
 export interface TemplateRegistrationFormModel {
   closeRegistrationOffset: number;
@@ -100,3 +100,5 @@ export const mergeTemplateRegistrationFormOverrides = (
     title: overrides.title ?? base.title,
   });
 };
+
+export { type RegistrationMode } from '@shared/registration-modes';

--- a/src/app/templates/shared/template-form/template-registration-option-form.utilities.ts
+++ b/src/app/templates/shared/template-form/template-registration-option-form.utilities.ts
@@ -6,7 +6,7 @@ export interface TemplateRegistrationFormModel {
   esnCardDiscountedPrice: '' | number;
   isPaid: boolean;
   openRegistrationOffset: number;
-  price: number;
+  price: '' | number;
   registeredDescription: string;
   registrationMode: RegistrationMode;
   roleIds: string[];
@@ -23,9 +23,10 @@ export type TemplateRegistrationFormOverrides = Partial<
 
 export type TemplateRegistrationSubmitData = Omit<
   TemplateRegistrationFormModel,
-  'esnCardDiscountedPrice'
+  'esnCardDiscountedPrice' | 'price'
 > & {
   esnCardDiscountedPrice: null | number;
+  price: number;
 };
 
 export const toTemplateRegistrationSubmitData = (
@@ -42,7 +43,8 @@ export const toTemplateRegistrationSubmitData = (
       : null,
   isPaid: registration.isPaid,
   openRegistrationOffset: registration.openRegistrationOffset,
-  price: registration.isPaid ? registration.price : 0,
+  price:
+    registration.isPaid && registration.price !== '' ? registration.price : 0,
   registeredDescription: registration.registeredDescription?.trim()
     ? registration.registeredDescription
     : '',

--- a/src/app/templates/template-create-event/template-create-event.component.html
+++ b/src/app/templates/template-create-event/template-create-event.component.html
@@ -7,6 +7,17 @@
 
 <main class="flex flex-col gap-6">
   @if (templateQuery.isSuccess()) {
+    @if (addOnCopyNotice(); as notice) {
+      <aside
+        class="border-outline-variant bg-surface-container-low text-on-surface rounded-lg border p-4"
+      >
+        <div class="flex items-start gap-3">
+          <fa-duotone-icon class="text-primary mt-1" [icon]="faCircleInfo" />
+          <p class="body-medium">{{ notice }}</p>
+        </div>
+      </aside>
+    }
+
     <form (submit)="onSubmit($event)">
       <div class="grid gap-6">
         <section class="bg-surface text-on-surface rounded-2xl p-4">
@@ -37,9 +48,11 @@
             type="submit"
             mat-button
             [disabled]="
-              createEventForm().invalid() ||
-              createEventForm().submitting() ||
-              createEventMutation.isPending()
+              templateCreateEventSubmitDisabled({
+                formInvalid: createEventForm().invalid(),
+                formSubmitting: createEventForm().submitting(),
+                mutationPending: createEventMutation.isPending(),
+              })
             "
           >
             Create event

--- a/src/app/templates/template-create-event/template-create-event.component.spec.ts
+++ b/src/app/templates/template-create-event/template-create-event.component.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  templateAddOnCopyNotice,
+  templateCreateEventSubmitDisabled,
+} from './template-create-event.component';
+
+describe('templateCreateEventSubmitDisabled', () => {
+  it('blocks template event creation while invalid, submitting, or awaiting the mutation', () => {
+    expect(
+      templateCreateEventSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(false);
+    expect(
+      templateCreateEventSubmitDisabled({
+        formInvalid: true,
+        formSubmitting: false,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      templateCreateEventSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: true,
+        mutationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      templateCreateEventSubmitDisabled({
+        formInvalid: false,
+        formSubmitting: false,
+        mutationPending: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('templateAddOnCopyNotice', () => {
+  it('stays hidden when a template has no reusable add-ons', () => {
+    expect(templateAddOnCopyNotice(0)).toBeNull();
+  });
+
+  it('keeps the create-event add-on boundary explicit', () => {
+    expect(templateAddOnCopyNotice(1)).toContain(
+      'This template has 1 reusable add-on.',
+    );
+    expect(templateAddOnCopyNotice(2)).toContain(
+      'Event creation copies registration options now',
+    );
+    expect(templateAddOnCopyNotice(2)).toContain(
+      'event-specific add-on sales are not available yet',
+    );
+  });
+});

--- a/src/app/templates/template-create-event/template-create-event.component.ts
+++ b/src/app/templates/template-create-event/template-create-event.component.ts
@@ -12,7 +12,10 @@ import { FieldTree, form, submit } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import { Router, RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faArrowLeft } from '@fortawesome/duotone-regular-svg-icons';
+import {
+  faArrowLeft,
+  faCircleInfo,
+} from '@fortawesome/duotone-regular-svg-icons';
 import {
   injectMutation,
   injectQuery,
@@ -28,7 +31,22 @@ import {
   eventGeneralFormSchema,
 } from '../../shared/components/forms/event-general-form/event-general-form.schema';
 import { RegistrationOptionForm } from '../../shared/components/forms/registration-option-form/registration-option-form';
-import { createRegistrationOptionFormModel } from '../../shared/components/forms/registration-option-form/registration-option-form.schema';
+import { createEventFormModelFromTemplate } from './template-create-event.mapper';
+
+export const templateCreateEventSubmitDisabled = ({
+  formInvalid,
+  formSubmitting,
+  mutationPending,
+}: {
+  formInvalid: boolean;
+  formSubmitting: boolean;
+  mutationPending: boolean;
+}): boolean => formInvalid || formSubmitting || mutationPending;
+
+export const templateAddOnCopyNotice = (addOnCount: number): null | string =>
+  addOnCount > 0
+    ? `This template has ${addOnCount} reusable add-on${addOnCount === 1 ? '' : 's'}. Event creation copies registration options now; event-specific add-on sales are not available yet.`
+    : null;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -42,6 +60,14 @@ import { createRegistrationOptionFormModel } from '../../shared/components/forms
   templateUrl: './template-create-event.component.html',
 })
 export class TemplateCreateEventComponent {
+  protected readonly templateId = input.required<string>();
+  private readonly rpc = AppRpc.injectClient();
+  protected readonly templateQuery = injectQuery(() =>
+    this.rpc.templates.findOne.queryOptions({ id: this.templateId() }),
+  );
+  protected readonly addOnCopyNotice = computed(() =>
+    templateAddOnCopyNotice(this.templateQuery.data()?.addOns.length ?? 0),
+  );
   protected readonly createEventModel = signal<EventGeneralFormModel>(
     createEventGeneralFormModel(),
   );
@@ -49,7 +75,6 @@ export class TemplateCreateEventComponent {
     this.createEventModel,
     eventGeneralFormSchema,
   );
-  private readonly rpc = AppRpc.injectClient();
   protected readonly createEventMutation = injectMutation(() =>
     this.rpc.events.create.mutationOptions(),
   );
@@ -65,11 +90,10 @@ export class TemplateCreateEventComponent {
     );
   });
   protected readonly faArrowLeft = faArrowLeft;
+  protected readonly faCircleInfo = faCircleInfo;
   protected readonly registrationModes = ['fcfs'] as const;
-  protected readonly templateId = input.required<string>();
-  protected readonly templateQuery = injectQuery(() =>
-    this.rpc.templates.findOne.queryOptions({ id: this.templateId() }),
-  );
+  protected readonly templateCreateEventSubmitDisabled =
+    templateCreateEventSubmitDisabled;
   private readonly initializedTemplateId = signal<null | string>(null);
   private readonly lastStart = signal<DateTime | null>(null);
 
@@ -86,36 +110,7 @@ export class TemplateCreateEventComponent {
         untracked(() => this.createEventForm.start().value()),
       );
       this.createEventModel.set(
-        createEventGeneralFormModel({
-          description: template.description,
-          end: startDateTime,
-          icon: template.icon,
-          location: template.location ?? null,
-          registrationOptions: template.registrationOptions.map((option) =>
-            createRegistrationOptionFormModel({
-              closeRegistrationTime: startDateTime.minus({
-                hours: option.closeRegistrationOffset,
-              }),
-              description: option.description ?? '',
-              // Preserve source option id only for local form tracking.
-              id: option.id,
-              isPaid: option.isPaid,
-              openRegistrationTime: startDateTime.minus({
-                hours: option.openRegistrationOffset,
-              }),
-              organizingRegistration: option.organizingRegistration,
-              price: option.price,
-              registeredDescription: option.registeredDescription ?? '',
-              registrationMode: 'fcfs',
-              roleIds: [...(option.roleIds ?? [])],
-              spots: option.spots,
-              stripeTaxRateId: option.stripeTaxRateId ?? null,
-              title: option.title,
-            }),
-          ),
-          start: startDateTime,
-          title: template.title,
-        }),
+        createEventFormModelFromTemplate(template, startDateTime),
       );
       this.lastStart.set(startDateTime);
       this.initializedTemplateId.set(template.id);
@@ -162,6 +157,16 @@ export class TemplateCreateEventComponent {
 
   async onSubmit(event: Event) {
     event.preventDefault();
+    if (
+      templateCreateEventSubmitDisabled({
+        formInvalid: this.createEventForm().invalid(),
+        formSubmitting: this.createEventForm().submitting(),
+        mutationPending: this.createEventMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     await submit(this.createEventForm, async (formState) => {
       const formValue = formState().value();
       if (!formValue.icon) {

--- a/src/app/templates/template-create-event/template-create-event.component.ts
+++ b/src/app/templates/template-create-event/template-create-event.component.ts
@@ -182,6 +182,10 @@ export class TemplateCreateEventComponent {
               .toJSDate()
               .toISOString(),
             description: option.description?.trim() ? option.description : null,
+            esnCardDiscountedPrice:
+              option.esnCardDiscountedPrice === ''
+                ? null
+                : option.esnCardDiscountedPrice,
             isPaid: option.isPaid,
             openRegistrationTime: this.toDateTime(option.openRegistrationTime)
               .toJSDate()

--- a/src/app/templates/template-create-event/template-create-event.mapper.spec.ts
+++ b/src/app/templates/template-create-event/template-create-event.mapper.spec.ts
@@ -1,0 +1,175 @@
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+
+import { createEventFormModelFromTemplate } from './template-create-event.mapper';
+
+describe('createEventFormModelFromTemplate', () => {
+  it('copies reusable event and registration defaults into the event form', () => {
+    const start = DateTime.fromISO('2026-06-01T18:00:00.000Z', {
+      zone: 'utc',
+    });
+
+    const model = createEventFormModelFromTemplate(
+      {
+        addOns: [],
+        categoryId: 'category-1',
+        description: '<p>Template description</p>',
+        icon: {
+          iconColor: 2,
+          iconName: 'calendar:fas',
+        },
+        id: 'template-1',
+        location: {
+          meetingProvider: 'zoom',
+          meetingUrl: 'https://example.test/meeting',
+          name: 'Online room',
+          type: 'online',
+        },
+        planningTips: 'Bring printed waiver forms.',
+        registrationOptions: [
+          {
+            closeRegistrationOffset: 24,
+            description: '<p>Public participant copy</p>',
+            esnCardDiscountedPrice: 1200,
+            id: 'template-option-1',
+            isPaid: true,
+            openRegistrationOffset: 168,
+            organizingRegistration: false,
+            price: 1500,
+            registeredDescription: '<p>Attendee details</p>',
+            registrationMode: 'fcfs',
+            roleIds: ['role-user'],
+            roles: [{ id: 'role-user', name: 'User' }],
+            spots: 40,
+            stripeTaxRateId: 'txr_123',
+            title: 'Participant',
+          },
+        ],
+        title: 'Weekly meetup',
+      },
+      start,
+    );
+
+    expect(model).toMatchObject({
+      description: '<p>Template description</p>',
+      icon: {
+        iconColor: 2,
+        iconName: 'calendar:fas',
+      },
+      location: {
+        meetingProvider: 'zoom',
+        meetingUrl: 'https://example.test/meeting',
+        name: 'Online room',
+        type: 'online',
+      },
+      title: 'Weekly meetup',
+    });
+    expect(model.start.toISO()).toBe('2026-06-01T18:00:00.000Z');
+    expect(model.end.toISO()).toBe('2026-06-01T18:00:00.000Z');
+    expect(model.registrationOptions).toHaveLength(1);
+    expect(model.registrationOptions[0]).toMatchObject({
+      description: '<p>Public participant copy</p>',
+      id: 'template-option-1',
+      isPaid: true,
+      organizingRegistration: false,
+      price: 1500,
+      registeredDescription: '<p>Attendee details</p>',
+      registrationMode: 'fcfs',
+      roleIds: ['role-user'],
+      spots: 40,
+      stripeTaxRateId: 'txr_123',
+      title: 'Participant',
+    });
+    expect(model.registrationOptions[0]?.openRegistrationTime.toISO()).toBe(
+      '2026-05-25T18:00:00.000Z',
+    );
+    expect(model.registrationOptions[0]?.closeRegistrationTime.toISO()).toBe(
+      '2026-05-31T18:00:00.000Z',
+    );
+  });
+
+  it('keeps organizer planning tips private to the template surface', () => {
+    const model = createEventFormModelFromTemplate(
+      {
+        addOns: [],
+        categoryId: 'category-1',
+        description: '<p>Template description</p>',
+        icon: {
+          iconColor: 2,
+          iconName: 'calendar:fas',
+        },
+        id: 'template-1',
+        location: null,
+        planningTips: 'Bring printed waiver forms.',
+        registrationOptions: [],
+        title: 'Weekly meetup',
+      },
+      DateTime.fromISO('2026-06-01T18:00:00.000Z', { zone: 'utc' }),
+    );
+
+    expect('planningTips' in model).toBe(false);
+    expect(model.description).toBe('<p>Template description</p>');
+  });
+
+  it('keeps reusable add-ons out of event form data until event add-on fulfillment exists', () => {
+    const model = createEventFormModelFromTemplate(
+      {
+        addOns: [
+          {
+            allowMultiple: false,
+            allowPurchaseBeforeEvent: false,
+            allowPurchaseDuringEvent: false,
+            allowPurchaseDuringRegistration: true,
+            description: 'Packed lunch',
+            id: 'addon-1',
+            isPaid: false,
+            maxQuantityPerUser: 1,
+            price: 0,
+            registrationOptions: [
+              {
+                quantity: 1,
+                registrationOptionId: 'template-option-1',
+              },
+            ],
+            stripeTaxRateId: null,
+            title: 'Lunch',
+            totalAvailableQuantity: 40,
+          },
+        ],
+        categoryId: 'category-1',
+        description: '<p>Template description</p>',
+        icon: {
+          iconColor: 2,
+          iconName: 'calendar:fas',
+        },
+        id: 'template-1',
+        location: null,
+        planningTips: null,
+        registrationOptions: [
+          {
+            closeRegistrationOffset: 24,
+            description: null,
+            esnCardDiscountedPrice: null,
+            id: 'template-option-1',
+            isPaid: false,
+            openRegistrationOffset: 168,
+            organizingRegistration: false,
+            price: 0,
+            registeredDescription: null,
+            registrationMode: 'fcfs',
+            roleIds: [],
+            roles: [],
+            spots: 40,
+            stripeTaxRateId: null,
+            title: 'Participant',
+          },
+        ],
+        title: 'Weekly meetup',
+      },
+      DateTime.fromISO('2026-06-01T18:00:00.000Z', { zone: 'utc' }),
+    );
+
+    expect('addOns' in model).toBe(false);
+    expect(model.registrationOptions[0]?.id).toBe('template-option-1');
+  });
+});

--- a/src/app/templates/template-create-event/template-create-event.mapper.spec.ts
+++ b/src/app/templates/template-create-event/template-create-event.mapper.spec.ts
@@ -69,6 +69,7 @@ describe('createEventFormModelFromTemplate', () => {
     expect(model.registrationOptions).toHaveLength(1);
     expect(model.registrationOptions[0]).toMatchObject({
       description: '<p>Public participant copy</p>',
+      esnCardDiscountedPrice: 1200,
       id: 'template-option-1',
       isPaid: true,
       organizingRegistration: false,

--- a/src/app/templates/template-create-event/template-create-event.mapper.ts
+++ b/src/app/templates/template-create-event/template-create-event.mapper.ts
@@ -1,0 +1,44 @@
+import type { TemplateFindOneRecord } from '@shared/rpc-contracts/app-rpcs/templates.rpcs';
+
+import { DateTime } from 'luxon';
+
+import {
+  createEventGeneralFormModel,
+  EventGeneralFormModel,
+} from '../../shared/components/forms/event-general-form/event-general-form.schema';
+import { createRegistrationOptionFormModel } from '../../shared/components/forms/registration-option-form/registration-option-form.schema';
+
+export const createEventFormModelFromTemplate = (
+  template: TemplateFindOneRecord,
+  startDateTime: DateTime,
+): EventGeneralFormModel =>
+  createEventGeneralFormModel({
+    description: template.description,
+    end: startDateTime,
+    icon: template.icon,
+    location: template.location ?? null,
+    registrationOptions: template.registrationOptions.map((option) =>
+      createRegistrationOptionFormModel({
+        closeRegistrationTime: startDateTime.minus({
+          hours: option.closeRegistrationOffset,
+        }),
+        description: option.description ?? '',
+        esnCardDiscountedPrice: option.esnCardDiscountedPrice ?? '',
+        id: option.id,
+        isPaid: option.isPaid,
+        openRegistrationTime: startDateTime.minus({
+          hours: option.openRegistrationOffset,
+        }),
+        organizingRegistration: option.organizingRegistration,
+        price: option.price,
+        registeredDescription: option.registeredDescription ?? '',
+        registrationMode: 'fcfs',
+        roleIds: [...(option.roleIds ?? [])],
+        spots: option.spots,
+        stripeTaxRateId: option.stripeTaxRateId ?? null,
+        title: option.title,
+      }),
+    ),
+    start: startDateTime,
+    title: template.title,
+  });

--- a/src/app/templates/template-create/template-create.component.ts
+++ b/src/app/templates/template-create/template-create.component.ts
@@ -125,7 +125,7 @@ export class TemplateCreateComponent {
     event.preventDefault();
     if (
       templateWriteSubmitDisabled({
-        formInvalid: this.templateForm().invalid(),
+        formInvalid: false,
         formSubmitting: this.templateForm().submitting(),
         mutationPending: this.createTemplateMutation.isPending(),
       })

--- a/src/app/templates/template-create/template-create.component.ts
+++ b/src/app/templates/template-create/template-create.component.ts
@@ -24,6 +24,7 @@ import {
   TemplateFormData,
   TemplateFormOverrides,
   TemplateFormSubmitData,
+  templateWriteSubmitDisabled,
 } from '../shared/template-form/template-form.utilities';
 import { TemplateGeneralFormComponent } from '../shared/template-form/template-general-form.component';
 import { templateGeneralFormSchema } from '../shared/template-form/template-general-form.schema';
@@ -56,6 +57,9 @@ const logger = consola.withTag('app/templates/create');
 })
 export class TemplateCreateComponent {
   private readonly rpc = AppRpc.injectClient();
+  protected readonly createTemplateMutation = injectMutation(() =>
+    this.rpc.templates.createSimpleTemplate.mutationOptions(),
+  );
   protected readonly discountProvidersQuery = injectQuery(() =>
     this.rpc.discounts.getTenantProviders.queryOptions(),
   );
@@ -90,15 +94,15 @@ export class TemplateCreateComponent {
     this.templateModel,
     templateFormSchema,
   );
+
   protected readonly canSubmit = computed(
     () =>
       this.discountProvidersQuery.isSuccess() &&
-      !this.templateForm().invalid() &&
-      !this.templateForm().submitting(),
-  );
-
-  protected readonly createTemplateMutation = injectMutation(() =>
-    this.rpc.templates.createSimpleTemplate.mutationOptions(),
+      !templateWriteSubmitDisabled({
+        formInvalid: this.templateForm().invalid(),
+        formSubmitting: this.templateForm().submitting(),
+        mutationPending: this.createTemplateMutation.isPending(),
+      }),
   );
 
   protected readonly esnEnabled = computed(() => {
@@ -113,11 +117,22 @@ export class TemplateCreateComponent {
   protected readonly faArrowLeft = faArrowLeft;
   protected readonly registrationModes: readonly RegistrationMode[] = ['fcfs'];
 
+  protected readonly templateWriteSubmitDisabled = templateWriteSubmitDisabled;
   private queryClient = inject(QueryClient);
   private router = inject(Router);
 
   async onSubmit(event: Event) {
     event.preventDefault();
+    if (
+      templateWriteSubmitDisabled({
+        formInvalid: this.templateForm().invalid(),
+        formSubmitting: this.templateForm().submitting(),
+        mutationPending: this.createTemplateMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     await submit(this.templateForm, async (formState) => {
       const formValue = formState().value();
       if (!formValue.icon) {

--- a/src/app/templates/template-details/template-details.component.html
+++ b/src/app/templates/template-details/template-details.component.html
@@ -30,6 +30,7 @@
 @if (templateQuery.isError()) {
   <p>Error: {{ errorMessage(templateQuery.error()) }}</p>
 } @else if (templateQuery.isSuccess()) {
+  @let template = templateQuery.data();
   <a mat-fab extended routerLink="create-event" class="fab-fixed">
     <fa-duotone-icon [icon]="faPlus" />
     Create event
@@ -39,21 +40,97 @@
     <section class="bg-surface text-on-surface rounded-2xl p-4">
       <div
         class="prose dark:prose-invert max-w-none"
-        [innerHTML]="templateQuery.data().description"
+        [innerHTML]="template.description"
       ></div>
     </section>
 
     <section class="bg-surface text-on-surface rounded-2xl p-4">
       <h2 class="mb-6 text-lg font-semibold">Additional configuration</h2>
-      @if (templateQuery.data().location) {
-        <div>Location: {{ templateQuery.data().location?.name }}</div>
+      @if (template.location) {
+        <div>Location: {{ template.location.name }}</div>
       }
-      @if (templateQuery.data().planningTips) {
+      @if (template.planningTips) {
         <div class="mt-4">
           <h3 class="title-small">Organizer planning tips</h3>
           <p class="whitespace-pre-line text-sm">
-            {{ templateQuery.data().planningTips }}
+            {{ template.planningTips }}
           </p>
+        </div>
+      }
+      @if (template.addOns.length > 0) {
+        <div class="mt-6">
+          <h3 class="title-small">Reusable add-ons</h3>
+          <div class="mt-3 grid gap-4">
+            @for (addOn of template.addOns; track addOn.id) {
+              <article class="border-outline-variant border-t pt-3">
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h4 class="font-medium">{{ addOn.title }}</h4>
+                    @if (addOn.description) {
+                      <p class="text-on-surface-variant text-sm">
+                        {{ addOn.description }}
+                      </p>
+                    }
+                  </div>
+                  <div class="text-right">
+                    @if (addOn.isPaid) {
+                      @if (
+                        taxRatesQuery.isSuccess() &&
+                          findRateByStripeId(addOn.stripeTaxRateId);
+                        as rate
+                      ) {
+                        <app-price-with-tax
+                          [amount]="addOn.price"
+                          [taxRate]="rate"
+                        />
+                      } @else {
+                        <app-price-with-tax [amount]="addOn.price" />
+                      }
+                    } @else {
+                      <span>Free</span>
+                    }
+                  </div>
+                </div>
+                <dl class="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+                  <div>
+                    <dt class="text-on-surface-variant">Available quantity</dt>
+                    <dd>{{ addOn.totalAvailableQuantity }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-on-surface-variant">Max per user</dt>
+                    <dd>{{ addOn.maxQuantityPerUser }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-on-surface-variant">Purchase timing</dt>
+                    <dd>{{ templateAddonPurchaseTiming(addOn) }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-on-surface-variant">
+                      Registration options
+                    </dt>
+                    <dd>
+                      @for (
+                        option of addOn.registrationOptions;
+                        track option.registrationOptionId
+                      ) {
+                        <span>
+                          {{
+                            registrationOptionTitle(
+                              template,
+                              option.registrationOptionId
+                            )
+                          }}
+                          ({{ option.quantity }})
+                        </span>
+                      } @empty {
+                        <span>None</span>
+                      }
+                    </dd>
+                  </div>
+                </dl>
+              </article>
+            }
+          </div>
         </div>
       }
     </section>
@@ -64,10 +141,7 @@
       <h2 class="mb-6 text-lg font-semibold">Registration Options</h2>
 
       <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        @for (
-          option of templateQuery.data().registrationOptions;
-          track option.id
-        ) {
+        @for (option of template.registrationOptions; track option.id) {
           <div
             class="bg-surface text-on-surface flex flex-col gap-4 rounded-xl p-4"
           >
@@ -107,7 +181,7 @@
                 </span>
                 <div class="flex items-center gap-1">
                   <span class="font-medium">{{
-                    option.registrationMode | titlecase
+                    registrationModeLabel(option.registrationMode)
                   }}</span>
                   <span class="text-on-surface-variant">·</span>
                   @if (option.isPaid) {

--- a/src/app/templates/template-details/template-details.component.spec.ts
+++ b/src/app/templates/template-details/template-details.component.spec.ts
@@ -1,0 +1,95 @@
+import type { TemplateFindOneRecord } from '@shared/rpc-contracts/app-rpcs/templates.rpcs';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  templateAddonPurchaseTiming,
+  templateRegistrationOptionTitle,
+} from './template-details.component';
+
+const createTemplate = (): TemplateFindOneRecord => ({
+  addOns: [],
+  categoryId: 'category-1',
+  description: '<p>Template description</p>',
+  icon: {
+    iconColor: 0,
+    iconName: 'calendar:fas',
+  },
+  id: 'template-1',
+  location: null,
+  planningTips: null,
+  registrationOptions: [
+    {
+      closeRegistrationOffset: 24,
+      description: null,
+      esnCardDiscountedPrice: null,
+      id: 'template-option-1',
+      isPaid: false,
+      openRegistrationOffset: 168,
+      organizingRegistration: false,
+      price: 0,
+      registeredDescription: null,
+      registrationMode: 'fcfs',
+      roleIds: [],
+      roles: [],
+      spots: 20,
+      stripeTaxRateId: null,
+      title: 'Participant registration',
+    },
+  ],
+  title: 'Template',
+});
+
+describe('template detail add-on helpers', () => {
+  it('formats enabled purchase timing windows', () => {
+    expect(
+      templateAddonPurchaseTiming({
+        allowMultiple: true,
+        allowPurchaseBeforeEvent: true,
+        allowPurchaseDuringEvent: false,
+        allowPurchaseDuringRegistration: true,
+        description: null,
+        id: 'addon-1',
+        isPaid: false,
+        maxQuantityPerUser: 1,
+        price: 0,
+        registrationOptions: [],
+        stripeTaxRateId: null,
+        title: 'Dinner',
+        totalAvailableQuantity: 40,
+      }),
+    ).toBe('During registration, Before event');
+  });
+
+  it('marks add-ons without purchase windows as unavailable', () => {
+    expect(
+      templateAddonPurchaseTiming({
+        allowMultiple: false,
+        allowPurchaseBeforeEvent: false,
+        allowPurchaseDuringEvent: false,
+        allowPurchaseDuringRegistration: false,
+        description: null,
+        id: 'addon-1',
+        isPaid: false,
+        maxQuantityPerUser: 1,
+        price: 0,
+        registrationOptions: [],
+        stripeTaxRateId: null,
+        title: 'Dinner',
+        totalAvailableQuantity: 40,
+      }),
+    ).toBe('Unavailable');
+  });
+
+  it('resolves add-on registration option labels from the template record', () => {
+    expect(
+      templateRegistrationOptionTitle(createTemplate(), 'template-option-1'),
+    ).toBe('Participant registration');
+  });
+
+  it('keeps missing add-on registration option labels explicit', () => {
+    expect(
+      templateRegistrationOptionTitle(createTemplate(), 'missing-option'),
+    ).toBe('Unknown registration option');
+  });
+});

--- a/src/app/templates/template-details/template-details.component.ts
+++ b/src/app/templates/template-details/template-details.component.ts
@@ -1,4 +1,6 @@
-import { CommonModule, TitleCasePipe } from '@angular/common';
+import type { TemplateFindOneRecord } from '@shared/rpc-contracts/app-rpcs/templates.rpcs';
+
+import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -17,6 +19,7 @@ import {
   faEllipsisVertical,
   faPlus,
 } from '@fortawesome/duotone-regular-svg-icons';
+import { registrationModeLabel } from '@shared/registration-modes';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import { AppRpc } from '../../core/effect-rpc-angular-client';
@@ -24,6 +27,26 @@ import { getErrorMessage } from '../../core/error-message';
 import { IconComponent } from '../../shared/components/icon/icon.component';
 import { PriceWithTaxComponent } from '../../shared/components/inclusive-price-label/price-with-tax.component';
 import { RegistrationStartOffsetPipe } from '../../shared/pipes/registration-start-offset.pipe';
+
+export const templateAddonPurchaseTiming = (
+  addOn: TemplateFindOneRecord['addOns'][number],
+): string => {
+  const windows = [
+    addOn.allowPurchaseDuringRegistration ? 'During registration' : null,
+    addOn.allowPurchaseBeforeEvent ? 'Before event' : null,
+    addOn.allowPurchaseDuringEvent ? 'During event' : null,
+  ].filter((window): window is string => window !== null);
+
+  return windows.length > 0 ? windows.join(', ') : 'Unavailable';
+};
+
+export const templateRegistrationOptionTitle = (
+  template: TemplateFindOneRecord,
+  registrationOptionId: string,
+): string =>
+  template.registrationOptions.find(
+    (option) => option.id === registrationOptionId,
+  )?.title ?? 'Unknown registration option';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -35,7 +58,6 @@ import { RegistrationStartOffsetPipe } from '../../shared/pipes/registration-sta
     FontAwesomeModule,
     MatMenuModule,
     IconComponent,
-    TitleCasePipe,
     MatChipsModule,
     RegistrationStartOffsetPipe,
     PriceWithTaxComponent,
@@ -50,7 +72,9 @@ export class TemplateDetailsComponent {
   protected readonly faClockFour = faClockFour;
   protected readonly faEllipsisVertical = faEllipsisVertical;
   protected readonly faPlus = faPlus;
+  protected readonly registrationModeLabel = registrationModeLabel;
 
+  protected readonly registrationOptionTitle = templateRegistrationOptionTitle;
   private readonly rpc = AppRpc.injectClient();
   protected readonly taxRatesQuery = injectQuery(() =>
     this.rpc.taxRates.listActive.queryOptions(),
@@ -59,7 +83,10 @@ export class TemplateDetailsComponent {
     const rates = this.taxRatesQuery.data() ?? [];
     return Object.fromEntries(rates.map((r) => [r.stripeTaxRateId, r]));
   });
+  protected readonly templateAddonPurchaseTiming = templateAddonPurchaseTiming;
+
   protected readonly templateId = input.required<string>();
+
   protected readonly templateQuery = injectQuery(() =>
     this.rpc.templates.findOne.queryOptions({ id: this.templateId() }),
   );

--- a/src/app/templates/template-edit/template-edit.component.ts
+++ b/src/app/templates/template-edit/template-edit.component.ts
@@ -128,7 +128,7 @@ export class TemplateEditComponent {
     event.preventDefault();
     if (
       templateWriteSubmitDisabled({
-        formInvalid: this.templateForm().invalid(),
+        formInvalid: false,
         formSubmitting: this.templateForm().submitting(),
         mutationPending: this.updateTemplateMutation.isPending(),
       })

--- a/src/app/templates/template-edit/template-edit.component.ts
+++ b/src/app/templates/template-edit/template-edit.component.ts
@@ -24,6 +24,7 @@ import {
   TemplateFormData,
   TemplateFormOverrides,
   TemplateFormSubmitData,
+  templateWriteSubmitDisabled,
 } from '../shared/template-form/template-form.utilities';
 import { TemplateGeneralFormComponent } from '../shared/template-form/template-general-form.component';
 import { templateGeneralFormSchema } from '../shared/template-form/template-general-form.schema';
@@ -95,11 +96,18 @@ export class TemplateEditComponent {
     templateFormSchema,
   );
 
+  protected readonly updateTemplateMutation = injectMutation(() =>
+    this.rpc.templates.updateSimpleTemplate.mutationOptions(),
+  );
+
   protected readonly canSubmit = computed(
     () =>
       this.discountProvidersQuery.isSuccess() &&
-      !this.templateForm().invalid() &&
-      !this.templateForm().submitting(),
+      !templateWriteSubmitDisabled({
+        formInvalid: this.templateForm().invalid(),
+        formSubmitting: this.templateForm().submitting(),
+        mutationPending: this.updateTemplateMutation.isPending(),
+      }),
   );
 
   protected readonly esnEnabled = computed(() => {
@@ -110,19 +118,24 @@ export class TemplateEditComponent {
       'enabled'
     );
   });
-
   protected readonly faArrowLeft = faArrowLeft;
+
   protected readonly registrationModes: readonly RegistrationMode[] = ['fcfs'];
-
-  protected readonly updateTemplateMutation = injectMutation(() =>
-    this.rpc.templates.updateSimpleTemplate.mutationOptions(),
-  );
-
   private queryClient = inject(QueryClient);
   private router = inject(Router);
 
   async onSubmit(event: Event) {
     event.preventDefault();
+    if (
+      templateWriteSubmitDisabled({
+        formInvalid: this.templateForm().invalid(),
+        formSubmitting: this.templateForm().submitting(),
+        mutationPending: this.updateTemplateMutation.isPending(),
+      })
+    ) {
+      return;
+    }
+
     await submit(this.templateForm, async (formState) => {
       const formValue = formState().value();
       if (!formValue.icon) {

--- a/src/app/templates/template-list/template-list.component.html
+++ b/src/app/templates/template-list/template-list.component.html
@@ -16,7 +16,7 @@
         mat-icon-button
         [matMenuTriggerFor]="menu"
       >
-        <fa-icon [icon]="faEllipsisVertical" />
+        <fa-duotone-icon [icon]="faEllipsisVertical" />
       </button>
       <mat-menu #menu="matMenu">
         <a routerLink="categories" mat-menu-item>Manage categories</a>

--- a/src/app/templates/template-list/template-list.component.html
+++ b/src/app/templates/template-list/template-list.component.html
@@ -85,6 +85,6 @@
   mat-fab
   extended
 >
-  <mat-icon svgIcon="faPlus" />
+  <fa-duotone-icon [icon]="faPlus" />
   Create template
 </a>

--- a/src/app/templates/template-list/template-list.component.ts
+++ b/src/app/templates/template-list/template-list.component.ts
@@ -5,11 +5,13 @@ import {
   signal,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faEllipsisVertical } from '@fortawesome/duotone-regular-svg-icons';
+import {
+  faEllipsisVertical,
+  faPlus,
+} from '@fortawesome/duotone-regular-svg-icons';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import { AppRpc } from '../../core/effect-rpc-angular-client';
@@ -21,7 +23,6 @@ import { IconComponent } from '../../shared/components/icon/icon.component';
   imports: [
     RouterLink,
     MatButtonModule,
-    MatIconModule,
     FontAwesomeModule,
     MatMenuModule,
     IconComponent,
@@ -34,6 +35,7 @@ import { IconComponent } from '../../shared/components/icon/icon.component';
 })
 export class TemplateListComponent {
   protected readonly faEllipsisVertical = faEllipsisVertical;
+  protected readonly faPlus = faPlus;
   protected readonly outletActive = signal(false);
   private readonly rpc = AppRpc.injectClient();
   protected templateQuery = injectQuery(() =>

--- a/src/db/schema/template-event-addons.spec.ts
+++ b/src/db/schema/template-event-addons.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from '@effect/vitest';
+import { readFileSync } from 'node:fs';
+
+const readSource = (path: string) =>
+  readFileSync(new URL(path, import.meta.url), 'utf8');
+
+describe('template event add-on schema', () => {
+  it('keeps add-ons scoped to templates until event add-on fulfillment exists', () => {
+    const schemaIndexSource = readSource('index.ts');
+    const templateAddonSource = readSource('template-event-addons.ts');
+
+    expect(schemaIndexSource).toContain(
+      "export * from './template-event-addons'",
+    );
+    expect(templateAddonSource).toContain("pgTable('template_event_addons'");
+    expect(schemaIndexSource).not.toContain("export * from './event-addons'");
+  });
+
+  it('does not expose registration-question schemas yet', () => {
+    const schemaIndexSource = readSource('index.ts');
+
+    expect(schemaIndexSource).not.toContain('registration-question');
+    expect(schemaIndexSource).not.toContain('registration-questions');
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,7 @@ import { handleHealthzWebRequest } from './server/http/healthz.web-handler';
 import { handleQrRegistrationCodeWebRequest } from './server/http/qr-code.web-handler';
 import { applySecurityHeaders } from './server/http/security-headers';
 import { handleStripeWebhookWebRequest } from './server/http/stripe-webhook.web-handler';
+import { handleTenantBrandAssetWebRequest } from './server/http/tenant-brand-asset.web-handler';
 import { stripeClientLayer } from './server/stripe-client';
 
 const angularApp = new AngularAppEngine();
@@ -154,6 +155,28 @@ const extractRegistrationId = (
   }
 };
 
+const extractTenantBrandAsset = (
+  request: HttpServerRequest.HttpServerRequest,
+) => {
+  const requestUrl = toAbsoluteRequestUrl(request);
+  const match = /^\/tenant-assets\/([^/]+)\/([^/]+)\/([^/]+)$/.exec(
+    requestUrl.pathname,
+  );
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return;
+  }
+
+  try {
+    return {
+      fileName: decodeURIComponent(match[3]),
+      kind: decodeURIComponent(match[2]),
+      tenantId: decodeURIComponent(match[1]),
+    };
+  } catch {
+    return;
+  }
+};
+
 const renderSsr = (request: HttpServerRequest.HttpServerRequest) =>
   Effect.gen(function* () {
     const authSession = yield* loadAuthSession(request);
@@ -253,6 +276,22 @@ const qrCodeRouteLayer = HttpLayerRouter.add(
     }),
 );
 
+const tenantBrandAssetRouteLayer = HttpLayerRouter.add(
+  'GET',
+  '/tenant-assets/:tenantId/:kind/:fileName',
+  (request) =>
+    Effect.gen(function* () {
+      const asset = extractTenantBrandAsset(request);
+      if (!asset) {
+        return HttpServerResponse.text('Asset not found', { status: 404 });
+      }
+
+      const webResponse = yield* handleTenantBrandAssetWebRequest(asset);
+
+      return HttpServerResponse.fromWeb(webResponse);
+    }),
+);
+
 const stripeWebhookRouteLayer = HttpLayerRouter.add(
   'POST',
   '/webhooks/stripe',
@@ -321,6 +360,7 @@ const routesLayer = Layer.mergeAll(
   logoutRouteLayer,
   forwardLoginRouteLayer,
   qrCodeRouteLayer,
+  tenantBrandAssetRouteLayer,
   stripeWebhookRouteLayer,
   rpcRouteLayer,
   staticAndAngularCatchAllLayer,

--- a/src/server.ts
+++ b/src/server.ts
@@ -155,6 +155,17 @@ const extractRegistrationId = (
   }
 };
 
+const decodePathSegment = (value: string): string | undefined => {
+  try {
+    const decoded = decodeURIComponent(value);
+    return decoded.includes('/') || decoded.includes('\\')
+      ? undefined
+      : decoded;
+  } catch {
+    return;
+  }
+};
+
 const extractTenantBrandAsset = (
   request: HttpServerRequest.HttpServerRequest,
 ) => {
@@ -166,15 +177,18 @@ const extractTenantBrandAsset = (
     return;
   }
 
-  try {
-    return {
-      fileName: decodeURIComponent(match[3]),
-      kind: decodeURIComponent(match[2]),
-      tenantId: decodeURIComponent(match[1]),
-    };
-  } catch {
+  const tenantId = decodePathSegment(match[1]);
+  const kind = decodePathSegment(match[2]);
+  const fileName = decodePathSegment(match[3]);
+  if (!tenantId || !kind || !fileName) {
     return;
   }
+
+  return {
+    fileName,
+    kind,
+    tenantId,
+  };
 };
 
 const renderSsr = (request: HttpServerRequest.HttpServerRequest) =>

--- a/src/server/effect/rpc/handlers/admin.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/admin.handlers.spec.ts
@@ -287,4 +287,35 @@ describe('adminHandlers tenant settings', () => {
       expect(error.message).toBe('Invalid tenant brand assets');
     }),
   );
+
+  it.effect('rejects dot-segment tenant brand asset paths', () =>
+    Effect.gen(function* () {
+      const database = {
+        update: () => {
+          throw new Error('database should not be touched');
+        },
+      };
+
+      const error = yield* adminHandlers['admin.tenant.updateSettings'](
+        {
+          allowOther: true,
+          currency: 'EUR',
+          defaultLocation: null,
+          esnCardEnabled: false,
+          locale: 'en-GB',
+          logoUrl: '/tenant-assets/../logout',
+          receiptCountries: ['NL'],
+          theme: 'evorto',
+          timezone: 'Europe/Berlin',
+        },
+        { headers: createSettingsAdminHeaders() } as never,
+      ).pipe(
+        Effect.provide(Layer.succeed(Database, database as never)),
+        Effect.flip,
+      );
+
+      expect(error['_tag']).toBe('RpcBadRequestError');
+      expect(error.message).toBe('Invalid tenant brand assets');
+    }),
+  );
 });

--- a/src/server/effect/rpc/handlers/admin.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/admin.handlers.spec.ts
@@ -210,6 +210,53 @@ describe('adminHandlers tenant settings', () => {
     }),
   );
 
+  it.effect('preserves uploaded tenant brand asset route URLs', () =>
+    Effect.gen(function* () {
+      let capturedUpdate: Record<string, unknown> | undefined;
+      const updateQuery = {
+        returning: () =>
+          Effect.succeed([
+            {
+              id: 'tenant-1',
+            },
+          ]),
+        set: (value: Record<string, unknown>) => {
+          capturedUpdate = value;
+          return updateQuery;
+        },
+        where: () => updateQuery,
+      };
+      const database = {
+        update: () => updateQuery,
+      };
+
+      const result = yield* adminHandlers['admin.tenant.updateSettings'](
+        {
+          allowOther: true,
+          currency: 'EUR',
+          defaultLocation: null,
+          esnCardEnabled: false,
+          faviconUrl: ' /tenant-assets/tenant-1/favicon/favicon.ico ',
+          locale: 'en-GB',
+          logoUrl: '/tenant-assets/tenant-1/logo/logo.png',
+          receiptCountries: ['NL'],
+          theme: 'evorto',
+          timezone: 'Europe/Berlin',
+        },
+        { headers: createSettingsAdminHeaders() } as never,
+      ).pipe(Effect.provide(Layer.succeed(Database, database as never)));
+
+      expect(capturedUpdate).toMatchObject({
+        faviconUrl: '/tenant-assets/tenant-1/favicon/favicon.ico',
+        logoUrl: '/tenant-assets/tenant-1/logo/logo.png',
+      });
+      expect(result).toMatchObject({
+        faviconUrl: '/tenant-assets/tenant-1/favicon/favicon.ico',
+        logoUrl: '/tenant-assets/tenant-1/logo/logo.png',
+      });
+    }),
+  );
+
   it.effect('rejects invalid tenant brand asset URLs', () =>
     Effect.gen(function* () {
       const database = {

--- a/src/server/effect/rpc/handlers/admin.handlers.ts
+++ b/src/server/effect/rpc/handlers/admin.handlers.ts
@@ -29,6 +29,7 @@ import { ConfigPermissions } from '../../../../shared/rpc-contracts/app-rpcs/con
 import { Tenant } from '../../../../types/custom/tenant';
 import { normalizeEsnCardConfig } from '../../../discounts/discount-provider-config';
 import { StripeClient } from '../../../stripe-client';
+import { uploadTenantBrandAsset } from '../../../tenant-brand-assets';
 import {
   decodeRpcContextHeaderJson,
   RPC_CONTEXT_HEADERS,
@@ -70,6 +71,22 @@ const normalizeOptionalUrl = (
   }
 };
 
+const normalizeOptionalBrandAssetUrl = (
+  value: string | undefined,
+  fieldName: string,
+): null | string => {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  if (trimmedValue.startsWith('/tenant-assets/')) {
+    return trimmedValue;
+  }
+
+  return normalizeOptionalUrl(trimmedValue, fieldName);
+};
+
 const normalizeTenantLegalLinks = (input: {
   legalNoticeText?: string | undefined;
   legalNoticeUrl?: string | undefined;
@@ -93,8 +110,8 @@ const normalizeTenantBrandAssets = (input: {
   faviconUrl?: string | undefined;
   logoUrl?: string | undefined;
 }) => ({
-  faviconUrl: normalizeOptionalUrl(input.faviconUrl, 'faviconUrl'),
-  logoUrl: normalizeOptionalUrl(input.logoUrl, 'logoUrl'),
+  faviconUrl: normalizeOptionalBrandAssetUrl(input.faviconUrl, 'faviconUrl'),
+  logoUrl: normalizeOptionalBrandAssetUrl(input.logoUrl, 'logoUrl'),
 });
 
 const normalizeHubRoleRecord = (role: {
@@ -630,5 +647,22 @@ export const adminHandlers = {
       }
 
       return validatedTenant;
+    }),
+  'admin.tenant.uploadBrandAsset': (input, options) =>
+    Effect.gen(function* () {
+      yield* ensurePermission(options.headers, 'admin:changeSettings');
+      const tenant = decodeHeaderJson(
+        options.headers[RPC_CONTEXT_HEADERS.TENANT],
+        Tenant,
+      );
+
+      return yield* uploadTenantBrandAsset({
+        fileBase64: input.fileBase64,
+        fileName: input.fileName,
+        fileSizeBytes: input.fileSizeBytes,
+        kind: input.kind,
+        mimeType: input.mimeType,
+        tenantId: tenant.id,
+      });
     }),
 } satisfies Partial<AppRpcHandlers>;

--- a/src/server/effect/rpc/handlers/admin.handlers.ts
+++ b/src/server/effect/rpc/handlers/admin.handlers.ts
@@ -80,8 +80,23 @@ const normalizeOptionalBrandAssetUrl = (
     return null;
   }
 
-  if (trimmedValue.startsWith('/tenant-assets/')) {
-    return trimmedValue;
+  if (trimmedValue.startsWith('/')) {
+    const parsed = new URL(trimmedValue, 'https://tenant-assets.invalid');
+    if (
+      parsed.origin === 'https://tenant-assets.invalid' &&
+      parsed.pathname === trimmedValue &&
+      /^\/tenant-assets\/[^/]+\/(?:favicon|logo)\/[^/]+$/.test(
+        parsed.pathname,
+      ) &&
+      parsed.search === '' &&
+      parsed.hash === ''
+    ) {
+      return parsed.pathname;
+    }
+
+    throw new Error(
+      `${fieldName} must be an uploaded tenant asset path or a valid http or https URL`,
+    );
   }
 
   return normalizeOptionalUrl(trimmedValue, fieldName);

--- a/src/server/effect/rpc/handlers/events/events-lifecycle.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/events/events-lifecycle.handlers.spec.ts
@@ -312,7 +312,7 @@ describe('eventLifecycleHandlers', () => {
         const insertedRegistrationOptions =
           insertedRegistrationOptionValues.mock.calls[0]?.[0] ?? [];
         const secondInsertedOption = insertedRegistrationOptions[1];
-        expect(secondInsertedOption).toBeDefined();
+        expect(secondInsertedOption?.id).toEqual(expect.any(String));
         expect(insertedDiscountValues).toHaveBeenCalledWith([
           {
             discountedPrice: 500,

--- a/src/server/effect/rpc/handlers/events/events-lifecycle.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/events/events-lifecycle.handlers.spec.ts
@@ -328,6 +328,9 @@ describe('eventLifecycleHandlers', () => {
     () =>
       Effect.gen(function* () {
         const insertedDiscountValues = vi.fn(() => Effect.succeed());
+        const insertedRegistrationOptionValues = vi.fn((values) =>
+          Effect.succeed(values),
+        );
         const database = {
           insert: vi.fn((table) => {
             if (table === eventInstances) {
@@ -346,15 +349,7 @@ describe('eventLifecycleHandlers', () => {
 
             if (table === eventRegistrationOptions) {
               return {
-                values: vi.fn(() => ({
-                  returning: vi.fn(() =>
-                    Effect.succeed([
-                      {
-                        id: 'event-option-1',
-                      },
-                    ]),
-                  ),
-                })),
+                values: insertedRegistrationOptionValues,
               };
             }
 

--- a/src/server/effect/rpc/handlers/events/events-query.handlers.ts
+++ b/src/server/effect/rpc/handlers/events/events-query.handlers.ts
@@ -1,5 +1,8 @@
 import { RpcForbiddenError } from '@shared/errors/rpc-errors';
-import { includesPermission } from '@shared/permissions/permissions';
+import {
+  includesPermission,
+  type Permission,
+} from '@shared/permissions/permissions';
 import {
   EventConflictError,
   EventNotFoundError,
@@ -35,6 +38,9 @@ import {
   getEsnCardDiscountedPriceByOptionId,
   isEsnCardEnabled,
 } from './events.shared';
+
+const canInspectTenantEvents = (permissions: readonly Permission[]): boolean =>
+  includesPermission('globalAdmin:manageTenants', permissions);
 
 export const eventQueryHandlers = {
   'events.canOrganize': ({ eventId }, _options) =>
@@ -82,6 +88,7 @@ export const eventQueryHandlers = {
       const { tenant } = yield* RpcAccess.current();
       const { user } = yield* RpcAccess.current();
       const userPermissions = user?.permissions ?? [];
+      const canInspectAllTenantEvents = canInspectTenantEvents(userPermissions);
 
       if (user?.id !== input.userId) {
         yield* Effect.logWarning(
@@ -98,6 +105,7 @@ export const eventQueryHandlers = {
         input.status.length === 1 && input.status[0] === 'APPROVED';
       if (
         !onlyApprovedStatus &&
+        !canInspectAllTenantEvents &&
         !includesPermission('events:seeDrafts', userPermissions)
       ) {
         return yield* Effect.fail(
@@ -110,6 +118,7 @@ export const eventQueryHandlers = {
 
       if (
         input.includeUnlisted &&
+        !canInspectAllTenantEvents &&
         !includesPermission('events:seeUnlisted', userPermissions)
       ) {
         return yield* Effect.fail(
@@ -120,21 +129,22 @@ export const eventQueryHandlers = {
         );
       }
 
-      const rolesToFilterBy =
-        user?.roleIds ??
-        (yield* databaseEffect((database) =>
-          database.query.roles
-            .findMany({
-              columns: { id: true },
-              where: {
-                defaultUserRole: true,
-                tenantId: tenant.id,
-              },
-            })
-            .pipe(
-              Effect.map((roleRecords) => roleRecords.map((role) => role.id)),
-            ),
-        ));
+      const rolesToFilterBy = canInspectAllTenantEvents
+        ? []
+        : (user?.roleIds ??
+          (yield* databaseEffect((database) =>
+            database.query.roles
+              .findMany({
+                columns: { id: true },
+                where: {
+                  defaultUserRole: true,
+                  tenantId: tenant.id,
+                },
+              })
+              .pipe(
+                Effect.map((roleRecords) => roleRecords.map((role) => role.id)),
+              ),
+          )));
       const roleFilters =
         rolesToFilterBy.length > 0 ? [...rolesToFilterBy] : [''];
       const startAfter = new Date(input.startAfter);
@@ -172,23 +182,30 @@ export const eventQueryHandlers = {
               ...(input.includeUnlisted
                 ? []
                 : [eq(eventInstances.unlisted, false)]),
-              exists(
-                database
-                  .select()
-                  .from(eventRegistrationOptions)
-                  .where(
-                    and(
-                      eq(eventRegistrationOptions.eventId, eventInstances.id),
-                      or(
-                        sql`cardinality(${eventRegistrationOptions.roleIds}) = 0`,
-                        arrayOverlaps(
-                          eventRegistrationOptions.roleIds,
-                          roleFilters,
+              ...(canInspectAllTenantEvents
+                ? []
+                : [
+                    exists(
+                      database
+                        .select()
+                        .from(eventRegistrationOptions)
+                        .where(
+                          and(
+                            eq(
+                              eventRegistrationOptions.eventId,
+                              eventInstances.id,
+                            ),
+                            or(
+                              sql`cardinality(${eventRegistrationOptions.roleIds}) = 0`,
+                              arrayOverlaps(
+                                eventRegistrationOptions.roleIds,
+                                roleFilters,
+                              ),
+                            ),
+                          ),
                         ),
-                      ),
                     ),
-                  ),
-              ),
+                  ]),
             ),
           )
           .limit(input.limit)
@@ -225,22 +242,25 @@ export const eventQueryHandlers = {
     Effect.gen(function* () {
       const { tenant } = yield* RpcAccess.current();
       const { user } = yield* RpcAccess.current();
+      const userPermissions = user?.permissions ?? [];
+      const canInspectAllTenantEvents = canInspectTenantEvents(userPermissions);
 
-      const rolesToFilterBy =
-        user?.roleIds ??
-        (yield* databaseEffect((database) =>
-          database.query.roles
-            .findMany({
-              columns: { id: true },
-              where: {
-                defaultUserRole: true,
-                tenantId: tenant.id,
-              },
-            })
-            .pipe(
-              Effect.map((roleRecords) => roleRecords.map((role) => role.id)),
-            ),
-        ));
+      const rolesToFilterBy = canInspectAllTenantEvents
+        ? []
+        : (user?.roleIds ??
+          (yield* databaseEffect((database) =>
+            database.query.roles
+              .findMany({
+                columns: { id: true },
+                where: {
+                  defaultUserRole: true,
+                  tenantId: tenant.id,
+                },
+              })
+              .pipe(
+                Effect.map((roleRecords) => roleRecords.map((role) => role.id)),
+              ),
+          )));
 
       const event = yield* databaseEffect((database) =>
         database.query.eventInstances.findFirst({
@@ -279,13 +299,15 @@ export const eventQueryHandlers = {
                 stripeTaxRateId: true,
                 title: true,
               },
-              where: {
-                RAW: (table) =>
-                  sql`cardinality(${table.roleIds}) = 0 or ${arrayOverlaps(
-                    table.roleIds,
-                    [...rolesToFilterBy],
-                  )}`,
-              },
+              where: canInspectAllTenantEvents
+                ? undefined
+                : {
+                    RAW: (table) =>
+                      sql`cardinality(${table.roleIds}) = 0 or ${arrayOverlaps(
+                        table.roleIds,
+                        [...rolesToFilterBy],
+                      )}`,
+                  },
             },
             reviewer: {
               columns: {
@@ -303,7 +325,8 @@ export const eventQueryHandlers = {
       }
 
       const canSeeDrafts =
-        user && includesPermission('events:seeDrafts', user.permissions);
+        canInspectAllTenantEvents ||
+        (user && includesPermission('events:seeDrafts', user.permissions));
       const canReviewEvents =
         user && includesPermission('events:review', user.permissions);
       const canEditEvent_ = user

--- a/src/server/effect/rpc/handlers/events/events-registration.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/events/events-registration.handlers.spec.ts
@@ -5,6 +5,9 @@ import { Database } from '../../../../../db';
 import {
   eventRegistrationOptions,
   eventRegistrations,
+  rolesToTenantUsers,
+  users,
+  usersToTenants,
 } from '../../../../../db/schema';
 import { type Permission } from '../../../../../shared/permissions/permissions';
 import {
@@ -115,6 +118,358 @@ const nonConfirmedRegistrationStatuses = [
   'PENDING',
   'WAITLIST',
 ] as const;
+
+const expectCounterDecrement = (
+  updateSet: unknown,
+  field: 'confirmedSpots' | 'reservedSpots' | 'waitlistSpots',
+  amount: number,
+) => {
+  const sqlUpdate = (
+    updateSet as Record<string, { queryChunks?: readonly unknown[] }>
+  )[field];
+
+  expect(sqlUpdate).toEqual(
+    expect.objectContaining({
+      queryChunks: expect.arrayContaining([amount]),
+    }),
+  );
+};
+
+const createGuestCancellationDatabase = ({
+  status,
+}: {
+  status: 'CONFIRMED' | 'PENDING';
+}) => {
+  const updateSets: unknown[] = [];
+  const tx = {
+    update: (table: unknown) => ({
+      set: (values: unknown) => {
+        updateSets.push(values);
+        return {
+          where: () => ({
+            returning: () => {
+              if (
+                table === eventRegistrations ||
+                table === eventRegistrationOptions
+              ) {
+                return Effect.succeed([{ id: 'updated' }]);
+              }
+              return Effect.succeed([]);
+            },
+          }),
+        };
+      },
+    }),
+  };
+  const database = {
+    query: {
+      eventRegistrations: {
+        findFirst: () =>
+          Effect.succeed({
+            checkedInGuestCount: 0,
+            checkInTime: null,
+            event: {
+              start: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            },
+            guestCount: 2,
+            id: 'registration-1',
+            registrationOptionId: 'option-1',
+            status,
+            transactions: [],
+          }),
+      },
+    },
+    transaction: vi.fn((callback: (tx: typeof tx) => unknown) => callback(tx)),
+  };
+
+  return { database, updateSets };
+};
+
+const createTransferDatabase = ({
+  existingTargetRegistration = null,
+  organizerRegistrations = [
+    {
+      id: 'organizer-registration-1',
+      registrationOption: {
+        organizingRegistration: true,
+      },
+    },
+  ],
+  registration = {
+    appliedDiscountedPrice: null,
+    appliedDiscountType: null,
+    checkInTime: null,
+    event: {
+      start: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    },
+    eventId: 'event-1',
+    id: 'registration-1',
+    registrationOptionId: 'option-1',
+    status: 'CONFIRMED',
+    transactions: [],
+    userId: 'attendee-1',
+  },
+  registrationOptionRoleIds = ['participant-role-1'],
+  targetTenantUser = {
+    id: 'target-tenant-user-1',
+    roles: [{ id: 'participant-role-1' }],
+  },
+  targetUser = { id: 'target-user-1' },
+}: {
+  existingTargetRegistration?: null | { id: string };
+  organizerRegistrations?: readonly {
+    id: string;
+    registrationOption: {
+      organizingRegistration: boolean;
+    };
+  }[];
+  registration?: null | {
+    appliedDiscountedPrice: null | number;
+    appliedDiscountType: 'esnCard' | null;
+    checkInTime: Date | null;
+    event: null | { start: Date };
+    eventId: string;
+    id: string;
+    registrationOptionId: string;
+    status: 'CANCELLED' | 'CONFIRMED' | 'PENDING' | 'WAITLIST';
+    transactions: readonly {
+      amount: number;
+      status: 'cancelled' | 'pending' | 'successful';
+      type: 'other' | 'refund' | 'registration';
+    }[];
+    userId: string;
+  };
+  registrationOptionRoleIds?: string[];
+  targetTenantUser?: null | { id: string; roles: readonly { id: string }[] };
+  targetUser?: null | { id: string };
+} = {}) => {
+  const updateSets: unknown[] = [];
+  const database = {
+    query: {
+      eventRegistrationOptions: {
+        findFirst: () =>
+          Effect.succeed({
+            roleIds: registrationOptionRoleIds,
+          }),
+      },
+      eventRegistrations: {
+        findFirst: vi
+          .fn()
+          .mockReturnValueOnce(Effect.succeed(registration))
+          .mockReturnValueOnce(Effect.succeed(existingTargetRegistration)),
+        findMany: () => Effect.succeed(organizerRegistrations),
+      },
+      users: {
+        findFirst: () => Effect.succeed(targetUser),
+      },
+      usersToTenants: {
+        findFirst: () => Effect.succeed(targetTenantUser),
+      },
+    },
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: () => {
+            if (table === users) {
+              return Effect.succeed(targetUser ? [targetUser] : []);
+            }
+            return Effect.succeed([]);
+          },
+        }),
+      }),
+    }),
+    transaction: (run: (transaction: typeof tx) => Effect.Effect<unknown>) =>
+      run(tx),
+    update: (table: unknown) => ({
+      set: (values: unknown) => {
+        updateSets.push(values);
+        return {
+          where: () => ({
+            returning: () => {
+              if (table === eventRegistrations) {
+                return Effect.succeed([{ id: 'registration-1' }]);
+              }
+              return Effect.succeed([]);
+            },
+          }),
+        };
+      },
+    }),
+  };
+
+  return { database, updateSets };
+};
+
+const createTransferTargetsDatabase = ({
+  registrationOptionRoleIds = ['participant-role-1'],
+}: {
+  registrationOptionRoleIds?: string[];
+} = {}) => {
+  const tenantUserRows = [
+    {
+      email: 'current@example.com',
+      firstName: 'Current',
+      id: 'tenant-user-current',
+      lastName: 'Owner',
+      userId: 'attendee-1',
+    },
+    {
+      email: 'alex@example.com',
+      firstName: 'Alex',
+      id: 'tenant-user-eligible',
+      lastName: 'Able',
+      userId: 'target-user-1',
+    },
+    {
+      email: 'registered@example.com',
+      firstName: 'Already',
+      id: 'tenant-user-active',
+      lastName: 'Registered',
+      userId: 'already-registered-user',
+    },
+    {
+      email: 'other@example.com',
+      firstName: 'Other',
+      id: 'tenant-user-ineligible',
+      lastName: 'Role',
+      userId: 'other-user-1',
+    },
+  ];
+  const database = {
+    query: {
+      eventRegistrationOptions: {
+        findFirst: () =>
+          Effect.succeed({
+            roleIds: registrationOptionRoleIds,
+          }),
+      },
+      eventRegistrations: {
+        findFirst: () =>
+          Effect.succeed({
+            appliedDiscountedPrice: null,
+            appliedDiscountType: null,
+            checkInTime: null,
+            event: {
+              start: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            },
+            eventId: 'event-1',
+            id: 'registration-1',
+            registrationOptionId: 'option-1',
+            status: 'CONFIRMED',
+            transactions: [],
+            userId: 'attendee-1',
+          }),
+        findMany: vi
+          .fn()
+          .mockReturnValueOnce(
+            Effect.succeed([
+              {
+                id: 'organizer-registration-1',
+                registrationOption: {
+                  organizingRegistration: true,
+                },
+              },
+            ]),
+          )
+          .mockReturnValueOnce(
+            Effect.succeed([
+              {
+                userId: 'already-registered-user',
+              },
+            ]),
+          ),
+      },
+      usersToTenants: {
+        findMany: () =>
+          Effect.succeed([
+            {
+              id: 'tenant-user-current',
+              roles: [{ id: 'participant-role-1' }],
+              user: {
+                email: 'current@example.com',
+                firstName: 'Current',
+                id: 'attendee-1',
+                lastName: 'Owner',
+              },
+              userId: 'attendee-1',
+            },
+            {
+              id: 'tenant-user-eligible',
+              roles: [{ id: 'participant-role-1' }],
+              user: {
+                email: 'alex@example.com',
+                firstName: 'Alex',
+                id: 'target-user-1',
+                lastName: 'Able',
+              },
+              userId: 'target-user-1',
+            },
+            {
+              id: 'tenant-user-active',
+              roles: [{ id: 'participant-role-1' }],
+              user: {
+                email: 'registered@example.com',
+                firstName: 'Already',
+                id: 'already-registered-user',
+                lastName: 'Registered',
+              },
+              userId: 'already-registered-user',
+            },
+            {
+              id: 'tenant-user-ineligible',
+              roles: [{ id: 'other-role-1' }],
+              user: {
+                email: 'other@example.com',
+                firstName: 'Other',
+                id: 'other-user-1',
+                lastName: 'Role',
+              },
+              userId: 'other-user-1',
+            },
+          ]),
+      },
+    },
+    select: () => ({
+      from: (table: unknown) => {
+        if (table === usersToTenants) {
+          return {
+            innerJoin: () => ({
+              where: () => Effect.succeed(tenantUserRows),
+            }),
+          };
+        }
+
+        if (table === rolesToTenantUsers) {
+          return {
+            where: () =>
+              Effect.succeed([
+                {
+                  roleId: 'participant-role-1',
+                  userTenantId: 'tenant-user-current',
+                },
+                {
+                  roleId: 'participant-role-1',
+                  userTenantId: 'tenant-user-eligible',
+                },
+                {
+                  roleId: 'participant-role-1',
+                  userTenantId: 'tenant-user-active',
+                },
+                {
+                  roleId: 'other-role-1',
+                  userTenantId: 'tenant-user-ineligible',
+                },
+              ]),
+          };
+        }
+
+        throw new Error('Unexpected select table');
+      },
+    }),
+  };
+
+  return database;
+};
 
 describe('event registration cancellation handlers', () => {
   it.effect(
@@ -290,6 +645,24 @@ describe('event registration cancellation handlers', () => {
       }),
   );
 
+  it.effect(
+    'cancels confirmed guest registrations and releases buyer plus guest spots',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createGuestCancellationDatabase({
+          status: 'CONFIRMED',
+        });
+
+        yield* eventRegistrationHandlers['events.cancelRegistration'](
+          { registrationId: 'registration-1' },
+          { headers: {} } as never,
+        ).pipe(Effect.provide(createContextLayer({ database })));
+
+        expectCounterDecrement(updateSets[1], 'confirmedSpots', 3);
+        expect(database.transaction).toHaveBeenCalledOnce();
+      }),
+  );
+
   it.effect('cancels pending registrations and releases a reserved spot', () =>
     Effect.gen(function* () {
       const updateSets: unknown[] = [];
@@ -347,6 +720,24 @@ describe('event registration cancellation handlers', () => {
       ]);
       expect(database.transaction).toHaveBeenCalledOnce();
     }),
+  );
+
+  it.effect(
+    'cancels pending guest registrations and releases buyer plus guest reserved spots',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createGuestCancellationDatabase({
+          status: 'PENDING',
+        });
+
+        yield* eventRegistrationHandlers['events.cancelRegistration'](
+          { registrationId: 'registration-1' },
+          { headers: {} } as never,
+        ).pipe(Effect.provide(createContextLayer({ database })));
+
+        expectCounterDecrement(updateSets[1], 'reservedSpots', 3);
+        expect(database.transaction).toHaveBeenCalledOnce();
+      }),
   );
 
   it.effect('rejects checked-in registration cancellation', () =>
@@ -506,6 +897,399 @@ describe('event registration cancellation handlers', () => {
           expect.objectContaining({ waitlistSpots: expect.anything() }),
         ]);
         expect(database.transaction).toHaveBeenCalledOnce();
+      }),
+  );
+});
+
+describe('event registration transfer handlers', () => {
+  it.effect(
+    'returns eligible transfer targets for organizer-assisted transfer',
+    () =>
+      Effect.gen(function* () {
+        const result = yield* eventRegistrationHandlers[
+          'events.findTransferTargets'
+        ](
+          {
+            eventId: 'event-1',
+            registrationId: 'registration-1',
+            search: 'alex',
+          },
+          { headers: {} } as never,
+        ).pipe(
+          Effect.provide(
+            createContextLayer({ database: createTransferTargetsDatabase() }),
+          ),
+        );
+
+        expect(result).toEqual([
+          {
+            email: 'alex@example.com',
+            firstName: 'Alex',
+            id: 'target-user-1',
+            lastName: 'Able',
+          },
+        ]);
+      }),
+  );
+
+  it.effect(
+    'returns transfer targets for unrestricted registration options',
+    () =>
+      Effect.gen(function* () {
+        const result = yield* eventRegistrationHandlers[
+          'events.findTransferTargets'
+        ](
+          {
+            eventId: 'event-1',
+            registrationId: 'registration-1',
+            search: 'alex',
+          },
+          { headers: {} } as never,
+        ).pipe(
+          Effect.provide(
+            createContextLayer({
+              database: createTransferTargetsDatabase({
+                registrationOptionRoleIds: [],
+              }),
+            }),
+          ),
+        );
+
+        expect(result).toEqual([
+          {
+            email: 'alex@example.com',
+            firstName: 'Alex',
+            id: 'target-user-1',
+            lastName: 'Able',
+          },
+          {
+            email: 'other@example.com',
+            firstName: 'Other',
+            id: 'other-user-1',
+            lastName: 'Role',
+          },
+        ]);
+      }),
+  );
+
+  it.effect(
+    'allows event organizers to transfer a confirmed unpaid registration to another tenant user',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase();
+
+        yield* eventRegistrationHandlers['events.transferEventRegistration'](
+          {
+            eventId: 'event-1',
+            registrationId: 'registration-1',
+            targetUserId: 'target-user-1',
+          },
+          { headers: {} } as never,
+        ).pipe(Effect.provide(createContextLayer({ database })));
+
+        expect(updateSets).toEqual([{ userId: 'target-user-1' }]);
+      }),
+  );
+
+  it.effect(
+    'allows participants to transfer their own confirmed unpaid registration by target email',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase({
+          organizerRegistrations: [],
+        });
+
+        yield* eventRegistrationHandlers['events.transferMyRegistration'](
+          {
+            registrationId: 'registration-1',
+            targetEmail: ' TARGET@EXAMPLE.COM ',
+          },
+          { headers: {} } as never,
+        ).pipe(
+          Effect.provide(
+            createContextLayer({
+              database,
+              user: createUser({ id: 'attendee-1' }),
+            }),
+          ),
+        );
+
+        expect(updateSets).toEqual([{ userId: 'target-user-1' }]);
+      }),
+  );
+
+  it.effect('allows transfer to unrestricted registration options', () =>
+    Effect.gen(function* () {
+      const { database, updateSets } = createTransferDatabase({
+        registrationOptionRoleIds: [],
+        targetTenantUser: {
+          id: 'target-tenant-user-1',
+          roles: [],
+        },
+      });
+
+      yield* eventRegistrationHandlers['events.transferEventRegistration'](
+        {
+          eventId: 'event-1',
+          registrationId: 'registration-1',
+          targetUserId: 'target-user-1',
+        },
+        { headers: {} } as never,
+      ).pipe(Effect.provide(createContextLayer({ database })));
+
+      expect(updateSets).toEqual([{ userId: 'target-user-1' }]);
+    }),
+  );
+
+  it.effect(
+    'rejects participant transfer when the target email is not an existing user',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase({
+          targetUser: null,
+        });
+
+        const error = yield* eventRegistrationHandlers[
+          'events.transferMyRegistration'
+        ](
+          {
+            registrationId: 'registration-1',
+            targetEmail: 'missing@example.com',
+          },
+          { headers: {} } as never,
+        ).pipe(
+          Effect.flip,
+          Effect.provide(
+            createContextLayer({
+              database,
+              user: createUser({ id: 'attendee-1' }),
+            }),
+          ),
+        );
+
+        expect(error['_tag']).toBe('EventRegistrationNotFoundError');
+        expect(error.message).toBe('Target user not found');
+        expect(updateSets).toEqual([]);
+      }),
+  );
+
+  it.effect(
+    'does not reveal existing users outside the tenant during participant transfer',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase({
+          targetTenantUser: null,
+        });
+
+        const error = yield* eventRegistrationHandlers[
+          'events.transferMyRegistration'
+        ](
+          {
+            registrationId: 'registration-1',
+            targetEmail: 'target@example.com',
+          },
+          { headers: {} } as never,
+        ).pipe(
+          Effect.flip,
+          Effect.provide(
+            createContextLayer({
+              database,
+              user: createUser({ id: 'attendee-1' }),
+            }),
+          ),
+        );
+
+        expect(error['_tag']).toBe('EventRegistrationNotFoundError');
+        expect(error.message).toBe('Target user not found');
+        expect(updateSets).toEqual([]);
+      }),
+  );
+
+  it.effect('rejects transfer without organizer access', () =>
+    Effect.gen(function* () {
+      const { database, updateSets } = createTransferDatabase({
+        organizerRegistrations: [],
+      });
+
+      const error = yield* eventRegistrationHandlers[
+        'events.transferEventRegistration'
+      ](
+        {
+          eventId: 'event-1',
+          registrationId: 'registration-1',
+          targetUserId: 'target-user-1',
+        },
+        { headers: {} } as never,
+      ).pipe(Effect.flip, Effect.provide(createContextLayer({ database })));
+
+      expect(error['_tag']).toBe('RpcForbiddenError');
+      expect(updateSets).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    'rejects paid registration transfer until refund and resale handling exists',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase({
+          registration: {
+            appliedDiscountedPrice: null,
+            appliedDiscountType: null,
+            checkInTime: null,
+            event: {
+              start: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            },
+            eventId: 'event-1',
+            id: 'registration-1',
+            registrationOptionId: 'option-1',
+            status: 'CONFIRMED',
+            transactions: [
+              {
+                amount: 1200,
+                status: 'successful',
+                type: 'registration',
+              },
+            ],
+            userId: 'attendee-1',
+          },
+        });
+
+        const error = yield* eventRegistrationHandlers[
+          'events.transferEventRegistration'
+        ](
+          {
+            eventId: 'event-1',
+            registrationId: 'registration-1',
+            targetUserId: 'target-user-1',
+          },
+          { headers: {} } as never,
+        ).pipe(Effect.flip, Effect.provide(createContextLayer({ database })));
+
+        expect(error['_tag']).toBe('EventRegistrationConflictError');
+        expect(error.message).toBe(
+          'Paid registration transfer is not available until the refund/resale flow is implemented',
+        );
+        expect(updateSets).toEqual([]);
+      }),
+  );
+
+  it.effect(
+    'rejects discounted registration transfer until target discount validation exists',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase({
+          registration: {
+            appliedDiscountedPrice: 0,
+            appliedDiscountType: 'esnCard',
+            checkInTime: null,
+            event: {
+              start: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            },
+            eventId: 'event-1',
+            id: 'registration-1',
+            registrationOptionId: 'option-1',
+            status: 'CONFIRMED',
+            transactions: [],
+            userId: 'attendee-1',
+          },
+        });
+
+        const error = yield* eventRegistrationHandlers[
+          'events.transferEventRegistration'
+        ](
+          {
+            eventId: 'event-1',
+            registrationId: 'registration-1',
+            targetUserId: 'target-user-1',
+          },
+          { headers: {} } as never,
+        ).pipe(Effect.flip, Effect.provide(createContextLayer({ database })));
+
+        expect(error['_tag']).toBe('EventRegistrationConflictError');
+        expect(error.message).toBe(
+          'Discounted registration transfer is not available until transfer discount validation is implemented',
+        );
+        expect(updateSets).toEqual([]);
+      }),
+  );
+
+  it.effect('rejects transfer when the target user is not role-eligible', () =>
+    Effect.gen(function* () {
+      const { database, updateSets } = createTransferDatabase({
+        targetTenantUser: {
+          id: 'target-tenant-user-1',
+          roles: [{ id: 'other-role-1' }],
+        },
+      });
+
+      const error = yield* eventRegistrationHandlers[
+        'events.transferEventRegistration'
+      ](
+        {
+          eventId: 'event-1',
+          registrationId: 'registration-1',
+          targetUserId: 'target-user-1',
+        },
+        { headers: {} } as never,
+      ).pipe(Effect.flip, Effect.provide(createContextLayer({ database })));
+
+      expect(error['_tag']).toBe('EventRegistrationConflictError');
+      expect(error.message).toBe(
+        'Target user is not eligible for this registration option',
+      );
+      expect(updateSets).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    'rejects transfer when the target user is outside the current tenant',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase({
+          targetTenantUser: null,
+        });
+
+        const error = yield* eventRegistrationHandlers[
+          'events.transferEventRegistration'
+        ](
+          {
+            eventId: 'event-1',
+            registrationId: 'registration-1',
+            targetUserId: 'target-user-1',
+          },
+          { headers: {} } as never,
+        ).pipe(Effect.flip, Effect.provide(createContextLayer({ database })));
+
+        expect(error['_tag']).toBe('EventRegistrationNotFoundError');
+        expect(error.message).toBe('Target tenant user not found');
+        expect(updateSets).toEqual([]);
+      }),
+  );
+
+  it.effect(
+    'rejects transfer when the target already has an active registration',
+    () =>
+      Effect.gen(function* () {
+        const { database, updateSets } = createTransferDatabase({
+          existingTargetRegistration: { id: 'target-registration-1' },
+        });
+
+        const error = yield* eventRegistrationHandlers[
+          'events.transferEventRegistration'
+        ](
+          {
+            eventId: 'event-1',
+            registrationId: 'registration-1',
+            targetUserId: 'target-user-1',
+          },
+          { headers: {} } as never,
+        ).pipe(Effect.flip, Effect.provide(createContextLayer({ database })));
+
+        expect(error['_tag']).toBe('EventRegistrationConflictError');
+        expect(error.message).toBe(
+          'Target user already has an active registration',
+        );
+        expect(updateSets).toEqual([]);
       }),
   );
 });

--- a/src/server/effect/rpc/handlers/events/events-registration.handlers.ts
+++ b/src/server/effect/rpc/handlers/events/events-registration.handlers.ts
@@ -6,12 +6,24 @@ import {
   includesPermission,
   type Permission,
 } from '@shared/permissions/permissions';
+import { registrationSpotCount } from '@shared/registration-spots';
 import {
   EventRegistrationConflictError,
   EventRegistrationInternalError,
   EventRegistrationNotFoundError,
 } from '@shared/rpc-contracts/app-rpcs/events.errors';
-import { and, eq, gte, isNull, sql } from 'drizzle-orm';
+import {
+  and,
+  eq,
+  gte,
+  ilike,
+  inArray,
+  isNull,
+  not,
+  notExists,
+  sql,
+} from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { Effect } from 'effect';
 
 import type { AppRpcHandlers } from '../shared/handler-types';
@@ -20,7 +32,10 @@ import { Database } from '../../../../../db';
 import {
   eventRegistrationOptions,
   eventRegistrations,
+  rolesToTenantUsers,
   transactions,
+  users,
+  usersToTenants,
 } from '../../../../../db/schema';
 import { StripeClient } from '../../../../stripe-client';
 import { RpcAccess } from '../shared/rpc-access.service';
@@ -55,6 +70,30 @@ const CHECK_IN_PRE_START_WINDOW_MS = 60 * 60 * 1000;
 
 const isWithinCheckInWindow = (eventStart: Date, now = new Date()): boolean =>
   eventStart.getTime() - now.getTime() <= CHECK_IN_PRE_START_WINDOW_MS;
+
+const normalizeTransferTargetSearch = (search: string | undefined) =>
+  search?.trim().toLowerCase() ?? '';
+
+const hasSuccessfulPaidRegistrationTransaction = (
+  transactionsToCheck: readonly {
+    amount: number;
+    status: string;
+    type: string;
+  }[],
+) =>
+  transactionsToCheck.some(
+    (transaction) =>
+      transaction.type === 'registration' &&
+      transaction.status === 'successful' &&
+      transaction.amount > 0,
+  );
+
+const hasAppliedRegistrationDiscount = (registration: {
+  appliedDiscountedPrice: null | number;
+  appliedDiscountType: null | string;
+}) =>
+  registration.appliedDiscountedPrice !== null ||
+  registration.appliedDiscountType !== null;
 
 const ensureCanScanEventRegistration = ({
   eventId,
@@ -214,7 +253,7 @@ const cancelRegistration = ({
         }),
       );
     }
-    const registeredSpotCount = registration.guestCount + 1;
+    const registeredSpotCount = registrationSpotCount(registration.guestCount);
 
     const pendingStripeTransaction = registration.transactions.find(
       (currentTransaction) =>
@@ -374,6 +413,263 @@ const cancelRegistration = ({
       ),
       Effect.catch(() => Effect.void),
     );
+  });
+
+const transferEventRegistration = ({
+  eventId,
+  registrationId,
+  requireOrganizerAccess = true,
+  targetUserId,
+}: {
+  eventId?: string;
+  registrationId: string;
+  requireOrganizerAccess?: boolean;
+  targetUserId: string;
+}) =>
+  Effect.gen(function* () {
+    yield* RpcAccess.ensureAuthenticated();
+    const { tenant } = yield* RpcAccess.current();
+    const user = yield* RpcAccess.requireUser();
+    const now = new Date();
+
+    const registration = yield* databaseEffect((database) =>
+      database.query.eventRegistrations.findFirst({
+        columns: {
+          appliedDiscountedPrice: true,
+          appliedDiscountType: true,
+          checkInTime: true,
+          eventId: true,
+          id: true,
+          registrationOptionId: true,
+          status: true,
+          userId: true,
+        },
+        where: {
+          ...(eventId ? { eventId } : {}),
+          id: registrationId,
+          status: { NOT: 'CANCELLED' },
+          tenantId: tenant.id,
+          ...(requireOrganizerAccess ? {} : { userId: user.id }),
+        },
+        with: {
+          event: {
+            columns: {
+              start: true,
+            },
+          },
+          transactions: {
+            columns: {
+              amount: true,
+              status: true,
+              type: true,
+            },
+          },
+        },
+      }),
+    );
+
+    if (!registration) {
+      return yield* Effect.fail(
+        new EventRegistrationNotFoundError({
+          message: 'Registration not found',
+        }),
+      );
+    }
+
+    if (requireOrganizerAccess) {
+      yield* ensureCanScanEventRegistration({
+        eventId: registration.eventId,
+        tenantId: tenant.id,
+        user,
+      });
+    }
+
+    if (registration.status !== 'CONFIRMED') {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message: 'Only confirmed registrations can be transferred',
+        }),
+      );
+    }
+
+    if (!registration.event) {
+      return yield* Effect.fail(
+        new EventRegistrationInternalError({
+          message: 'Registration event relation missing',
+        }),
+      );
+    }
+
+    if (registration.checkInTime) {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message: 'Checked-in registrations cannot be transferred',
+        }),
+      );
+    }
+
+    if (registration.event.start <= now) {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message: 'Registration can no longer be transferred',
+        }),
+      );
+    }
+
+    if (registration.userId === targetUserId) {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message: 'Registration is already assigned to this user',
+        }),
+      );
+    }
+
+    if (hasSuccessfulPaidRegistrationTransaction(registration.transactions)) {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message:
+            'Paid registration transfer is not available until the refund/resale flow is implemented',
+        }),
+      );
+    }
+
+    if (hasAppliedRegistrationDiscount(registration)) {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message:
+            'Discounted registration transfer is not available until transfer discount validation is implemented',
+        }),
+      );
+    }
+
+    const targetTenantUser = yield* databaseEffect((database) =>
+      database.query.usersToTenants.findFirst({
+        columns: {
+          id: true,
+        },
+        where: {
+          tenantId: tenant.id,
+          userId: targetUserId,
+        },
+        with: {
+          roles: {
+            columns: {
+              id: true,
+            },
+          },
+        },
+      }),
+    );
+
+    if (!targetTenantUser) {
+      return yield* Effect.fail(
+        new EventRegistrationNotFoundError({
+          message: 'Target tenant user not found',
+        }),
+      );
+    }
+
+    const targetRoleIds = new Set(
+      targetTenantUser.roles.map((role) => role.id),
+    );
+    const registrationOption = yield* databaseEffect((database) =>
+      database.query.eventRegistrationOptions.findFirst({
+        columns: {
+          roleIds: true,
+        },
+        where: {
+          eventId: registration.eventId,
+          id: registration.registrationOptionId,
+        },
+      }),
+    );
+    if (!registrationOption) {
+      return yield* Effect.fail(
+        new EventRegistrationInternalError({
+          message: 'Registration option missing',
+        }),
+      );
+    }
+
+    const targetEligible =
+      registrationOption.roleIds.length === 0 ||
+      registrationOption.roleIds.some((roleId) => targetRoleIds.has(roleId));
+    if (!targetEligible) {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message: 'Target user is not eligible for this registration option',
+        }),
+      );
+    }
+
+    const existingTargetRegistration = yield* databaseEffect((database) =>
+      database.query.eventRegistrations.findFirst({
+        columns: {
+          id: true,
+        },
+        where: {
+          eventId: registration.eventId,
+          status: { NOT: 'CANCELLED' },
+          tenantId: tenant.id,
+          userId: targetUserId,
+        },
+      }),
+    );
+
+    if (existingTargetRegistration) {
+      return yield* Effect.fail(
+        new EventRegistrationConflictError({
+          message: 'Target user already has an active registration',
+        }),
+      );
+    }
+
+    const transferredRegistrations = yield* databaseEffect((database) => {
+      const targetRegistrations = alias(
+        eventRegistrations,
+        'target_registrations',
+      );
+      return database
+        .update(eventRegistrations)
+        .set({
+          userId: targetUserId,
+        })
+        .where(
+          and(
+            eq(eventRegistrations.id, registration.id),
+            eq(eventRegistrations.tenantId, tenant.id),
+            eq(eventRegistrations.status, 'CONFIRMED'),
+            not(eq(eventRegistrations.userId, targetUserId)),
+            notExists(
+              database
+                .select({ id: targetRegistrations.id })
+                .from(targetRegistrations)
+                .where(
+                  and(
+                    eq(targetRegistrations.tenantId, tenant.id),
+                    eq(targetRegistrations.eventId, registration.eventId),
+                    eq(targetRegistrations.userId, targetUserId),
+                    not(eq(targetRegistrations.status, 'CANCELLED')),
+                  ),
+                ),
+            ),
+            ...(requireOrganizerAccess
+              ? []
+              : [eq(eventRegistrations.userId, user.id)]),
+          ),
+        )
+        .returning({
+          id: eventRegistrations.id,
+        });
+    });
+
+    if (transferredRegistrations.length === 0) {
+      return yield* Effect.fail(
+        new EventRegistrationNotFoundError({
+          message: 'Registration not found',
+        }),
+      );
+    }
   });
 
 export const eventRegistrationHandlers = {
@@ -596,6 +892,233 @@ export const eventRegistrationHandlers = {
         checkInTime: checkedInRegistration.checkInTime.toISOString(),
       };
     }).pipe(Effect.catch(mapRegistrationScanInternalError)),
+  'events.findTransferTargets': (
+    { eventId, registrationId, search },
+    _options,
+  ) =>
+    Effect.gen(function* () {
+      yield* RpcAccess.ensureAuthenticated();
+      const { tenant } = yield* RpcAccess.current();
+      const user = yield* RpcAccess.requireUser();
+      const now = new Date();
+      const normalizedSearch = normalizeTransferTargetSearch(search);
+
+      const registration = yield* databaseEffect((database) =>
+        database.query.eventRegistrations.findFirst({
+          columns: {
+            appliedDiscountedPrice: true,
+            appliedDiscountType: true,
+            checkInTime: true,
+            eventId: true,
+            id: true,
+            registrationOptionId: true,
+            status: true,
+            userId: true,
+          },
+          where: {
+            eventId,
+            id: registrationId,
+            status: { NOT: 'CANCELLED' },
+            tenantId: tenant.id,
+          },
+          with: {
+            event: {
+              columns: {
+                start: true,
+              },
+            },
+            transactions: {
+              columns: {
+                amount: true,
+                status: true,
+                type: true,
+              },
+            },
+          },
+        }),
+      );
+
+      if (!registration) {
+        return yield* Effect.fail(
+          new EventRegistrationNotFoundError({
+            message: 'Registration not found',
+          }),
+        );
+      }
+
+      yield* ensureCanScanEventRegistration({
+        eventId: registration.eventId,
+        tenantId: tenant.id,
+        user,
+      });
+
+      if (registration.status !== 'CONFIRMED') {
+        return yield* Effect.fail(
+          new EventRegistrationConflictError({
+            message: 'Only confirmed registrations can be transferred',
+          }),
+        );
+      }
+
+      if (!registration.event) {
+        return yield* Effect.fail(
+          new EventRegistrationInternalError({
+            message: 'Registration event relation missing',
+          }),
+        );
+      }
+
+      if (registration.checkInTime) {
+        return yield* Effect.fail(
+          new EventRegistrationConflictError({
+            message: 'Checked-in registrations cannot be transferred',
+          }),
+        );
+      }
+
+      if (registration.event.start <= now) {
+        return yield* Effect.fail(
+          new EventRegistrationConflictError({
+            message: 'Registration can no longer be transferred',
+          }),
+        );
+      }
+
+      if (
+        registration.transactions.some(
+          (transaction) =>
+            transaction.type === 'registration' &&
+            transaction.status === 'successful' &&
+            transaction.amount > 0,
+        )
+      ) {
+        return yield* Effect.fail(
+          new EventRegistrationConflictError({
+            message:
+              'Paid registration transfer is not available until the refund/resale flow is implemented',
+          }),
+        );
+      }
+
+      if (hasAppliedRegistrationDiscount(registration)) {
+        return yield* Effect.fail(
+          new EventRegistrationConflictError({
+            message:
+              'Discounted registration transfer is not available until transfer discount validation is implemented',
+          }),
+        );
+      }
+
+      const registrationOption = yield* databaseEffect((database) =>
+        database.query.eventRegistrationOptions.findFirst({
+          columns: {
+            roleIds: true,
+          },
+          where: {
+            eventId: registration.eventId,
+            id: registration.registrationOptionId,
+          },
+        }),
+      );
+      if (!registrationOption) {
+        return yield* Effect.fail(
+          new EventRegistrationInternalError({
+            message: 'Registration option missing',
+          }),
+        );
+      }
+
+      const activeRegistrations = yield* databaseEffect((database) =>
+        database.query.eventRegistrations.findMany({
+          columns: {
+            userId: true,
+          },
+          where: {
+            eventId: registration.eventId,
+            status: { NOT: 'CANCELLED' },
+            tenantId: tenant.id,
+          },
+        }),
+      );
+      const activeUserIds = new Set(
+        activeRegistrations.map(
+          (activeRegistration) => activeRegistration.userId,
+        ),
+      );
+
+      const tenantUsers = yield* databaseEffect((database) =>
+        database
+          .select({
+            email: users.email,
+            firstName: users.firstName,
+            id: usersToTenants.id,
+            lastName: users.lastName,
+            userId: usersToTenants.userId,
+          })
+          .from(usersToTenants)
+          .innerJoin(users, eq(usersToTenants.userId, users.id))
+          .where(
+            normalizedSearch
+              ? and(
+                  eq(usersToTenants.tenantId, tenant.id),
+                  ilike(users.searchableInfo, `%${normalizedSearch}%`),
+                )
+              : eq(usersToTenants.tenantId, tenant.id),
+          ),
+      );
+      const tenantUserIds = tenantUsers.map((tenantUser) => tenantUser.id);
+      const tenantUserRoles =
+        tenantUserIds.length > 0
+          ? yield* databaseEffect((database) =>
+              database
+                .select({
+                  roleId: rolesToTenantUsers.roleId,
+                  userTenantId: rolesToTenantUsers.userTenantId,
+                })
+                .from(rolesToTenantUsers)
+                .where(inArray(rolesToTenantUsers.userTenantId, tenantUserIds)),
+            )
+          : [];
+      const roleIdsByTenantUserId = new Map<string, Set<string>>();
+      for (const tenantUserRole of tenantUserRoles) {
+        const roleIds =
+          roleIdsByTenantUserId.get(tenantUserRole.userTenantId) ?? new Set();
+        roleIds.add(tenantUserRole.roleId);
+        roleIdsByTenantUserId.set(tenantUserRole.userTenantId, roleIds);
+      }
+
+      return tenantUsers
+        .filter((tenantUser) => {
+          if (tenantUser.userId === registration.userId) {
+            return false;
+          }
+          if (activeUserIds.has(tenantUser.userId)) {
+            return false;
+          }
+
+          const roleIds = roleIdsByTenantUserId.get(tenantUser.id) ?? new Set();
+          const roleEligible =
+            registrationOption.roleIds.length === 0 ||
+            registrationOption.roleIds.some((roleId) => roleIds.has(roleId));
+          if (!roleEligible) {
+            return false;
+          }
+          return true;
+        })
+        .map((tenantUser) => ({
+          email: tenantUser.email,
+          firstName: tenantUser.firstName,
+          id: tenantUser.userId,
+          lastName: tenantUser.lastName,
+        }))
+        .toSorted((userA, userB) => {
+          const lastNameCompare = userA.lastName.localeCompare(userB.lastName);
+          return lastNameCompare === 0
+            ? userA.firstName.localeCompare(userB.firstName)
+            : lastNameCompare;
+        })
+        .slice(0, 25);
+    }),
   'events.getRegistrationStatus': ({ eventId }, _options) =>
     Effect.gen(function* () {
       const { tenant } = yield* RpcAccess.current();
@@ -613,6 +1136,7 @@ export const eventRegistrationHandlers = {
             appliedDiscountedPrice: true,
             appliedDiscountType: true,
             basePriceAtRegistration: true,
+            checkInTime: true,
             discountAmount: true,
             guestCount: true,
             id: true,
@@ -628,6 +1152,11 @@ export const eventRegistrationHandlers = {
             userId: user.id,
           },
           with: {
+            event: {
+              columns: {
+                start: true,
+              },
+            },
             registrationOption: {
               columns: {
                 price: true,
@@ -701,6 +1230,15 @@ export const eventRegistrationHandlers = {
           registrationOptionId: registration.registrationOptionId,
           registrationOptionTitle: registrationOption.title,
           status: registration.status,
+          transferAvailable:
+            registration.status === 'CONFIRMED' &&
+            registration.checkInTime === null &&
+            !!registration.event &&
+            registration.event.start > new Date() &&
+            !hasAppliedRegistrationDiscount(registration) &&
+            !hasSuccessfulPaidRegistrationTransaction(
+              registration.transactions,
+            ),
         };
       });
 
@@ -870,4 +1408,62 @@ export const eventRegistrationHandlers = {
         },
       };
     }).pipe(Effect.catch(mapRegistrationScanInternalError)),
+  'events.transferEventRegistration': (
+    { eventId, registrationId, targetUserId },
+    _options,
+  ) =>
+    transferEventRegistration({
+      eventId,
+      registrationId,
+      targetUserId,
+    }),
+  'events.transferMyRegistration': (
+    { registrationId, targetEmail },
+    _options,
+  ) =>
+    Effect.gen(function* () {
+      yield* RpcAccess.ensureAuthenticated();
+      const normalizedTargetEmail = targetEmail.trim().toLowerCase();
+
+      if (!normalizedTargetEmail) {
+        return yield* Effect.fail(
+          new EventRegistrationNotFoundError({
+            message: 'Target user not found',
+          }),
+        );
+      }
+
+      const targetUsers = yield* databaseEffect((database) =>
+        database
+          .select({ id: users.id })
+          .from(users)
+          .where(sql`lower(${users.email}) = ${normalizedTargetEmail}`)
+          .limit(1),
+      );
+      const targetUser = targetUsers[0];
+
+      if (!targetUser) {
+        return yield* Effect.fail(
+          new EventRegistrationNotFoundError({
+            message: 'Target user not found',
+          }),
+        );
+      }
+
+      return yield* transferEventRegistration({
+        registrationId,
+        requireOrganizerAccess: false,
+        targetUserId: targetUser.id,
+      }).pipe(
+        Effect.catchTag('EventRegistrationNotFoundError', (error) =>
+          error.message === 'Target tenant user not found'
+            ? Effect.fail(
+                new EventRegistrationNotFoundError({
+                  message: 'Target user not found',
+                }),
+              )
+            : Effect.fail(error),
+        ),
+      );
+    }),
 } satisfies Partial<AppRpcHandlers>;

--- a/src/server/effect/rpc/handlers/events/events-rpcs.schema.spec.ts
+++ b/src/server/effect/rpc/handlers/events/events-rpcs.schema.spec.ts
@@ -52,6 +52,7 @@ describe('events RPC registration status schema', () => {
         registrationOptionId: 'option-1',
         registrationOptionTitle: 'Participant',
         status: 'UNKNOWN',
+        transferAvailable: false,
       }),
     ).toThrow();
   });

--- a/src/server/effect/rpc/handlers/events/events.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/events/events.handlers.spec.ts
@@ -14,6 +14,7 @@ describe('eventHandlers composition', () => {
       'events.eventList',
       'events.findOne',
       'events.findOneForEdit',
+      'events.findTransferTargets',
       'events.getOrganizeOverview',
       'events.getPendingReviews',
       'events.getRegistrationStatus',
@@ -22,6 +23,8 @@ describe('eventHandlers composition', () => {
       'events.registrationScanned',
       'events.reviewEvent',
       'events.submitForReview',
+      'events.transferEventRegistration',
+      'events.transferMyRegistration',
       'events.update',
       'events.updateListing',
     ]);

--- a/src/server/effect/rpc/handlers/finance/finance-receipts.handlers.ts
+++ b/src/server/effect/rpc/handlers/finance/finance-receipts.handlers.ts
@@ -716,7 +716,6 @@ export const financeReceiptsHandlers = {
       const event = yield* databaseEffect((database) =>
         database.query.eventInstances.findFirst({
           columns: {
-            end: true,
             id: true,
           },
           where: {
@@ -731,14 +730,6 @@ export const financeReceiptsHandlers = {
             id: input.eventId,
             message: 'Event not found for receipt submission',
             resource: 'event',
-          }),
-        );
-      }
-      if (event.end > new Date()) {
-        return yield* Effect.fail(
-          new RpcBadRequestError({
-            message: 'Receipts can only be submitted after the event ends',
-            reason: 'event_not_finished',
           }),
         );
       }

--- a/src/server/effect/rpc/handlers/finance/finance.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/finance/finance.handlers.spec.ts
@@ -137,6 +137,25 @@ const databaseWithTenantEvent = (event: { end?: Date; id?: string } = {}) => ({
   },
 });
 
+const databaseWithReceiptInsert = (event: { end?: Date; id?: string } = {}) => {
+  let insertedValues: unknown;
+  const insertQuery = {
+    returning: () => Effect.succeed([{ id: 'receipt-1' }]),
+    values: (values: unknown) => {
+      insertedValues = values;
+      return insertQuery;
+    },
+  };
+
+  return {
+    database: {
+      ...databaseWithTenantEvent(event),
+      insert: () => insertQuery,
+    },
+    insertedValues: () => insertedValues,
+  };
+};
+
 const databaseWithSubmittedReceipt = () => ({
   query: {
     financeReceipts: {
@@ -365,32 +384,32 @@ describe('finance transaction permissions', () => {
 });
 
 describe('finance receipt amount validation', () => {
-  it.effect('rejects receipt submissions before the event has ended', () =>
+  it.effect('allows receipt submissions before the event has ended', () =>
     Effect.gen(function* () {
-      const error = yield* financeHandlers['finance.receipts.submit'](
+      const receiptDatabase = databaseWithReceiptInsert({
+        end: new Date(Date.now() + 60 * 60 * 1000),
+      });
+
+      const result = yield* financeHandlers['finance.receipts.submit'](
         receiptSubmitInput,
         { headers: {} } as never,
       ).pipe(
-        Effect.flip,
         Effect.provide(
           createContextLayer(['events:organizeAll'], {
-            database: {
-              ...databaseWithTenantEvent({
-                end: new Date(Date.now() + 60 * 60 * 1000),
-              }),
-              insert: () =>
-                Effect.die(
-                  new Error(
-                    'receipt insert should not run before event end validation',
-                  ),
-                ),
-            },
+            database: receiptDatabase.database,
           }),
         ),
       );
 
-      expect(error['_tag']).toBe('RpcBadRequestError');
-      expect(error.reason).toBe('event_not_finished');
+      expect(result).toEqual({ id: 'receipt-1' });
+      expect(receiptDatabase.insertedValues()).toEqual(
+        expect.objectContaining({
+          eventId: 'event-1',
+          status: 'submitted',
+          submittedByUserId: 'user-1',
+          tenantId: 'tenant-1',
+        }),
+      );
     }),
   );
 

--- a/src/server/effect/rpc/handlers/global-admin.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/global-admin.handlers.spec.ts
@@ -73,6 +73,7 @@ describe('globalAdminHandlers', () => {
           id: 'tenant-1',
           locale: 'en-GB',
           name: 'Tenant',
+          stripeAccountId: 'acct_123',
           stripeConnected: true,
           theme: 'esn',
           timezone: 'Europe/Berlin',
@@ -118,6 +119,7 @@ describe('globalAdminHandlers', () => {
         id: 'tenant-1',
         locale: 'en-GB',
         name: 'Tenant',
+        stripeAccountId: null,
         stripeConnected: false,
         theme: 'evorto',
         timezone: 'Europe/Berlin',
@@ -227,5 +229,223 @@ describe('globalAdminHandlers', () => {
         expect(error['_tag']).toBe('RpcForbiddenError');
         expect(error.permission).toBe('globalAdmin:manageTenants');
       }),
+  );
+
+  it.effect('creates tenants with normalized operational settings', () =>
+    Effect.gen(function* () {
+      let capturedInsert: Record<string, unknown> | undefined;
+      const insertQuery = {
+        returning: () =>
+          Effect.succeed([
+            {
+              currency: 'CZK',
+              domain: 'section.example.org',
+              id: 'tenant-1',
+              locale: 'en-GB',
+              name: 'Example Section',
+              stripeAccountId: 'acct_123',
+              theme: 'esn',
+              timezone: 'Europe/Prague',
+            },
+          ]),
+        values: (value: Record<string, unknown>) => {
+          capturedInsert = value;
+          return insertQuery;
+        },
+      };
+      const database = {
+        insert: () => insertQuery,
+        query: {
+          tenants: {
+            findFirst: () => Effect.succeed(),
+          },
+        },
+      };
+
+      const tenant = yield* globalAdminHandlers['globalAdmin.tenants.create'](
+        {
+          currency: 'CZK',
+          domain: ' https://Section.Example.Org ',
+          locale: 'en-GB',
+          name: ' Example Section ',
+          stripeAccountId: ' acct_123 ',
+          theme: 'esn',
+          timezone: 'Europe/Prague',
+        },
+        { headers: createHeaders(['globalAdmin:manageTenants']) } as never,
+      ).pipe(Effect.provide(Layer.succeed(Database, database as never)));
+
+      expect(capturedInsert).toMatchObject({
+        currency: 'CZK',
+        domain: 'section.example.org',
+        locale: 'en-GB',
+        name: 'Example Section',
+        stripeAccountId: 'acct_123',
+        theme: 'esn',
+        timezone: 'Europe/Prague',
+      });
+      expect(tenant).toMatchObject({
+        domain: 'section.example.org',
+        name: 'Example Section',
+        stripeAccountId: 'acct_123',
+        stripeConnected: true,
+      });
+    }),
+  );
+
+  it.effect(
+    'maps duplicate tenant domains to bad requests before inserting',
+    () =>
+      Effect.gen(function* () {
+        const database = {
+          insert: () => {
+            throw new Error('insert should not run');
+          },
+          query: {
+            tenants: {
+              findFirst: () => Effect.succeed({ id: 'existing-tenant' }),
+            },
+          },
+        };
+
+        const error = yield* globalAdminHandlers['globalAdmin.tenants.create'](
+          {
+            currency: 'EUR',
+            domain: 'Tenant.Example.com',
+            locale: 'en-GB',
+            name: 'Duplicate Tenant',
+            theme: 'evorto',
+            timezone: 'Europe/Berlin',
+          },
+          { headers: createHeaders(['globalAdmin:manageTenants']) } as never,
+        ).pipe(
+          Effect.provide(Layer.succeed(Database, database as never)),
+          Effect.flip,
+        );
+
+        expect(error['_tag']).toBe('RpcBadRequestError');
+        expect(error.message).toBe('Tenant domain already exists');
+        expect(error.reason).toBe('tenant.example.com');
+      }),
+  );
+
+  it.effect('updates tenants and clears blank Stripe account ids', () =>
+    Effect.gen(function* () {
+      let capturedUpdate: Record<string, unknown> | undefined;
+      const updateQuery = {
+        returning: () =>
+          Effect.succeed([
+            {
+              currency: 'EUR',
+              domain: 'tenant.example.com',
+              id: 'tenant-1',
+              locale: 'en-US',
+              name: 'Tenant',
+              stripeAccountId: null,
+              theme: 'evorto',
+              timezone: 'Europe/Berlin',
+            },
+          ]),
+        set: (value: Record<string, unknown>) => {
+          capturedUpdate = value;
+          return updateQuery;
+        },
+        where: () => updateQuery,
+      };
+      const database = {
+        query: {
+          tenants: {
+            findFirst: () => Effect.succeed({ id: 'tenant-1' }),
+          },
+        },
+        update: () => updateQuery,
+      };
+
+      const tenant = yield* globalAdminHandlers['globalAdmin.tenants.update'](
+        {
+          currency: 'EUR',
+          domain: 'tenant.example.com',
+          id: 'tenant-1',
+          locale: 'en-US',
+          name: 'Tenant',
+          stripeAccountId: ' ',
+          theme: 'evorto',
+          timezone: 'Europe/Berlin',
+        },
+        { headers: createHeaders(['globalAdmin:manageTenants']) } as never,
+      ).pipe(Effect.provide(Layer.succeed(Database, database as never)));
+
+      expect(capturedUpdate).toMatchObject({
+        domain: 'tenant.example.com',
+        name: 'Tenant',
+        stripeAccountId: null,
+      });
+      expect(tenant.stripeConnected).toBe(false);
+    }),
+  );
+
+  it.effect(
+    'maps duplicate tenant domains to bad requests before updating',
+    () =>
+      Effect.gen(function* () {
+        const database = {
+          query: {
+            tenants: {
+              findFirst: () => Effect.succeed({ id: 'other-tenant' }),
+            },
+          },
+          update: () => {
+            throw new Error('update should not run');
+          },
+        };
+
+        const error = yield* globalAdminHandlers['globalAdmin.tenants.update'](
+          {
+            currency: 'EUR',
+            domain: 'Tenant.Example.com',
+            id: 'tenant-1',
+            locale: 'en-GB',
+            name: 'Duplicate Tenant',
+            theme: 'evorto',
+            timezone: 'Europe/Berlin',
+          },
+          { headers: createHeaders(['globalAdmin:manageTenants']) } as never,
+        ).pipe(
+          Effect.provide(Layer.succeed(Database, database as never)),
+          Effect.flip,
+        );
+
+        expect(error['_tag']).toBe('RpcBadRequestError');
+        expect(error.message).toBe('Tenant domain already exists');
+        expect(error.reason).toBe('tenant.example.com');
+      }),
+  );
+
+  it.effect('rejects invalid tenant domains before mutating tenants', () =>
+    Effect.gen(function* () {
+      const database = {
+        insert: () => {
+          throw new Error('database should not be touched');
+        },
+      };
+
+      const error = yield* globalAdminHandlers['globalAdmin.tenants.create'](
+        {
+          currency: 'EUR',
+          domain: 'section.example.org/path',
+          locale: 'en-GB',
+          name: 'Section',
+          theme: 'evorto',
+          timezone: 'Europe/Berlin',
+        },
+        { headers: createHeaders(['globalAdmin:manageTenants']) } as never,
+      ).pipe(
+        Effect.provide(Layer.succeed(Database, database as never)),
+        Effect.flip,
+      );
+
+      expect(error['_tag']).toBe('RpcBadRequestError');
+      expect(error.message).toBe('Invalid tenant settings');
+    }),
   );
 });

--- a/src/server/effect/rpc/handlers/global-admin.handlers.ts
+++ b/src/server/effect/rpc/handlers/global-admin.handlers.ts
@@ -1,6 +1,8 @@
+import type { GlobalAdminTenantWriteInput } from '@shared/rpc-contracts/app-rpcs/global-admin.rpcs';
 import type { Headers } from 'effect/unstable/http';
 
 import {
+  RpcBadRequestError,
   RpcForbiddenError,
   RpcUnauthorizedError,
 } from '@shared/errors/rpc-errors';
@@ -8,11 +10,13 @@ import {
   GlobalAdminTenantRecord,
   type GlobalAdminTenantRecord as GlobalAdminTenantRecordType,
 } from '@shared/rpc-contracts/app-rpcs/global-admin.rpcs';
+import { eq } from 'drizzle-orm';
 import { Effect, Schema } from 'effect';
 
 import type { AppRpcHandlers } from './shared/handler-types';
 
 import { Database, type DatabaseClient } from '../../../../db';
+import { tenants } from '../../../../db/schema';
 import {
   includesPermission,
   type Permission,
@@ -70,13 +74,63 @@ const toGlobalAdminTenantRecord = (tenant: {
   theme: string;
   timezone: string;
 }): GlobalAdminTenantRecordType => {
-  const { stripeAccountId, ...record } = tenant;
-
   return Schema.decodeUnknownSync(GlobalAdminTenantRecord)({
-    ...record,
-    stripeConnected: !!stripeAccountId,
+    ...tenant,
+    stripeConnected: !!tenant.stripeAccountId,
   });
 };
+
+const normalizeTenantDomain = (value: string): string => {
+  const trimmedValue = value.trim().toLocaleLowerCase();
+  if (!trimmedValue) {
+    throw new Error('Domain is required');
+  }
+
+  const url = new URL(
+    trimmedValue.includes('://') ? trimmedValue : `https://${trimmedValue}`,
+  );
+  if (
+    !url.hostname ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error('Domain must be a single host name');
+  }
+
+  return url.hostname;
+};
+
+const normalizeTenantWriteInput = (
+  input: GlobalAdminTenantWriteInput,
+): GlobalAdminTenantWriteInput => {
+  const name = input.name.trim();
+  if (!name) {
+    throw new Error('Tenant name is required');
+  }
+
+  return {
+    currency: input.currency,
+    domain: normalizeTenantDomain(input.domain),
+    locale: input.locale,
+    name,
+    stripeAccountId: input.stripeAccountId?.trim() || undefined,
+    theme: input.theme,
+    timezone: input.timezone,
+  };
+};
+
+const normalizeTenantWritePayload = (input: GlobalAdminTenantWriteInput) =>
+  Effect.try({
+    catch: (error) =>
+      new RpcBadRequestError({
+        message: 'Invalid tenant settings',
+        reason: error instanceof Error ? error.message : String(error),
+      }),
+    try: () => normalizeTenantWriteInput(input),
+  });
 
 const globalAdminTenantColumns = {
   currency: true,
@@ -89,7 +143,57 @@ const globalAdminTenantColumns = {
   timezone: true,
 } as const;
 
+const globalAdminTenantReturningColumns = {
+  currency: tenants.currency,
+  domain: tenants.domain,
+  id: tenants.id,
+  locale: tenants.locale,
+  name: tenants.name,
+  stripeAccountId: tenants.stripeAccountId,
+  theme: tenants.theme,
+  timezone: tenants.timezone,
+} as const;
+
 export const globalAdminHandlers = {
+  'globalAdmin.tenants.create': (input, options) =>
+    Effect.gen(function* () {
+      yield* ensurePermission(options.headers, 'globalAdmin:manageTenants');
+      const tenantInput = yield* normalizeTenantWritePayload(input);
+      const existingDomainTenant = yield* databaseEffect((database) =>
+        database.query.tenants.findFirst({
+          columns: {
+            id: true,
+          },
+          where: {
+            domain: tenantInput.domain,
+          },
+        }),
+      );
+      if (existingDomainTenant) {
+        return yield* Effect.fail(
+          new RpcBadRequestError({
+            message: 'Tenant domain already exists',
+            reason: tenantInput.domain,
+          }),
+        );
+      }
+
+      const createdTenants = yield* databaseEffect((database) =>
+        database
+          .insert(tenants)
+          .values({
+            ...tenantInput,
+            stripeAccountId: tenantInput.stripeAccountId ?? null,
+          })
+          .returning(globalAdminTenantReturningColumns),
+      );
+      const createdTenant = createdTenants[0];
+      if (!createdTenant) {
+        return yield* Effect.die(new Error('Tenant creation returned no rows'));
+      }
+
+      return toGlobalAdminTenantRecord(createdTenant);
+    }),
   'globalAdmin.tenants.findMany': (_payload, options) =>
     Effect.gen(function* () {
       yield* ensurePermission(options.headers, 'globalAdmin:manageTenants');
@@ -115,5 +219,48 @@ export const globalAdminHandlers = {
       );
 
       return tenant ? toGlobalAdminTenantRecord(tenant) : null;
+    }),
+  'globalAdmin.tenants.update': (input, options) =>
+    Effect.gen(function* () {
+      yield* ensurePermission(options.headers, 'globalAdmin:manageTenants');
+      const { id, ...writeInput } = input;
+      const tenantInput = yield* normalizeTenantWritePayload(writeInput);
+      const existingDomainTenant = yield* databaseEffect((database) =>
+        database.query.tenants.findFirst({
+          columns: {
+            id: true,
+          },
+          where: {
+            domain: tenantInput.domain,
+          },
+        }),
+      );
+      if (existingDomainTenant && existingDomainTenant.id !== id) {
+        return yield* Effect.fail(
+          new RpcBadRequestError({
+            message: 'Tenant domain already exists',
+            reason: tenantInput.domain,
+          }),
+        );
+      }
+
+      const updatedTenants = yield* databaseEffect((database) =>
+        database
+          .update(tenants)
+          .set({
+            ...tenantInput,
+            stripeAccountId: tenantInput.stripeAccountId ?? null,
+          })
+          .where(eq(tenants.id, id))
+          .returning(globalAdminTenantReturningColumns),
+      );
+      const updatedTenant = updatedTenants[0];
+      if (!updatedTenant) {
+        return yield* Effect.fail(
+          new RpcBadRequestError({ message: 'Tenant not found' }),
+        );
+      }
+
+      return toGlobalAdminTenantRecord(updatedTenant);
     }),
 } satisfies Partial<AppRpcHandlers>;

--- a/src/server/effect/rpc/handlers/roles.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/roles.handlers.spec.ts
@@ -158,6 +158,52 @@ describe('roleHandlers lookup permissions', () => {
 
   it.effect('findOne allows event creators', () =>
     Effect.gen(function* () {
+      let queryInput: unknown;
+      const database = {
+        query: {
+          roles: {
+            findFirst: (query: unknown) => {
+              queryInput = query;
+              return Effect.succeed({
+                defaultOrganizerRole: false,
+                defaultUserRole: true,
+                id: 'role-1',
+                name: 'Participant',
+              });
+            },
+          },
+        },
+      };
+
+      const result = yield* roleHandlers['roles.findOne']({ id: 'role-1' }, {
+        headers: {},
+      } as never).pipe(
+        Effect.provide(createContextLayer(['events:create'], database)),
+      );
+
+      expect(queryInput).toEqual({
+        columns: {
+          defaultOrganizerRole: true,
+          defaultUserRole: true,
+          id: true,
+          name: true,
+        },
+        where: {
+          id: 'role-1',
+          tenantId: tenant.id,
+        },
+      });
+      expect(result).toEqual({
+        defaultOrganizerRole: false,
+        defaultUserRole: true,
+        id: 'role-1',
+        name: 'Participant',
+      });
+    }),
+  );
+
+  it.effect('findOne strips permission-bearing role data from the result', () =>
+    Effect.gen(function* () {
       const database = {
         query: {
           roles: {
@@ -167,6 +213,7 @@ describe('roleHandlers lookup permissions', () => {
                 defaultUserRole: true,
                 id: 'role-1',
                 name: 'Participant',
+                permissions: ['admin:manageRoles'],
               }),
           },
         },

--- a/src/server/effect/rpc/handlers/templates.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/templates.handlers.spec.ts
@@ -8,7 +8,10 @@ import {
   type RpcRequestContextShape,
 } from '../../../../shared/rpc-contracts/app-rpcs';
 import { RpcAccess } from './shared/rpc-access.service';
-import { templateHandlers } from './templates.handlers';
+import {
+  normalizeTemplateFindOneRecord,
+  templateHandlers,
+} from './templates.handlers';
 
 const tenant = {
   currency: 'EUR' as const,
@@ -165,4 +168,92 @@ describe('templateHandlers permissions', () => {
         expect(error['_tag']).toBe('TemplateSimpleNotFoundError');
       }),
   );
+});
+
+describe('normalizeTemplateFindOneRecord', () => {
+  it('returns reusable template add-ons with registration option attachments', () => {
+    const record = normalizeTemplateFindOneRecord(
+      {
+        addOns: [
+          {
+            allowMultiple: true,
+            allowPurchaseBeforeEvent: true,
+            allowPurchaseDuringEvent: false,
+            allowPurchaseDuringRegistration: true,
+            description: 'Optional dinner ticket',
+            id: 'addon-1',
+            isPaid: true,
+            maxQuantityPerUser: 2,
+            price: 1200,
+            stripeTaxRateId: 'txr-1',
+            title: 'Dinner',
+            totalAvailableQuantity: 40,
+          },
+        ],
+        categoryId: 'category-1',
+        description: '<p>Useful event template description</p>',
+        icon: {
+          iconColor: 0,
+          iconName: 'calendar:fas',
+        },
+        id: 'template-1',
+        location: null,
+        planningTips: null,
+        registrationOptions: [
+          {
+            closeRegistrationOffset: 24,
+            description: null,
+            id: 'template-option-1',
+            isPaid: true,
+            openRegistrationOffset: 168,
+            organizingRegistration: false,
+            price: 1200,
+            registeredDescription: null,
+            registrationMode: 'fcfs',
+            roleIds: [],
+            spots: 20,
+            stripeTaxRateId: 'txr-1',
+            title: 'Participant registration',
+          },
+        ],
+        title: 'Template',
+      },
+      new Map(),
+      new Map(),
+      new Map([
+        [
+          'addon-1',
+          [
+            {
+              quantity: 1,
+              registrationOptionId: 'template-option-1',
+            },
+          ],
+        ],
+      ]),
+    );
+
+    expect(record.addOns).toEqual([
+      {
+        allowMultiple: true,
+        allowPurchaseBeforeEvent: true,
+        allowPurchaseDuringEvent: false,
+        allowPurchaseDuringRegistration: true,
+        description: 'Optional dinner ticket',
+        id: 'addon-1',
+        isPaid: true,
+        maxQuantityPerUser: 2,
+        price: 1200,
+        registrationOptions: [
+          {
+            quantity: 1,
+            registrationOptionId: 'template-option-1',
+          },
+        ],
+        stripeTaxRateId: 'txr-1',
+        title: 'Dinner',
+        totalAvailableQuantity: 40,
+      },
+    ]);
+  });
 });

--- a/src/server/effect/rpc/handlers/templates.handlers.ts
+++ b/src/server/effect/rpc/handlers/templates.handlers.ts
@@ -6,6 +6,7 @@ import type { AppRpcHandlers } from './shared/handler-types';
 
 import { Database, type DatabaseClient } from '../../../../db';
 import {
+  addonToTemplateRegistrationOptions,
   eventTemplates,
   templateRegistrationOptionDiscounts,
 } from '../../../../db/schema';
@@ -17,8 +18,22 @@ const databaseEffect = <A>(
 ): Effect.Effect<A, never, Database> =>
   Database.use((database) => operation(database).pipe(Effect.orDie));
 
-const normalizeTemplateFindOneRecord = (
+export const normalizeTemplateFindOneRecord = (
   template: {
+    addOns: readonly {
+      allowMultiple: boolean;
+      allowPurchaseBeforeEvent: boolean;
+      allowPurchaseDuringEvent: boolean;
+      allowPurchaseDuringRegistration: boolean;
+      description: null | string;
+      id: string;
+      isPaid: boolean;
+      maxQuantityPerUser: number;
+      price: number;
+      stripeTaxRateId: null | string;
+      title: string;
+      totalAvailableQuantity: number;
+    }[];
     categoryId: string;
     description: string;
     icon: typeof eventTemplates.$inferSelect.icon;
@@ -44,7 +59,32 @@ const normalizeTemplateFindOneRecord = (
   },
   rolesById: ReadonlyMap<string, { id: string; name: string }>,
   esnDiscountByOptionId: ReadonlyMap<string, number>,
+  addonRegistrationOptionsByAddonId: ReadonlyMap<
+    string,
+    {
+      quantity: number;
+      registrationOptionId: string;
+    }[]
+  >,
 ): {
+  addOns: {
+    allowMultiple: boolean;
+    allowPurchaseBeforeEvent: boolean;
+    allowPurchaseDuringEvent: boolean;
+    allowPurchaseDuringRegistration: boolean;
+    description: null | string;
+    id: string;
+    isPaid: boolean;
+    maxQuantityPerUser: number;
+    price: number;
+    registrationOptions: {
+      quantity: number;
+      registrationOptionId: string;
+    }[];
+    stripeTaxRateId: null | string;
+    title: string;
+    totalAvailableQuantity: number;
+  }[];
   categoryId: string;
   description: string;
   icon: typeof eventTemplates.$inferSelect.icon;
@@ -70,6 +110,21 @@ const normalizeTemplateFindOneRecord = (
   }[];
   title: string;
 } => ({
+  addOns: template.addOns.map((addOn) => ({
+    allowMultiple: addOn.allowMultiple,
+    allowPurchaseBeforeEvent: addOn.allowPurchaseBeforeEvent,
+    allowPurchaseDuringEvent: addOn.allowPurchaseDuringEvent,
+    allowPurchaseDuringRegistration: addOn.allowPurchaseDuringRegistration,
+    description: addOn.description ?? null,
+    id: addOn.id,
+    isPaid: addOn.isPaid,
+    maxQuantityPerUser: addOn.maxQuantityPerUser,
+    price: addOn.price,
+    registrationOptions: addonRegistrationOptionsByAddonId.get(addOn.id) ?? [],
+    stripeTaxRateId: addOn.stripeTaxRateId ?? null,
+    title: addOn.title,
+    totalAvailableQuantity: addOn.totalAvailableQuantity,
+  })),
   categoryId: template.categoryId,
   description: template.description,
   icon: template.icon,
@@ -210,11 +265,72 @@ export const templateHandlers = {
           discount.discountedPrice,
         ]),
       );
+      const addOns = yield* databaseEffect((database) =>
+        database.query.templateEventAddons.findMany({
+          columns: {
+            allowMultiple: true,
+            allowPurchaseBeforeEvent: true,
+            allowPurchaseDuringEvent: true,
+            allowPurchaseDuringRegistration: true,
+            description: true,
+            id: true,
+            isPaid: true,
+            maxQuantityPerUser: true,
+            price: true,
+            stripeTaxRateId: true,
+            title: true,
+            totalAvailableQuantity: true,
+          },
+          orderBy: { createdAt: 'asc' },
+          where: {
+            templateId: id,
+          },
+        }),
+      );
+      const addOnIds = addOns.map((addOn) => addOn.id);
+      const addonRegistrationOptions =
+        addOnIds.length > 0
+          ? yield* databaseEffect((database) =>
+              database
+                .select({
+                  addonId: addonToTemplateRegistrationOptions.addonId,
+                  quantity: addonToTemplateRegistrationOptions.quantity,
+                  registrationOptionId:
+                    addonToTemplateRegistrationOptions.registrationOptionId,
+                })
+                .from(addonToTemplateRegistrationOptions)
+                .where(
+                  inArray(addonToTemplateRegistrationOptions.addonId, addOnIds),
+                ),
+            )
+          : [];
+      const addonRegistrationOptionsByAddonId = new Map<
+        string,
+        {
+          quantity: number;
+          registrationOptionId: string;
+        }[]
+      >();
+      for (const addonRegistrationOption of addonRegistrationOptions) {
+        const existing =
+          addonRegistrationOptionsByAddonId.get(
+            addonRegistrationOption.addonId,
+          ) ?? [];
+        existing.push({
+          quantity: addonRegistrationOption.quantity,
+          registrationOptionId: addonRegistrationOption.registrationOptionId,
+        });
+        addonRegistrationOptionsByAddonId.set(
+          addonRegistrationOption.addonId,
+          existing,
+        );
+      }
 
       return normalizeTemplateFindOneRecord(
-        template,
+        { ...template, addOns },
         rolesById,
         esnDiscountByOptionId,
+        addonRegistrationOptionsByAddonId,
       );
     }),
   'templates.groupedByCategory': (_payload, _options) =>

--- a/src/server/effect/rpc/handlers/templates/templates-rpcs.schema.spec.ts
+++ b/src/server/effect/rpc/handlers/templates/templates-rpcs.schema.spec.ts
@@ -40,6 +40,7 @@ const validSimpleTemplateInput = {
 };
 
 const validTemplateFindOneRecord = {
+  addOns: [],
   categoryId: 'category-1',
   description: '<p>Useful event template description</p>',
   icon: {
@@ -85,6 +86,36 @@ describe('templates RPC location schema', () => {
       Schema.decodeUnknownSync(TemplateSimpleInput)({
         ...validSimpleTemplateInput,
         location: validGoogleLocation,
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts reusable add-ons in template find-one responses', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(TemplateFindOneRecord)({
+        ...validTemplateFindOneRecord,
+        addOns: [
+          {
+            allowMultiple: true,
+            allowPurchaseBeforeEvent: true,
+            allowPurchaseDuringEvent: false,
+            allowPurchaseDuringRegistration: true,
+            description: 'Optional dinner ticket',
+            id: 'addon-1',
+            isPaid: true,
+            maxQuantityPerUser: 2,
+            price: 1200,
+            registrationOptions: [
+              {
+                quantity: 1,
+                registrationOptionId: 'template-option-1',
+              },
+            ],
+            stripeTaxRateId: 'txr-1',
+            title: 'Dinner',
+            totalAvailableQuantity: 40,
+          },
+        ],
       }),
     ).not.toThrow();
   });

--- a/src/server/http/tenant-brand-asset.web-handler.spec.ts
+++ b/src/server/http/tenant-brand-asset.web-handler.spec.ts
@@ -1,0 +1,128 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+
+import { handleTenantBrandAssetWebRequest } from './tenant-brand-asset.web-handler';
+
+const runtimeGlobal = globalThis as typeof globalThis & {
+  Bun?: {
+    S3Client?: unknown;
+  };
+};
+
+const originalBunRuntime = runtimeGlobal.Bun;
+const bunRuntime = (originalBunRuntime ?? {}) as {
+  S3Client?: unknown;
+};
+const originalS3Client = bunRuntime.S3Client;
+
+if (!originalBunRuntime) {
+  Object.defineProperty(runtimeGlobal, 'Bun', {
+    configurable: true,
+    value: bunRuntime,
+  });
+}
+
+beforeEach(() => {
+  if (!originalBunRuntime) {
+    Object.defineProperty(runtimeGlobal, 'Bun', {
+      configurable: true,
+      value: bunRuntime,
+    });
+  }
+});
+
+const objectStorageProviderLayer = ConfigProvider.layer(
+  ConfigProvider.fromEnv({
+    env: Object.fromEntries([
+      ['S3_ACCESS_KEY_ID', 'test-key'],
+      ['S3_BUCKET', 'test-bucket'],
+      ['S3_ENDPOINT', 'https://s3.example.test'],
+      ['S3_REGION', 'auto'],
+      ['S3_SECRET_ACCESS_KEY', 'test-secret'],
+    ]),
+  }),
+);
+
+afterEach(() => {
+  if (originalBunRuntime) {
+    originalBunRuntime.S3Client = originalS3Client;
+    return;
+  }
+
+  delete runtimeGlobal.Bun;
+});
+
+describe('handleTenantBrandAssetWebRequest', () => {
+  it.effect('serves stored tenant brand assets from object storage', () =>
+    Effect.gen(function* () {
+      class FakeS3Client {
+        file() {
+          return {
+            arrayBuffer: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer),
+            presign: vi.fn(() => 'https://signed.example.com/object'),
+            write: vi.fn(async () => 0),
+          };
+        }
+      }
+
+      bunRuntime.S3Client = FakeS3Client;
+
+      const response = yield* handleTenantBrandAssetWebRequest({
+        fileName: 'logo.png',
+        kind: 'logo',
+        tenantId: 'tenant-1',
+      }).pipe(Effect.provide(objectStorageProviderLayer));
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/png');
+      expect(response.headers.get('Cache-Control')).toContain('immutable');
+      const body = yield* Effect.promise(() => response.arrayBuffer());
+      expect(new Uint8Array(body)).toEqual(new Uint8Array([1, 2, 3]));
+    }),
+  );
+
+  it.effect('returns 404 for unsupported asset paths', () =>
+    Effect.gen(function* () {
+      const response = yield* handleTenantBrandAssetWebRequest({
+        fileName: 'logo.svg',
+        kind: 'logo',
+        tenantId: 'tenant-1',
+      }).pipe(Effect.provide(objectStorageProviderLayer));
+
+      expect(response.status).toBe(404);
+    }),
+  );
+
+  it.effect('returns 404 for missing object storage assets', () =>
+    Effect.gen(function* () {
+      class FakeS3Client {
+        file() {
+          return {
+            arrayBuffer: vi.fn(async () => {
+              throw new Error('No such key');
+            }),
+            presign: vi.fn(() => 'https://signed.example.com/object'),
+            write: vi.fn(async () => 0),
+          };
+        }
+      }
+
+      bunRuntime.S3Client = FakeS3Client;
+
+      const response = yield* handleTenantBrandAssetWebRequest({
+        fileName: 'logo.png',
+        kind: 'logo',
+        tenantId: 'tenant-1',
+      }).pipe(Effect.provide(objectStorageProviderLayer));
+
+      expect(response.status).toBe(404);
+    }),
+  );
+});

--- a/src/server/http/tenant-brand-asset.web-handler.ts
+++ b/src/server/http/tenant-brand-asset.web-handler.ts
@@ -1,0 +1,72 @@
+import type { AdminTenantBrandAssetKind } from '@shared/rpc-contracts/app-rpcs/admin.rpcs';
+
+import { RpcInternalServerError } from '@shared/errors/rpc-errors';
+import { Effect } from 'effect';
+
+import { getObjectFromR2 } from '../integrations/cloudflare-r2';
+import {
+  tenantBrandAssetContentTypeFromFileName,
+  tenantBrandAssetStorageKey,
+} from '../tenant-brand-assets';
+
+const response = (body: BodyInit, status: number) =>
+  new Response(body, { status });
+
+const isObjectNotFoundError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (/not found|no such key|404/i.test(error.message)) {
+    return true;
+  }
+
+  return isObjectNotFoundError(error.cause);
+};
+
+const isTenantBrandAssetKind = (
+  value: string,
+): value is AdminTenantBrandAssetKind =>
+  value === 'favicon' || value === 'logo';
+
+export const handleTenantBrandAssetWebRequest = (input: {
+  fileName: string;
+  kind: string;
+  tenantId: string;
+}) =>
+  Effect.gen(function* () {
+    if (!input.tenantId.trim() || !isTenantBrandAssetKind(input.kind)) {
+      return response('Asset not found', 404);
+    }
+
+    const fileName = input.fileName.trim();
+    const contentType = tenantBrandAssetContentTypeFromFileName(fileName);
+    if (!fileName || !contentType) {
+      return response('Asset not found', 404);
+    }
+
+    const storageKey = tenantBrandAssetStorageKey({
+      fileName,
+      kind: input.kind,
+      tenantId: input.tenantId,
+    });
+    const body = yield* getObjectFromR2({ key: storageKey }).pipe(
+      Effect.catchIf(isObjectNotFoundError, () => Effect.succeed(null)),
+      Effect.mapError(
+        (cause) =>
+          new RpcInternalServerError({
+            cause,
+            message: 'Failed to load tenant brand asset',
+          }),
+      ),
+    );
+    if (!body) {
+      return response('Asset not found', 404);
+    }
+
+    return new Response(body, {
+      headers: {
+        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Content-Type': contentType,
+      },
+    });
+  });

--- a/src/server/integrations/cloudflare-r2.spec.ts
+++ b/src/server/integrations/cloudflare-r2.spec.ts
@@ -3,6 +3,7 @@ import { ConfigProvider, Effect } from 'effect';
 
 import { objectStorageConfig } from '../config/object-storage-config';
 import {
+  getObjectFromR2,
   getSignedReceiptObjectUrlFromR2,
   uploadReceiptOriginalToR2,
 } from './cloudflare-r2';
@@ -101,6 +102,7 @@ describe('cloudflare-r2', () => {
           file(key: string) {
             captured.key = key;
             return {
+              arrayBuffer: vi.fn(async () => new ArrayBuffer(0)),
               presign,
               write,
             };
@@ -141,6 +143,7 @@ describe('cloudflare-r2', () => {
       class FakeS3Client {
         file() {
           return {
+            arrayBuffer: vi.fn(async () => new ArrayBuffer(0)),
             presign,
             write: vi.fn(async () => 0),
           };
@@ -169,6 +172,35 @@ describe('cloudflare-r2', () => {
         expiresIn: 30,
         method: 'GET',
       });
+    }),
+  );
+
+  it.effect('reads objects with Bun.S3Client', () =>
+    Effect.gen(function* () {
+      const arrayBuffer = vi.fn(async () => new Uint8Array([4, 5, 6]).buffer);
+      const captured = {
+        key: '',
+      };
+
+      class FakeS3Client {
+        file(key: string) {
+          captured.key = key;
+          return {
+            arrayBuffer,
+            presign: vi.fn(() => 'https://signed.example.com/object'),
+            write: vi.fn(async () => 0),
+          };
+        }
+      }
+
+      bunRuntime.S3Client = FakeS3Client;
+
+      const result = yield* getObjectFromR2({
+        key: 'tenant-assets/tenant-1/logo/logo.png',
+      }).pipe(Effect.provide(objectStorageProviderLayer));
+
+      expect(captured.key).toBe('tenant-assets/tenant-1/logo/logo.png');
+      expect(result).toEqual(new Uint8Array([4, 5, 6]));
     }),
   );
 });

--- a/src/server/integrations/cloudflare-r2.ts
+++ b/src/server/integrations/cloudflare-r2.ts
@@ -17,6 +17,7 @@ type BunS3ClientConstructor = new (config: {
 }) => BunS3Client;
 
 interface BunS3File {
+  arrayBuffer(): Promise<ArrayBuffer>;
   presign(input?: {
     contentDisposition?: string;
     expiresIn?: number;
@@ -78,7 +79,7 @@ const buildS3Client = (config: ObjectStorageRuntimeConfig) => {
   });
 };
 
-export const uploadReceiptOriginalToR2 = (input: {
+export const uploadObjectToR2 = (input: {
   body: Uint8Array;
   contentType: string;
   key: string;
@@ -103,6 +104,25 @@ export const uploadReceiptOriginalToR2 = (input: {
       storageKey: input.key,
       storageUrl: `${config.endpoint.replace(/\/$/, '')}/${config.bucket}/${input.key}`,
     };
+  });
+
+export const uploadReceiptOriginalToR2 = uploadObjectToR2;
+
+export const getObjectFromR2 = (input: { key: string }) =>
+  Effect.gen(function* () {
+    const config = yield* resolveObjectStorageConfig();
+    const client = buildS3Client(config);
+
+    const body = yield* Effect.tryPromise({
+      catch: (cause) =>
+        new RpcInternalServerError({
+          cause,
+          message: `R2 read failed for key ${input.key}`,
+        }),
+      try: () => client.file(input.key).arrayBuffer(),
+    });
+
+    return new Uint8Array(body);
   });
 
 export const getSignedReceiptObjectUrlFromR2 = (input: {

--- a/src/server/tenant-brand-assets.spec.ts
+++ b/src/server/tenant-brand-assets.spec.ts
@@ -1,0 +1,171 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+
+import {
+  sanitizeTenantBrandAssetFileName,
+  tenantBrandAssetContentTypeFromFileName,
+  tenantBrandAssetStorageKey,
+  tenantBrandAssetUrl,
+  uploadTenantBrandAsset,
+} from './tenant-brand-assets';
+
+const runtimeGlobal = globalThis as typeof globalThis & {
+  Bun?: {
+    S3Client?: unknown;
+  };
+};
+
+const originalBunRuntime = runtimeGlobal.Bun;
+const bunRuntime = (originalBunRuntime ?? {}) as {
+  S3Client?: unknown;
+};
+const originalS3Client = bunRuntime.S3Client;
+
+if (!originalBunRuntime) {
+  Object.defineProperty(runtimeGlobal, 'Bun', {
+    configurable: true,
+    value: bunRuntime,
+  });
+}
+
+const objectStorageProviderLayer = ConfigProvider.layer(
+  ConfigProvider.fromEnv({
+    env: Object.fromEntries([
+      ['S3_ACCESS_KEY_ID', 'test-key'],
+      ['S3_BUCKET', 'test-bucket'],
+      ['S3_ENDPOINT', 'https://s3.example.test'],
+      ['S3_REGION', 'auto'],
+      ['S3_SECRET_ACCESS_KEY', 'test-secret'],
+    ]),
+  }),
+);
+
+beforeEach(() => {
+  if (!originalBunRuntime) {
+    Object.defineProperty(runtimeGlobal, 'Bun', {
+      configurable: true,
+      value: bunRuntime,
+    });
+  }
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalBunRuntime) {
+    originalBunRuntime.S3Client = originalS3Client;
+    return;
+  }
+
+  delete runtimeGlobal.Bun;
+});
+
+describe('tenant brand assets', () => {
+  it('normalizes public brand asset paths', () => {
+    expect(sanitizeTenantBrandAssetFileName(' Section Logo (final).png ')).toBe(
+      'Section-Logo-final-.png',
+    );
+    expect(
+      tenantBrandAssetStorageKey({
+        fileName: 'logo.png',
+        kind: 'logo',
+        tenantId: 'tenant-1',
+      }),
+    ).toBe('tenant-assets/tenant-1/logo/logo.png');
+    expect(
+      tenantBrandAssetUrl({
+        fileName: 'logo.png',
+        kind: 'logo',
+        tenantId: 'tenant-1',
+      }),
+    ).toBe('/tenant-assets/tenant-1/logo/logo.png');
+    expect(tenantBrandAssetContentTypeFromFileName('favicon.ico')).toBe(
+      'image/x-icon',
+    );
+  });
+
+  it.effect('uploads a logo and returns an app-origin tenant asset URL', () =>
+    Effect.gen(function* () {
+      const write = vi.fn(async () => 3);
+      const captured = {
+        key: '',
+      };
+
+      class FakeS3Client {
+        file(key: string) {
+          captured.key = key;
+          return {
+            arrayBuffer: vi.fn(async () => new ArrayBuffer(0)),
+            presign: vi.fn(() => 'https://signed.example.com/object'),
+            write,
+          };
+        }
+      }
+
+      bunRuntime.S3Client = FakeS3Client;
+
+      const result = yield* uploadTenantBrandAsset({
+        fileBase64: Buffer.from([1, 2, 3]).toString('base64'),
+        fileName: 'Section Logo.png',
+        fileSizeBytes: 3,
+        kind: 'logo',
+        mimeType: 'image/png',
+        tenantId: 'tenant-1',
+      }).pipe(Effect.provide(objectStorageProviderLayer));
+
+      expect(captured.key).toMatch(
+        /^tenant-assets\/tenant-1\/logo\/[0-9a-f-]{36}-Section-Logo\.png$/,
+      );
+      expect(new Uint8Array(write.mock.calls[0]?.[0] as Uint8Array)).toEqual(
+        new Uint8Array([1, 2, 3]),
+      );
+      expect(write.mock.calls[0]?.[1]).toEqual({ type: 'image/png' });
+      expect(result).toEqual({
+        assetUrl: `/${captured.key}`,
+        sizeBytes: 3,
+        storageKey: captured.key,
+      });
+    }),
+  );
+
+  it.effect('rejects SVG uploads for tenant brand assets', () =>
+    Effect.gen(function* () {
+      const error = yield* uploadTenantBrandAsset({
+        fileBase64: Buffer.from('<svg />').toString('base64'),
+        fileName: 'logo.svg',
+        fileSizeBytes: 7,
+        kind: 'logo',
+        mimeType: 'image/svg+xml',
+        tenantId: 'tenant-1',
+      }).pipe(Effect.flip);
+
+      expect(error['_tag']).toBe('RpcBadRequestError');
+    }),
+  );
+
+  it.effect('rejects payloads that do not match the declared file size', () =>
+    Effect.gen(function* () {
+      const error = yield* uploadTenantBrandAsset({
+        fileBase64: Buffer.from([1, 2, 3]).toString('base64'),
+        fileName: 'logo.png',
+        fileSizeBytes: 4,
+        kind: 'logo',
+        mimeType: 'image/png',
+        tenantId: 'tenant-1',
+      }).pipe(Effect.flip);
+
+      expect(error['_tag']).toBe('RpcBadRequestError');
+      expect(error.message).toBe(
+        'Uploaded file size does not match payload metadata',
+      );
+    }),
+  );
+});

--- a/src/server/tenant-brand-assets.ts
+++ b/src/server/tenant-brand-assets.ts
@@ -1,0 +1,157 @@
+import type { AdminTenantBrandAssetKind } from '@shared/rpc-contracts/app-rpcs/admin.rpcs';
+
+import {
+  RpcBadRequestError,
+  RpcInternalServerError,
+} from '@shared/errors/rpc-errors';
+import { Effect } from 'effect';
+import { randomUUID } from 'node:crypto';
+
+import { uploadObjectToR2 } from './integrations/cloudflare-r2';
+
+const MAX_TENANT_BRAND_ASSET_SIZE_BYTES = 5 * 1024 * 1024;
+
+const brandAssetMimeTypes = {
+  favicon: new Set([
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'image/vnd.microsoft.icon',
+    'image/webp',
+    'image/x-icon',
+  ]),
+  logo: new Set(['image/gif', 'image/jpeg', 'image/png', 'image/webp']),
+} satisfies Record<AdminTenantBrandAssetKind, ReadonlySet<string>>;
+
+const extensionByMimeType = new Map<string, string>([
+  ['image/gif', 'gif'],
+  ['image/jpeg', 'jpg'],
+  ['image/png', 'png'],
+  ['image/vnd.microsoft.icon', 'ico'],
+  ['image/webp', 'webp'],
+  ['image/x-icon', 'ico'],
+]);
+
+const mimeTypeByExtension = new Map(
+  Array.from(extensionByMimeType, ([mimeType, extension]) => [
+    extension,
+    mimeType,
+  ]),
+);
+
+export const sanitizeTenantBrandAssetFileName = (fileName: string): string =>
+  fileName
+    .trim()
+    .replaceAll(/[^A-Za-z0-9._-]+/g, '-')
+    .slice(0, 100) || 'brand-asset';
+
+export const tenantBrandAssetContentTypeFromFileName = (
+  fileName: string,
+): null | string => {
+  const extension = fileName.split('.').pop()?.toLocaleLowerCase();
+  return extension ? (mimeTypeByExtension.get(extension) ?? null) : null;
+};
+
+export const tenantBrandAssetStorageKey = (input: {
+  fileName: string;
+  kind: AdminTenantBrandAssetKind;
+  tenantId: string;
+}) => {
+  const tenantId = input.tenantId.trim();
+  if (!tenantId) {
+    throw new RpcBadRequestError({
+      message: 'Tenant id is required for brand asset storage',
+    });
+  }
+  return `tenant-assets/${tenantId}/${input.kind}/${input.fileName}`;
+};
+
+export const tenantBrandAssetUrl = (input: {
+  fileName: string;
+  kind: AdminTenantBrandAssetKind;
+  tenantId: string;
+}) =>
+  `/tenant-assets/${encodeURIComponent(input.tenantId)}/${input.kind}/${encodeURIComponent(input.fileName)}`;
+
+export const uploadTenantBrandAsset = (input: {
+  fileBase64: string;
+  fileName: string;
+  fileSizeBytes: number;
+  kind: AdminTenantBrandAssetKind;
+  mimeType: string;
+  tenantId: string;
+}) =>
+  Effect.gen(function* () {
+    if (!brandAssetMimeTypes[input.kind].has(input.mimeType)) {
+      return yield* Effect.fail(
+        new RpcBadRequestError({
+          message:
+            input.kind === 'favicon'
+              ? 'Favicons must be PNG, JPEG, WebP, GIF, or ICO files'
+              : 'Logos must be PNG, JPEG, WebP, or GIF files',
+        }),
+      );
+    }
+    if (
+      input.fileSizeBytes <= 0 ||
+      input.fileSizeBytes > MAX_TENANT_BRAND_ASSET_SIZE_BYTES
+    ) {
+      return yield* Effect.fail(
+        new RpcBadRequestError({
+          message: 'Brand asset file must be between 1 byte and 5 MB',
+        }),
+      );
+    }
+
+    const body = Buffer.from(input.fileBase64, 'base64');
+    if (body.byteLength !== input.fileSizeBytes) {
+      return yield* Effect.fail(
+        new RpcBadRequestError({
+          message: 'Uploaded file size does not match payload metadata',
+        }),
+      );
+    }
+
+    const extension = extensionByMimeType.get(input.mimeType);
+    if (!extension) {
+      return yield* Effect.fail(
+        new RpcBadRequestError({
+          message: 'Unsupported brand asset MIME type',
+        }),
+      );
+    }
+
+    const safeBaseName = sanitizeTenantBrandAssetFileName(input.fileName)
+      .replace(/\.[^.]+$/, '')
+      .slice(0, 80);
+    const fileName = `${randomUUID()}-${safeBaseName}.${extension}`;
+    const storageKey = tenantBrandAssetStorageKey({
+      fileName,
+      kind: input.kind,
+      tenantId: input.tenantId,
+    });
+
+    yield* uploadObjectToR2({
+      body,
+      contentType: input.mimeType,
+      key: storageKey,
+    }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new RpcInternalServerError({
+            cause,
+            message: 'Failed to upload tenant brand asset',
+          }),
+      ),
+    );
+
+    return {
+      assetUrl: tenantBrandAssetUrl({
+        fileName,
+        kind: input.kind,
+        tenantId: input.tenantId,
+      }),
+      sizeBytes: body.byteLength,
+      storageKey,
+    };
+  });

--- a/src/shared/errors/rpc-errors.ts
+++ b/src/shared/errors/rpc-errors.ts
@@ -67,15 +67,6 @@ export type BadRequestForbiddenOrUnauthorizedRpcError = Schema.Schema.Type<
   typeof BadRequestForbiddenOrUnauthorizedRpcError
 >;
 
-export const BadRequestInternalUnauthorizedRpcError = Schema.Union([
-  RpcBadRequestError,
-  RpcInternalServerError,
-  RpcUnauthorizedError,
-]);
-export type BadRequestInternalUnauthorizedRpcError = Schema.Schema.Type<
-  typeof BadRequestInternalUnauthorizedRpcError
->;
-
 export const BadRequestForbiddenInternalUnauthorizedRpcError = Schema.Union([
   RpcBadRequestError,
   RpcForbiddenError,
@@ -84,3 +75,12 @@ export const BadRequestForbiddenInternalUnauthorizedRpcError = Schema.Union([
 ]);
 export type BadRequestForbiddenInternalUnauthorizedRpcError =
   Schema.Schema.Type<typeof BadRequestForbiddenInternalUnauthorizedRpcError>;
+
+export const BadRequestInternalUnauthorizedRpcError = Schema.Union([
+  RpcBadRequestError,
+  RpcInternalServerError,
+  RpcUnauthorizedError,
+]);
+export type BadRequestInternalUnauthorizedRpcError = Schema.Schema.Type<
+  typeof BadRequestInternalUnauthorizedRpcError
+>;

--- a/src/shared/permissions/permissions.spec.ts
+++ b/src/shared/permissions/permissions.spec.ts
@@ -5,6 +5,7 @@ import {
   ALL_PERMISSIONS,
   includesPermission,
   PERMISSION_GROUPS,
+  permissionLabel,
   PermissionSchema,
 } from './permissions';
 
@@ -53,6 +54,19 @@ describe('PERMISSION_GROUPS', () => {
           label: 'Assign user roles (future)',
         }),
       ]),
+    );
+  });
+});
+
+describe('permissionLabel', () => {
+  it('returns admin-facing labels for dependency copy', () => {
+    expect(permissionLabel('templates:view')).toBe('View templates');
+    expect(permissionLabel('events:seeDrafts')).toBe('See draft events');
+  });
+
+  it('falls back to the key for technical permissions that are not role-form entries', () => {
+    expect(permissionLabel('globalAdmin:manageTenants')).toBe(
+      'globalAdmin:manageTenants',
     );
   });
 });

--- a/src/shared/permissions/permissions.ts
+++ b/src/shared/permissions/permissions.ts
@@ -246,6 +246,10 @@ const permissionMeta = (key: Permission): PermissionMeta => ({
   ...PERMISSION_METADATA[key as keyof typeof PERMISSION_METADATA],
 });
 
+export const permissionLabel = (permission: Permission): string =>
+  PERMISSION_METADATA[permission as keyof typeof PERMISSION_METADATA]?.label ??
+  permission;
+
 export const PERMISSION_GROUPS: PermissionGroup[] = [
   {
     icon: faGear,

--- a/src/shared/registration-modes.spec.ts
+++ b/src/shared/registration-modes.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type RegistrationMode,
+  registrationModeLabel,
+  registrationModeLabels,
+} from './registration-modes';
+
+describe('registrationModeLabel', () => {
+  it('renders readable labels for every persisted registration mode', () => {
+    const modes: readonly RegistrationMode[] = [
+      'application',
+      'fcfs',
+      'random',
+    ];
+
+    expect(Object.keys(registrationModeLabels).toSorted()).toEqual(
+      [...modes].toSorted(),
+    );
+    expect(modes.map((mode) => registrationModeLabel(mode))).toEqual([
+      'Application review',
+      'First come, first served',
+      'Random allocation',
+    ]);
+  });
+});

--- a/src/shared/registration-modes.ts
+++ b/src/shared/registration-modes.ts
@@ -1,0 +1,10 @@
+export type RegistrationMode = 'application' | 'fcfs' | 'random';
+
+export const registrationModeLabels: Record<RegistrationMode, string> = {
+  application: 'Application review',
+  fcfs: 'First come, first served',
+  random: 'Random allocation',
+};
+
+export const registrationModeLabel = (mode: RegistrationMode) =>
+  registrationModeLabels[mode];

--- a/src/shared/rpc-contracts/app-rpcs/admin.errors.ts
+++ b/src/shared/rpc-contracts/app-rpcs/admin.errors.ts
@@ -1,5 +1,5 @@
 import {
-  RpcBadRequestError,
+  BadRequestForbiddenInternalUnauthorizedRpcError,
   RpcForbiddenError,
   RpcUnauthorizedError,
 } from '@shared/errors/rpc-errors';
@@ -29,10 +29,8 @@ export class AdminTenantNotFoundError extends Schema.TaggedErrorClass<AdminTenan
 ) {}
 
 export const AdminTenantRpcError = Schema.Union([
-  RpcBadRequestError,
-  RpcForbiddenError,
+  BadRequestForbiddenInternalUnauthorizedRpcError,
   AdminTenantNotFoundError,
-  RpcUnauthorizedError,
 ]);
 export type AdminTenantRpcError = Schema.Schema.Type<
   typeof AdminTenantRpcError

--- a/src/shared/rpc-contracts/app-rpcs/admin.rpcs.spec.ts
+++ b/src/shared/rpc-contracts/app-rpcs/admin.rpcs.spec.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'effect';
 import { describe, expect, it } from 'vitest';
 
-import { AdminTenantUpdateSettingsInput } from './admin.rpcs';
+import {
+  AdminTenantBrandAssetKind,
+  AdminTenantUpdateSettingsInput,
+} from './admin.rpcs';
 
 const currentTenantSettingsInput = {
   allowOther: true,
@@ -64,14 +67,52 @@ describe('AdminTenantUpdateSettingsInput', () => {
     ).toThrow();
   });
 
-  it('keeps deferred domain and upload fields outside the current update payload', () => {
+  it('keeps deferred domain fields outside the current update payload', () => {
     const decoded = Schema.decodeUnknownSync(AdminTenantUpdateSettingsInput)({
       ...currentTenantSettingsInput,
       customDomain: 'section.example.org',
-      logoUpload: 'logo.svg',
       senderName: 'Example Section',
     });
 
     expect(decoded).toEqual(currentTenantSettingsInput);
+  });
+
+  it('accepts uploaded tenant brand asset paths', () => {
+    const decoded = Schema.decodeUnknownSync(AdminTenantUpdateSettingsInput)({
+      ...currentTenantSettingsInput,
+      faviconUrl: '/tenant-assets/tenant-1/favicon/favicon.ico',
+      logoUrl: '/tenant-assets/tenant-1/logo/logo.svg',
+    });
+
+    expect(decoded.faviconUrl).toBe(
+      '/tenant-assets/tenant-1/favicon/favicon.ico',
+    );
+    expect(decoded.logoUrl).toBe('/tenant-assets/tenant-1/logo/logo.svg');
+  });
+
+  it('keeps non-brand tenant URLs absolute', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(AdminTenantUpdateSettingsInput)({
+        ...currentTenantSettingsInput,
+        termsUrl: '/tenant-assets/tenant-1/terms.pdf',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('AdminTenantBrandAssetKind', () => {
+  it('accepts the supported tenant branding upload targets', () => {
+    expect(Schema.decodeUnknownSync(AdminTenantBrandAssetKind)('logo')).toBe(
+      'logo',
+    );
+    expect(Schema.decodeUnknownSync(AdminTenantBrandAssetKind)('favicon')).toBe(
+      'favicon',
+    );
+  });
+
+  it('rejects unsupported tenant branding upload targets', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(AdminTenantBrandAssetKind)('hero'),
+    ).toThrow();
   });
 });

--- a/src/shared/rpc-contracts/app-rpcs/admin.rpcs.ts
+++ b/src/shared/rpc-contracts/app-rpcs/admin.rpcs.ts
@@ -12,7 +12,7 @@ const UrlString = Schema.String.pipe(
   Schema.check(
     Schema.makeFilter((value) => {
       try {
-        new URL(value);
+        new URL(value.trim());
         return;
       } catch {
         return 'Expected a valid URL';
@@ -20,6 +20,27 @@ const UrlString = Schema.String.pipe(
     }),
   ),
 );
+
+const TenantBrandAssetUrlString = Schema.Union([
+  Schema.String.pipe(
+    Schema.check(
+      Schema.makeFilter((value) => {
+        const trimmedValue = value.trim();
+        if (trimmedValue.startsWith('/tenant-assets/')) {
+          return;
+        }
+        try {
+          const url = new URL(trimmedValue);
+          return url.protocol === 'http:' || url.protocol === 'https:'
+            ? undefined
+            : 'Expected an HTTP(S) tenant brand asset URL';
+        } catch {
+          return 'Expected a tenant brand asset URL';
+        }
+      }),
+    ),
+  ),
+]);
 
 export const AdminRoleRecord = Schema.Struct({
   collapseMembersInHup: Schema.Boolean,
@@ -209,11 +230,11 @@ export const AdminTenantUpdateSettingsInput = Schema.Struct({
   currency: Tenant.fields.currency,
   defaultLocation: Schema.NullOr(Schema.Any),
   esnCardEnabled: Schema.Boolean,
-  faviconUrl: Schema.optional(UrlString),
+  faviconUrl: Schema.optional(TenantBrandAssetUrlString),
   legalNoticeText: Schema.optional(Schema.String),
   legalNoticeUrl: Schema.optional(UrlString),
   locale: Tenant.fields.locale,
-  logoUrl: Schema.optional(UrlString),
+  logoUrl: Schema.optional(TenantBrandAssetUrlString),
   privacyPolicyText: Schema.optional(Schema.String),
   privacyPolicyUrl: Schema.optional(UrlString),
   receiptCountries: Schema.Array(Schema.NonEmptyString),
@@ -228,6 +249,29 @@ export const AdminTenantUpdateSettingsInput = Schema.Struct({
 export type AdminTenantUpdateSettingsInput = Schema.Schema.Type<
   typeof AdminTenantUpdateSettingsInput
 >;
+
+export const AdminTenantBrandAssetKind = literalUnion('favicon', 'logo');
+export type AdminTenantBrandAssetKind = Schema.Schema.Type<
+  typeof AdminTenantBrandAssetKind
+>;
+
+export const AdminTenantUploadBrandAsset = asRpcMutation(
+  Rpc.make('admin.tenant.uploadBrandAsset', {
+    error: AdminTenantRpcError,
+    payload: Schema.Struct({
+      fileBase64: Schema.NonEmptyString,
+      fileName: Schema.NonEmptyString,
+      fileSizeBytes: Schema.Number,
+      kind: AdminTenantBrandAssetKind,
+      mimeType: Schema.NonEmptyString,
+    }),
+    success: Schema.Struct({
+      assetUrl: Schema.NonEmptyString,
+      sizeBytes: Schema.Number,
+      storageKey: Schema.NonEmptyString,
+    }),
+  }),
+);
 
 export const AdminTenantUpdateSettings = asRpcMutation(
   Rpc.make('admin.tenant.updateSettings', {
@@ -248,5 +292,6 @@ export class AdminRpcs extends RpcGroup.make(
   AdminTenantImportStripeTaxRates,
   AdminTenantListImportedTaxRates,
   AdminTenantListStripeTaxRates,
+  AdminTenantUploadBrandAsset,
   AdminTenantUpdateSettings,
 ) {}

--- a/src/shared/rpc-contracts/app-rpcs/events.rpcs.ts
+++ b/src/shared/rpc-contracts/app-rpcs/events.rpcs.ts
@@ -1,4 +1,5 @@
 import { asRpcMutation, asRpcQuery } from '@heddendorp/effect-angular-query';
+import { notificationEmailPattern } from '@shared/notification-email';
 import { literalUnion, nonNegativeNumber } from '@shared/schema-utilities';
 import { Effect, Schema } from 'effect';
 import * as Rpc from 'effect/unstable/rpc/Rpc';
@@ -22,6 +23,10 @@ import {
   EventsUpdateListingRpcError,
   EventsUpdateRpcError,
 } from './events.errors';
+
+const TransferTargetEmail = Schema.NonEmptyString.check(
+  Schema.isPattern(notificationEmailPattern),
+);
 
 export const EventReviewStatus = literalUnion(
   'APPROVED',
@@ -79,6 +84,29 @@ export const EventsCancelEventRegistration = asRpcMutation(
     payload: Schema.Struct({
       eventId: Schema.NonEmptyString,
       registrationId: Schema.NonEmptyString,
+    }),
+    success: Schema.Void,
+  }),
+);
+
+export const EventsTransferEventRegistration = asRpcMutation(
+  Rpc.make('events.transferEventRegistration', {
+    error: EventsCheckInRegistrationError,
+    payload: Schema.Struct({
+      eventId: Schema.NonEmptyString,
+      registrationId: Schema.NonEmptyString,
+      targetUserId: Schema.NonEmptyString,
+    }),
+    success: Schema.Void,
+  }),
+);
+
+export const EventsTransferMyRegistration = asRpcMutation(
+  Rpc.make('events.transferMyRegistration', {
+    error: EventsCheckInRegistrationError,
+    payload: Schema.Struct({
+      registrationId: Schema.NonEmptyString,
+      targetEmail: TransferTargetEmail,
     }),
     success: Schema.Void,
   }),
@@ -316,6 +344,25 @@ export const EventsGetOrganizeOverview = asRpcQuery(
   }),
 );
 
+export const EventsTransferTargetRecord = Schema.Struct({
+  email: Schema.String,
+  firstName: Schema.String,
+  id: Schema.NonEmptyString,
+  lastName: Schema.String,
+});
+
+export const EventsFindTransferTargets = asRpcQuery(
+  Rpc.make('events.findTransferTargets', {
+    error: EventsCheckInRegistrationError,
+    payload: Schema.Struct({
+      eventId: Schema.NonEmptyString,
+      registrationId: Schema.NonEmptyString,
+      search: Schema.optional(Schema.String),
+    }),
+    success: Schema.Array(EventsTransferTargetRecord),
+  }),
+);
+
 export const EventsRegistrationStatusRecord = Schema.Struct({
   appliedDiscountedPrice: Schema.optional(Schema.NullOr(Schema.Number)),
   appliedDiscountType: Schema.optional(
@@ -331,6 +378,7 @@ export const EventsRegistrationStatusRecord = Schema.Struct({
   registrationOptionId: Schema.NonEmptyString,
   registrationOptionTitle: Schema.NonEmptyString,
   status: EventsRegistrationStatus,
+  transferAvailable: Schema.Boolean,
 });
 
 export type EventsRegistrationStatusRecord = Schema.Schema.Type<
@@ -494,12 +542,15 @@ export class EventsRpcs extends RpcGroup.make(
   EventsCancelPendingRegistration,
   EventsCancelRegistration,
   EventsCancelEventRegistration,
+  EventsTransferEventRegistration,
+  EventsTransferMyRegistration,
   EventsCanOrganize,
   EventsCheckInRegistration,
   EventsCreate,
   EventsEventList,
   EventsFindOne,
   EventsFindOneForEdit,
+  EventsFindTransferTargets,
   EventsGetOrganizeOverview,
   EventsGetPendingReviews,
   EventsGetRegistrationStatus,

--- a/src/shared/rpc-contracts/app-rpcs/global-admin.rpcs.spec.ts
+++ b/src/shared/rpc-contracts/app-rpcs/global-admin.rpcs.spec.ts
@@ -1,0 +1,43 @@
+import { Schema } from 'effect';
+import { describe, expect, it } from 'vitest';
+
+import { GlobalAdminTenantWriteInput } from './global-admin.rpcs';
+
+const tenantWriteInput = {
+  currency: 'EUR' as const,
+  domain: 'tenant.example.com',
+  locale: 'en-GB' as const,
+  name: 'Tenant',
+  stripeAccountId: 'acct_123',
+  theme: 'evorto' as const,
+  timezone: 'Europe/Berlin' as const,
+};
+
+describe('GlobalAdminTenantWriteInput', () => {
+  it('accepts the global-admin tenant create/edit surface', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(GlobalAdminTenantWriteInput)(tenantWriteInput),
+    ).not.toThrow();
+  });
+
+  it('rejects unsupported tenant runtime settings', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(GlobalAdminTenantWriteInput)({
+        ...tenantWriteInput,
+        currency: 'USD',
+      }),
+    ).toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(GlobalAdminTenantWriteInput)({
+        ...tenantWriteInput,
+        locale: 'de-DE',
+      }),
+    ).toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(GlobalAdminTenantWriteInput)({
+        ...tenantWriteInput,
+        timezone: 'America/New_York',
+      }),
+    ).toThrow();
+  });
+});

--- a/src/shared/rpc-contracts/app-rpcs/global-admin.rpcs.ts
+++ b/src/shared/rpc-contracts/app-rpcs/global-admin.rpcs.ts
@@ -1,14 +1,14 @@
-import { asRpcQuery } from '@heddendorp/effect-angular-query';
+import { asRpcMutation, asRpcQuery } from '@heddendorp/effect-angular-query';
 import { Schema } from 'effect';
 import * as Rpc from 'effect/unstable/rpc/Rpc';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
 import { Tenant } from '../../../types/custom/tenant';
-import { ForbiddenOrUnauthorizedRpcError } from '../../errors/rpc-errors';
+import { BadRequestForbiddenOrUnauthorizedRpcError } from '../../errors/rpc-errors';
 
-export const GlobalAdminRpcError = ForbiddenOrUnauthorizedRpcError;
+export const GlobalAdminRpcError = BadRequestForbiddenOrUnauthorizedRpcError;
 
-export type GlobalAdminRpcError = ForbiddenOrUnauthorizedRpcError;
+export type GlobalAdminRpcError = BadRequestForbiddenOrUnauthorizedRpcError;
 
 export const GlobalAdminTenantRecord = Schema.Struct({
   currency: Tenant.fields.currency,
@@ -16,6 +16,7 @@ export const GlobalAdminTenantRecord = Schema.Struct({
   id: Schema.NonEmptyString,
   locale: Tenant.fields.locale,
   name: Schema.NonEmptyString,
+  stripeAccountId: Schema.NullOr(Schema.String),
   stripeConnected: Schema.Boolean,
   theme: Tenant.fields.theme,
   timezone: Tenant.fields.timezone,
@@ -28,6 +29,20 @@ export type GlobalAdminTenantRecord = Schema.Schema.Type<
 export const GlobalAdminTenantIdInput = Schema.Struct({
   id: Schema.NonEmptyString,
 });
+
+export const GlobalAdminTenantWriteInput = Schema.Struct({
+  currency: Tenant.fields.currency,
+  domain: Schema.NonEmptyString,
+  locale: Tenant.fields.locale,
+  name: Schema.NonEmptyString,
+  stripeAccountId: Schema.optional(Schema.NullOr(Schema.NonEmptyString)),
+  theme: Tenant.fields.theme,
+  timezone: Tenant.fields.timezone,
+});
+
+export type GlobalAdminTenantWriteInput = Schema.Schema.Type<
+  typeof GlobalAdminTenantWriteInput
+>;
 
 export const GlobalAdminTenantsFindMany = asRpcQuery(
   Rpc.make('globalAdmin.tenants.findMany', {
@@ -45,7 +60,34 @@ export const GlobalAdminTenantsFindOne = asRpcQuery(
   }),
 );
 
+export const GlobalAdminTenantsCreate = asRpcMutation(
+  Rpc.make('globalAdmin.tenants.create', {
+    error: GlobalAdminRpcError,
+    payload: GlobalAdminTenantWriteInput,
+    success: GlobalAdminTenantRecord,
+  }),
+);
+
+export const GlobalAdminTenantsUpdate = asRpcMutation(
+  Rpc.make('globalAdmin.tenants.update', {
+    error: GlobalAdminRpcError,
+    payload: Schema.Struct({
+      currency: Tenant.fields.currency,
+      domain: Schema.NonEmptyString,
+      id: Schema.NonEmptyString,
+      locale: Tenant.fields.locale,
+      name: Schema.NonEmptyString,
+      stripeAccountId: Schema.optional(Schema.NullOr(Schema.NonEmptyString)),
+      theme: Tenant.fields.theme,
+      timezone: Tenant.fields.timezone,
+    }),
+    success: GlobalAdminTenantRecord,
+  }),
+);
+
 export class GlobalAdminRpcs extends RpcGroup.make(
+  GlobalAdminTenantsCreate,
   GlobalAdminTenantsFindOne,
   GlobalAdminTenantsFindMany,
+  GlobalAdminTenantsUpdate,
 ) {}

--- a/src/shared/rpc-contracts/app-rpcs/templates.rpcs.ts
+++ b/src/shared/rpc-contracts/app-rpcs/templates.rpcs.ts
@@ -71,7 +71,29 @@ export const TemplateRegistrationOptionRecord = Schema.Struct({
   title: Schema.NonEmptyString,
 });
 
+export const TemplateAddonRegistrationOptionRecord = Schema.Struct({
+  quantity: Schema.Number,
+  registrationOptionId: Schema.NonEmptyString,
+});
+
+export const TemplateAddonRecord = Schema.Struct({
+  allowMultiple: Schema.Boolean,
+  allowPurchaseBeforeEvent: Schema.Boolean,
+  allowPurchaseDuringEvent: Schema.Boolean,
+  allowPurchaseDuringRegistration: Schema.Boolean,
+  description: Schema.NullOr(Schema.String),
+  id: Schema.NonEmptyString,
+  isPaid: Schema.Boolean,
+  maxQuantityPerUser: Schema.Number,
+  price: Schema.Number,
+  registrationOptions: Schema.Array(TemplateAddonRegistrationOptionRecord),
+  stripeTaxRateId: Schema.NullOr(Schema.NonEmptyString),
+  title: Schema.NonEmptyString,
+  totalAvailableQuantity: Schema.Number,
+});
+
 export const TemplateFindOneRecord = Schema.Struct({
+  addOns: Schema.Array(TemplateAddonRecord),
   categoryId: Schema.NonEmptyString,
   description: Schema.NonEmptyString,
   icon: iconSchema,
@@ -81,6 +103,9 @@ export const TemplateFindOneRecord = Schema.Struct({
   registrationOptions: Schema.Array(TemplateRegistrationOptionRecord),
   title: Schema.NonEmptyString,
 });
+export type TemplateFindOneRecord = Schema.Schema.Type<
+  typeof TemplateFindOneRecord
+>;
 
 export const TemplateListRecord = Schema.Struct({
   icon: iconSchema,

--- a/tests/docs/admin/general-settings.doc.ts
+++ b/tests/docs/admin/general-settings.doc.ts
@@ -41,7 +41,7 @@ The current general settings page supports:
 - **Default Location** for event location search bias.
 - **Site theme** for the tenant theme.
 - **Currency**, **Locale**, and **Timezone** selection within the supported relaunch policy.
-- **Logo URL** and **Favicon URL** for externally hosted tenant brand assets. The configured favicon updates the browser tab icon.
+- **Logo URL** and **Favicon URL** for tenant brand assets. Admins can upload PNG, JPEG, WebP, or GIF logos; favicons also support ICO files. Externally hosted URLs are still supported. The configured favicon updates the browser tab icon.
 - **SEO title** and **SEO description** for tenant-level page metadata.
 - **Legal pages** for tenant imprint/legal notice, privacy policy, and terms. Admins can use external URLs or hosted text. External URLs appear in the public footer as off-site links.
   Hosted text appears at /legal/imprint, /legal/privacy, and /legal/terms.
@@ -56,7 +56,7 @@ Tax rates are managed on the separate **Tax Rates** page.
     body: `
 ## Relaunch scope notes
 
-One-domain-per-tenant remains the current relaunch scope in the application schema. The page now exposes the active primary domain for operator review, allows tenant admins to maintain supported currency, locale, timezone, legal links, and hosted legal text, and keeps an in-app deferred-settings summary for custom domain verification, tenant logo/favicon uploads beyond externally hosted URLs, email sender name, review/publishing policy, registration limits, and Stripe account management. When currency, locale, or timezone changes, Evorto reloads the app after saving so bootstrap-level formatting defaults use the new tenant settings.
+One-domain-per-tenant remains the current relaunch scope in the application schema. The page now exposes the active primary domain for operator review, allows tenant admins to maintain supported currency, locale, timezone, uploaded or externally hosted logo/favicon assets, legal links, and hosted legal text, and keeps an in-app deferred-settings summary for custom domain verification, email sender name, review/publishing policy, registration limits, and Stripe account management. When currency, locale, or timezone changes, Evorto reloads the app after saving so bootstrap-level formatting defaults use the new tenant settings.
 `,
   });
 });

--- a/tests/docs/admin/global-admin.doc.ts
+++ b/tests/docs/admin/global-admin.doc.ts
@@ -17,7 +17,7 @@ For this guide, we assume you have the **globalAdmin:manageTenants** permission 
 
 # Global Tenant Administration
 
-Global admins can review tenants from the **Global admin** area. This is a platform-level workflow: the permission is independent from normal tenant roles, but opening a tenant domain still requires valid tenant user context for tenant-scoped app pages.
+Global admins can review, create, and edit tenants from the **Global admin** area. This is a platform-level workflow: the permission is independent from normal tenant roles, but opening a tenant domain still requires valid tenant user context for tenant-scoped app pages.
 `,
   });
 
@@ -26,6 +26,7 @@ Global admins can review tenants from the **Global admin** area. This is a platf
   ).toBeVisible();
   await page.getByRole('link', { name: 'Tenants' }).click();
   await expect(page.getByRole('heading', { name: 'Tenants' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Create tenant' })).toBeVisible();
   await expect(page.getByLabel('Search tenants')).toBeVisible();
   await expect(page.getByText('Primary domain').first()).toBeVisible();
   await expect(page.getByText('Tenant ID').first()).toBeVisible();
@@ -39,6 +40,7 @@ Global admins can review tenants from the **Global admin** area. This is a platf
   await expect(
     page.getByText('Read-only operational tenant review'),
   ).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Edit tenant' })).toBeVisible();
   await expect(
     page.getByRole('link', { name: 'Open tenant domain' }),
   ).toBeVisible();
@@ -48,14 +50,31 @@ Global admins can review tenants from the **Global admin** area. This is a platf
     page,
     'Global admin tenant detail',
   );
+  await page.getByRole('link', { name: 'Edit tenant' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Relaunch tenant scope' }),
+  ).toBeVisible();
+  await expect(
+    page.getByText('One active primary domain is managed here.'),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      'Custom-domain verification and multi-domain automation are deferred.',
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      'Tenant-admin impersonation is not available from this form.',
+    ),
+  ).toBeVisible();
 
   await testInfo.attach('markdown', {
     body: `
 ## Current relaunch surface
 
-The current global-admin page is a searchable tenant list with a read-only tenant detail review. Each entry shows the tenant name, domain, tenant id, theme, locale, currency, timezone, and Stripe connection state for support and operational review. The tenant detail page repeats the operational fields and provides an external link to open the tenant's primary domain.
+The current global-admin page is a searchable tenant list with tenant creation, tenant editing, and a tenant detail review. Each entry shows the tenant name, domain, tenant id, theme, locale, currency, timezone, and Stripe connection state plus connected account id for support and operational review. The tenant detail page repeats the operational fields, links to the edit form, and provides an external link to open the tenant's primary domain.
 
-Tenant creation, tenant editing, custom-domain verification, and impersonation are not implemented in this surface yet.
+Tenant create/edit manages the one active primary domain, name, theme, locale, currency, timezone, and connected Stripe account id. The create/edit forms show the relaunch tenant scope directly: one active primary domain is managed here, custom-domain verification and multi-domain automation are deferred, and tenant-admin impersonation is not available from the form.
 `,
   });
 });

--- a/tests/docs/events/event-management.doc.ts
+++ b/tests/docs/events/event-management.doc.ts
@@ -217,10 +217,11 @@ The organizer view currently includes:
 
 Organizers check in attendees from the dedicated QR scanner. Attendees open their ticket QR code from the event registration page after a confirmed registration, and organizers scan it from **Scan**. The scanned-registration page shows the attendee, event, registration option, ESNcard discount marker when applicable, guest check-in progress when guests are attached to the registration, and warnings for self-scan, future events, non-confirmed registrations, and already checked-in tickets.
 
-Check-in is available to event organizers and users with event-wide organize access during the current check-in window. Confirming check-in records the registration check-in time and updates the checked-in count shown on the organizer overview. When a registration includes guests, the organizer chooses how many guests arrived with the attendee, and the checked-in count increases by the attendee plus the selected guests.
+Check-in is available to event organizers and users with event-wide organize access during the current check-in window. The scanner shows a future-event warning before that window opens. Confirming check-in records the registration check-in time and updates the checked-in count shown on the organizer overview. When a registration includes guests, the organizer chooses how many guests arrived with the attendee, and the checked-in count increases by the attendee plus the selected guests.
 Organizers can also cancel a participant's confirmed registration from the organizer overview before check-in, which releases the confirmed spot without promising an automatic refund.
+For unpaid registrations, organizers can transfer a not-yet-checked-in participant registration to another eligible tenant member. Paid registration transfer still remains blocked until the manual refund or resale money flow is handled.
 
-It does not currently include attendee export, attendee messaging, manual check-in controls outside QR scanning, transfer/resale, or automatic refund controls.
+It does not currently include attendee export, attendee messaging, manual check-in controls outside QR scanning, participant self-service resale, paid registration transfer, or automatic refund controls.
 Those flows should be documented separately when they exist in the product.
 
 ## Event Editing

--- a/tests/docs/events/register.doc.ts
+++ b/tests/docs/events/register.doc.ts
@@ -67,7 +67,7 @@ test.describe('Register for events', () => {
     );
     await testInfo.attach('markdown', {
       body: `
-  After selecting a free event, all left to do is press the **Register** button for the option you chose. After that, you will see your confirmation and ticket QR code.`,
+  After selecting a free event, all left to do is press the **Register** button for the option you chose. After that, you will see your confirmation, ticket QR code, cancellation action, and an unpaid transfer action when the registration is still eligible for self-service transfer.`,
     });
     const participantRegistrationCard = page
       .locator('app-event-registration-option')

--- a/tests/docs/profile/discounts.doc.ts
+++ b/tests/docs/profile/discounts.doc.ts
@@ -36,7 +36,7 @@ Add your ESN card to receive discounted prices on eligible events. Your card is 
 
   await testInfo.attach('markdown', {
     body: `
-If you already added your ESN card, you will see its status and validity here. You can refresh its status or remove it. Use the form to add or update your ESN card number. The profile page shows clear pending states while the card is checked and maps validation/provider errors into readable messages.
+If you already added your ESN card, you will see a readable verification status and validity here. You can refresh its status or remove it. Use the form to add or update your ESN card number. The profile page shows clear pending states while the card is checked and maps validation/provider errors into readable messages.
 `,
   });
 });

--- a/tests/docs/profile/user-profile.doc.ts
+++ b/tests/docs/profile/user-profile.doc.ts
@@ -137,7 +137,7 @@ The user profile now uses a two-column layout:
 - Left side: section navigation cards
 - Right side: selected section content
 - The **Events** section links each registration back to event details, shows registration status, selected option, guest quantity when applicable, payment state, and check-in time when available, and exposes implemented recovery actions such as continuing a pending checkout payment or opening the event page where confirmed tickets are shown
-- Profile event cards point pending checkout registrations at the implemented profile action, route ticket/cancellation details back to the event page, and keep automatic refunds plus transfer/resale visibly out of the current implemented scope
+- Profile event cards point pending checkout registrations at the implemented profile action, route ticket/cancellation/unpaid-transfer details back to the event page, and stop advertising cancellation or transfer once a registration is checked in
 - Other sections include **Overview**, **Discounts**, and **Receipts**
 `,
     });

--- a/tests/docs/roles/about-permissions.doc.ts
+++ b/tests/docs/roles/about-permissions.doc.ts
@@ -1,6 +1,7 @@
 import {
   PERMISSION_DEPENDENCIES,
   PERMISSION_GROUPS,
+  permissionLabel,
 } from '../../../src/shared/permissions/permissions';
 import { expect, test } from '../../support/fixtures/parallel-test';
 
@@ -17,7 +18,7 @@ const permissionLines = () =>
         `- What it allows: ${permission.description}`,
         ...(dependencies.length > 0
           ? [
-              `- Also includes: ${dependencies.map((key) => `\`${key}\``).join(', ')}`,
+              `- Also includes: ${dependencies.map((key) => `${permissionLabel(key)} (\`${key}\`)`).join(', ')}`,
             ]
           : []),
         '',

--- a/tests/docs/roles/roles.doc.ts
+++ b/tests/docs/roles/roles.doc.ts
@@ -45,7 +45,7 @@ There are some flags you can set:
 
 You can also add permissions to the role. The permissions are grouped by category. Learn more at [about permissions](/docs/about-permissions).
 
-Permissions that are required by another permission are automatically included and shown as non-editable dependent permissions.
+Permissions that are required by another permission are automatically included and shown as non-editable dependent permissions with the same admin-facing labels used in the permission reference.
 `,
   });
   await page.getByRole('textbox', { name: 'Name' }).fill('Test role');

--- a/tests/specs/permissions/global-admin-route-guard.spec.ts
+++ b/tests/specs/permissions/global-admin-route-guard.spec.ts
@@ -24,6 +24,29 @@ test.describe('global admin route guard allow path', () => {
       page.getByText('Read-only operational tenant review'),
     ).toBeVisible();
   });
+
+  test('allows global tenant admins to open tenant creation directly @permissions @globalAdmin', async ({
+    page,
+  }) => {
+    await page.goto('/global-admin/tenants/create');
+    await expect(page).toHaveURL(/\/global-admin\/tenants\/create/);
+    await expect(
+      page.getByRole('heading', { name: 'Create tenant' }),
+    ).toBeVisible();
+  });
+
+  test('allows global tenant admins to open tenant editing directly @permissions @globalAdmin', async ({
+    page,
+    tenant,
+  }) => {
+    await page.goto(`/global-admin/tenants/${tenant.id}/edit`);
+    await expect(page).toHaveURL(
+      new RegExp(`/global-admin/tenants/${tenant.id}/edit`),
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Edit tenant' }),
+    ).toBeVisible();
+  });
 });
 
 test.describe('global admin route guard deny path', () => {
@@ -41,6 +64,17 @@ test.describe('global admin route guard deny path', () => {
     tenant,
   }) => {
     await page.goto(`/global-admin/tenants/${tenant.id}`);
+    await expect(page).toHaveURL(/\/403/);
+  });
+
+  test('denies direct tenant create and edit routes without global tenant-admin permission @permissions @globalAdmin', async ({
+    page,
+    tenant,
+  }) => {
+    await page.goto('/global-admin/tenants/create');
+    await expect(page).toHaveURL(/\/403/);
+
+    await page.goto(`/global-admin/tenants/${tenant.id}/edit`);
     await expect(page).toHaveURL(/\/403/);
   });
 });

--- a/tests/specs/scanning/scanner.test.ts
+++ b/tests/specs/scanning/scanner.test.ts
@@ -82,7 +82,7 @@ test.skip('scan confirmed registration records check-in', async ({
       page.getByRole('heading', { name: 'Registration scanned' }),
     ).toBeVisible();
     await page.getByLabel('Guests to check in now').fill('2');
-    await page.getByRole('button', { name: 'Confirm 3 Check Ins' }).click();
+    await page.getByRole('button', { name: 'Confirm 3 check-ins' }).click();
     await expect(page.getByText('Check-in recorded')).toBeVisible();
 
     await expect

--- a/tests/specs/seed/seed-baseline.test.ts
+++ b/tests/specs/seed/seed-baseline.test.ts
@@ -35,6 +35,15 @@ test.describe('baseline seed invariants', () => {
         ]),
       );
     expect.soft(templates.every((template) => template.icon)).toBeTruthy();
+    const seededAddOns = templates.flatMap((template) => template.addOns);
+    expect.soft(seededAddOns.length).toBeGreaterThanOrEqual(2);
+    expect.soft(seededAddOns.some((addOn) => addOn.isPaid)).toBeTruthy();
+    expect.soft(seededAddOns.some((addOn) => !addOn.isPaid)).toBeTruthy();
+    expect
+      .soft(
+        seededAddOns.every((addOn) => addOn.registrationOptionIds.length > 0),
+      )
+      .toBeTruthy();
 
     expect(events.length).toBeGreaterThan(0);
     const allOptions = events.flatMap((e) => e.registrationOptions);

--- a/tests/support/fixtures/parallel-test.ts
+++ b/tests/support/fixtures/parallel-test.ts
@@ -62,6 +62,12 @@ interface BaseFixtures {
     title: string;
   }[];
   templates: {
+    addOns: {
+      id: string;
+      isPaid: boolean;
+      registrationOptionIds: string[];
+      title: string;
+    }[];
     description: string;
     icon: string;
     id: string;

--- a/tests/test-inventory.md
+++ b/tests/test-inventory.md
@@ -76,17 +76,29 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
   - `docs/events/**`
   - `specs/events/**`
   - `specs/discounts/esn-discounts.test.ts`
+  - app event edit, lifecycle-action, and organizer-action guard coverage in
+    `src/app/events`
 - Templates and categories:
   - `docs/templates/templates.doc.ts`
   - `docs/template-categories/categories.doc.ts`
   - `specs/templates/**`
   - `specs/template-categories/**`
+  - app category action guard coverage in `src/app/templates/categories`
+  - app create/edit submit-guard coverage in
+    `src/app/templates/shared/template-form`
+  - app template detail reusable add-on label coverage in
+    `src/app/templates/template-details`
+  - app mapper and submit-guard coverage in
+    `src/app/templates/template-create-event`
+  - shared registration-mode label coverage in `src/shared`
 - Roles and permissions:
   - `docs/roles/about-permissions.doc.ts`
   - `docs/roles/roles.doc.ts`
   - `specs/permissions/**`
-  - route-manifest specs in `src/app/admin`, `src/app/finance`,
-    `src/app/global-admin`, and `src/app/templates`
+  - shared permission-guard denial coverage in `src/app/core/guards`
+  - route-manifest and event-review queue action coverage in `src/app/admin`
+  - route-manifest specs in `src/app/finance`, `src/app/global-admin`, and
+    `src/app/templates`
 - Tenant/global admin:
   - `docs/admin/global-admin.doc.ts`
   - `docs/admin/general-settings.doc.ts`
@@ -97,6 +109,8 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
 - Profile and account:
   - `docs/profile/**`
   - `docs/users/create-account.doc.ts`
+  - app profile edit, event-card, receipt-card, and ESNcard action coverage in
+    `src/app/profile`
 - Scanning/check-in:
   - `docs/events/event-management.doc.ts`
   - `specs/scanning/scanner.test.ts`
@@ -106,8 +120,8 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
   - `specs/screenshot/doc-screenshot.test.ts`
   - `specs/seed/seed-baseline.test.ts` proves the seeded tenant has default
     roles, all template families, paid/free registration options, paid tax-rate
-    wiring, scenario handles, confirmed registrations, and checked-in scanner
-    aggregates.
+    wiring, reusable template add-ons, scenario handles, confirmed
+    registrations, and checked-in scanner aggregates.
   - `specs/smoke/load-application.test.ts`
 
 ## Intentional Gaps and Gates
@@ -117,6 +131,14 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
   "Tax free" display, fallback tax labels when rate details are missing,
   discounted ESNcard prices retaining tax labels, and paid template detail
   summaries sharing the same inclusive price component.
+- Event detail component coverage pins review and submit-for-review action
+  guards for permission, status, and mutation-pending states so the page and
+  handlers share the same lifecycle write boundaries.
+- Event registration option component coverage pins participant registration and
+  waitlist action disabling while a register or waitlist mutation is pending.
+- Active-registration component coverage pins participant cancellation and
+  self-service transfer action disabling while either write is pending or the
+  transfer is unavailable.
 - `specs/templates/paid-option-requires-tax-rate.spec.ts` has active
   simple-mode UI coverage for the paid-registration tax-rate requirement and a
   seeded inclusive tax-rate save path. Remaining fixme entries are limited to
@@ -126,6 +148,9 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
   selection visible to server validation while clearing hidden free-registration
   payment fields before submission. Server coverage proves the tax-rate select
   source is scoped to current-tenant active inclusive rates.
+- The admin tax-rate import dialog has local unit coverage for the shared import
+  action guard, keeping empty selections and pending imports from submitting
+  duplicate tenant tax-rate writes.
 - `docs/users/create-account.doc.ts` is integration-tagged with
   `@needs-auth0-management`; baseline list/discovery must not require those
   credentials.
@@ -138,35 +163,47 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
 - `specs/permissions/override.test.ts` is active desktop coverage for the
   permission override fixture; no mobile project currently runs this spec.
 - `specs/permissions/global-admin-route-guard.spec.ts` covers direct
-  `/global-admin` and `/global-admin/tenants/:tenantId` allow/deny behavior
-  once page-backed runtime is available.
+  `/global-admin`, `/global-admin/tenants/create`,
+  `/global-admin/tenants/:tenantId`, and
+  `/global-admin/tenants/:tenantId/edit` allow/deny behavior once page-backed
+  runtime is available.
 - Page-backed local execution requires the Playwright Chromium cache installed
   by `bun run test:e2e:install`.
 - `helpers/testing/playwright-skip-inventory.spec.ts` keeps all Playwright
-  `test.skip` and `test.fixme` usage allowlisted so new fixture-state gaps do
-  not become silent placeholders.
+  `test.skip` and `test.fixme` usage allowlisted with a local reason for each
+  entry, so new fixture-state gaps do not become silent placeholders.
 
 ## Stabilization Coverage Still Needed
 
 - Profile/account:
-  - Keep profile edit persistence documentation aligned with the notification
-    email behavior.
+  - Browser-backed profile edit persistence after saving notification email and
+    optional global reimbursement details. Generated docs already exercise the
+    notification-email edit/restore path, and app helper coverage proves payload
+    trimming and blank-value normalization before persistence.
   - Browser-backed profile event-card assertions for event links, registration
     status, guest quantity, payment state, and check-in state.
     App coverage already proves event-detail action copy, guest/status/payment
-    labels, deferred-action notes, waitlist event-page routing, and the
-    payment-continuation next-step copy.
-  - Profile ESNcard save, refresh, and remove flows with readable error states.
+    labels, implemented-action notes, waitlist event-page routing, and the
+    payment-continuation next-step copy. It also proves checked-in profile
+    event cards no longer advertise cancellation or transfer actions.
+    Organizer overview app coverage also proves checked-in rows and in-flight
+    writes disable participant cancellation and organizer-assisted transfer.
+  - Browser-backed ESNcard add, refresh, and remove flows with readable error
+    states.
     App and server coverage already prove upsert payload normalization,
-    readable mutation errors, global per-user card reads/upserts, refresh
-    persistence, and scoped removal.
+    readable mutation errors, readable status labels, save/refresh/remove action states, global
+    per-user card reads/upserts, refresh persistence, and scoped removal.
+    Local app coverage also proves that save, refresh, and remove actions share
+    an in-flight guard so profile discount-card writes do not overlap.
     App coverage also proves the `#discounts` profile fragment waits for
     tenant ESNcard provider availability before selecting the section.
   - Browser-backed account-creation retry and tenant-join behavior. Server
     coverage already proves transactional creation, existing-global-user tenant
     joins, duplicate-assignment conflicts, and visible create-account error
     message mapping. App helper coverage proves Auth0-data prefill,
-    email-verification gating, payload normalization, and error-message mapping.
+    email-verification gating, payload normalization, error-message mapping, and
+    the invalid/submitting/mutation-pending submit guard now shared by the
+    visible submit button and handler.
     Shared RPC schema coverage proves account-creation and profile-update
     notification email format validation, matching the create-account/profile
     edit form validators.
@@ -176,6 +213,10 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
     Root route-manifest coverage keeps `/create-account` reachable to
     authenticated users without a tenant assignment while protected feature
     routes keep assigned-account and auth guards.
+  - Browser-backed submitted-receipt visibility after a receipt submission.
+    Local app/server coverage already proves readable submitted-receipt status
+    labels, amount formatting, and `finance.receipts.my` profile-card row
+    normalization.
 - Finance/receipts:
   - Keep finance route-denial cases and route-manifest specs aligned as
     transaction, receipt approval, and reimbursement routes change.
@@ -183,8 +224,17 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
     notification and manual money-movement scope. Local component coverage,
     finance docs, and receipt flow specs now pin that the reimbursement queue
     records an Evorto transaction only, that money movement remains manual
-    through the selected payout method, and that finance receipt contact details
-    prefer the submitter's notification email with login email fallback.
+    through the selected payout method, that reimbursement actions require a
+    selected receipt plus the chosen payout detail, that selected totals sum the
+    selected rows only, that approval/rejection actions stay disabled while the
+    form is invalid, receipt details are loading, or the review mutation is
+    pending, that reimbursement recording stays disabled while the refund
+    mutation is pending, and that finance receipt contact details prefer the
+    submitter's notification email with login email fallback.
+  - Keep event-organizer receipt submission action coverage aligned with the
+    two-step upload-plus-submit flow. Local app coverage now pins that Add
+    receipt remains disabled while the event has not loaded yet, while the
+    original upload is pending, and while the submit mutation is pending.
   - Keep paid-registration webhook counter coverage aligned with buyer-plus-guest
     spot counts. Local shared coverage pins the capacity count helper used by
     webhook completion/expiry updates; Stripe replay specs remain
@@ -195,15 +245,25 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
   - Browser-backed organizer aggregate assertions after guest-quantity scan
     behavior. Local app coverage already proves organizer overview stat
     aggregation reads the same `checkedInSpots` counter updated by scanner
-    check-in mutations. Event-management docs now call out that guest-quantity
-    check-in increments the organizer checked-in count by the attendee plus
-    selected guests.
+    check-in mutations, and scanned-registration component coverage pins
+    check-in button labels plus selected spot-count copy. Event-management docs
+    now call out that guest-quantity check-in increments the organizer
+    checked-in count by the attendee plus selected guests.
+  - Keep scanned-registration action guards aligned with the write/refetch
+    lifecycle. Local app coverage now pins that the check-in action is disabled
+    when scan state disallows it, no spots are selected, the write is pending,
+    or the local success state is already recorded. It also pins guest-count
+    input clamping before the check-in mutation payload is built.
 - Tenant/global admin:
-  - Authenticated Browser review for the global-admin tenant list.
-    Local server/app coverage already proves the list and read-only tenant
-    detail return and render non-sensitive operational tenant state for support
-    review, and local app coverage proves the tenant list can be filtered by
-    operational fields with readable load-failure messages.
+  - Authenticated Browser review for the global-admin tenant list and
+    tenant-create/edit flows. Local server/app coverage already proves the list,
+    tenant detail, tenant create, and tenant edit surfaces return, render, and
+    persist operational tenant state for support review, and local app coverage
+    proves the tenant list can be filtered by operational fields, including
+    connected Stripe account ids, with readable load-failure messages and
+    account labels. Tenant form coverage also proves create/edit payload
+    shaping, mutation-pending submit disabling, and the visible relaunch
+    tenant-scope notice before page-backed runtime is available.
   - Keep tenant settings docs and payload tests aligned when new editable
     tenant settings move out of the deferred-settings summary. Current local
     coverage proves the general-settings form trims optional editable
@@ -211,13 +271,46 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
     currency/locale/timezone selections in the update payload, and normalizes
     blank optional values before the RPC call. Tenant schema, admin-handler, and
     route coverage pin supported relaunch currency/locale/timezone values,
-    hosted legal text fields, and public legal page routes while normalizing
-    legacy context payloads.
+    hosted legal text fields, public legal page routes, and tenant logo/favicon
+    upload storage paths while normalizing legacy context payloads.
+    General-settings identity coverage also pins read-only tenant name, primary
+    domain, and Stripe account support lookup labels.
+    General-settings component coverage also pins that invalid, submitting, and
+    mutation-pending saves stay disabled so slow settings writes cannot
+    double-submit, and that brand-asset uploads stay disabled while any upload
+    is active or mutation-pending.
 - Roles/user management:
   - Browser-backed least-privilege organizer review for event/template role
     selectors. Server coverage already proves lookup permissions and
     lookup-only role results; template autocomplete coverage now fails loudly
     when seeded roles are missing.
+  - Keep app action icons on the Font Awesome component path. Local source
+    coverage now fails if app templates or components reintroduce direct
+    Material icon elements or `MatIconModule`, preserving the shared
+    premium/brand icon package path.
+  - Keep template-to-event mapper coverage aligned with the event form as richer
+    reusable template data is added. Local app coverage now proves event
+    defaults, source registration option ids, registration-window offsets, and
+    private organizer planning tips at the template-to-event boundary. It also
+    pins that reusable add-ons do not enter event form data until event-side
+    add-on fulfillment exists.
+  - Template detail component coverage pins reusable add-on purchase timing and
+    registration-option labels. Server handler coverage pins the current
+    add-on read model while event-side add-on fulfillment remains out of scope.
+    Create-event component coverage pins the visible add-on boundary notice when
+    a template has reusable add-ons.
+  - Seed baseline coverage pins free and paid reusable template add-ons attached
+    to participant template options so the template detail add-on surface has
+    deterministic data once Browser/runtime review is available.
+  - Keep shared registration-mode labels aligned whenever stored modes are
+    implemented or retired. Local shared coverage now keeps event/template
+    authoring controls and template detail summaries away from raw storage ids.
+  - Local shared coverage pins admin-facing permission labels and descriptions,
+    including the labels used for role-form dependency copy and the generated
+    permission reference.
+  - Keep role create/edit submit guards aligned with the write lifecycle. Local
+    app coverage now pins that invalid, submitting, and mutation-pending role
+    forms stay disabled, and the component submit path shares the same guard.
   - User-list/role-assignment coverage once the role-assignment path exists.
     Server coverage already proves the current read-only user list pages tenant
     users before joining role rows and applies search before pagination, so
@@ -241,8 +334,10 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
 - Event, registration, template, finance receipt, scanner, and unlisted-event specs should fail loudly when deterministic fixture state is missing instead of silently passing through skips.
 - Playwright skip/fixme usage is locally audited; add new entries only when
   the gap is intentionally credential-gated or an honest Browser-backed
-  stabilization placeholder.
-- Playwright list/discovery output is intentionally readable: real spec/doc
+  stabilization placeholder, and record the reason in
+  `helpers/testing/playwright-skip-inventory.spec.ts`.
+- Playwright list/discovery output is intentionally readable:
+  `helpers/testing/playwright-skip-inventory.spec.ts` guards that real spec/doc
   titles no longer include placeholder `@track`, `@req`, or `@doc` metadata.
 - `docs/users/create-account.doc.ts` is the only current integration-tagged Playwright path; there is no non-doc integration-only spec yet.
 - Playwright `--list` discovery does not clean or write generated docs output,


### PR DESCRIPTION
## Purpose

This is the fourth #62 split slice. It hardens Playwright title metadata, duplicate-submit guards, permission denial routing, tenant brand persistence, and visible app action states.

## Scope

- Removes placeholder Playwright title metadata and guards test title conventions.
- Adds submit/action guards across event review, receipt review, templates, profile edit, tax-rate import, active registration, and account creation flows.
- Shows template add-ons and seeds template add-on data.
- Keeps app icons on the Font Awesome path used by the split stack.
- Routes permission denials to the not-allowed flow and tightens role lookup/scanner guest count behavior.
- Fixes tenant brand asset persistence and display/readback behavior.

## Runtime and schema impact

This slice is mostly app behavior, test metadata, and fixture/readback hardening. It should not be reviewed as a standalone product release; review it as the stacked diff against `codex/pr62-split-03-tenant-legal-pages`.

## Local validation

```bash
git fetch origin
git switch -C codex/pr62-split-04-playwright-title-metadata origin/codex/pr62-split-04-playwright-title-metadata
bun install
bun run lint
bun run format:write
bun run test:unit
bun run test:unit:server
bun run build:app
bun run test:e2e:install
bun run docker:start
bun run test:e2e
bun run test:e2e:docs
```

For focused review, run the Playwright specs covering admin actions, templates, receipt review, active registration, scanner, and tenant branding after the Docker stack is running.

## Review status

- Changed files: 144
- Review threads: resolved
- CI: green

* `main` <!-- branch-stack -->
  - **test: split PR 62 Playwright title metadata** :point\_left:
    - \#67
      - \#72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added event registration transfer workflows, including transfer dialogs and transfer target selection.
  - Added global admin tenant create/edit pages and tenant branding uploads for logo and favicon.
  - Added reusable add-ons to templates and surfaced them in event creation/details.
  - Improved profile, role, and registration screens with clearer labels and actions.

- **Bug Fixes**
  - Prevented duplicate submits and overlapping writes across many forms and actions.
  - Tightened permission-based redirects and disabled states for unavailable actions.
  - Improved scan/check-in, receipt, and reimbursement behavior with better validation and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
