### PR TITLE
test: harden launch-critical Playwright coverage

### DIFF
--- a/src/app/internal-pages/members-hub/members-hub.component.spec.ts
+++ b/src/app/internal-pages/members-hub/members-hub.component.spec.ts
@@ -1,0 +1,122 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  provideTanStackQuery,
+  QueryClient,
+} from '@tanstack/angular-query-experimental';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AdminHubRoleRecord } from '../../../shared/rpc-contracts/app-rpcs/admin.rpcs';
+
+import {
+  MembersHubComponent,
+  MembersHubQueries,
+} from './members-hub.component';
+
+const hubRolesQuery = vi.fn<() => Promise<AdminHubRoleRecord[]>>();
+const membersHubQueries = {
+  hubRoles: () => ({
+    queryFn: hubRolesQuery,
+    queryKey: ['members-hub-roles'],
+  }),
+};
+
+const normalizeText = (fixture: ComponentFixture<MembersHubComponent>) =>
+  fixture.nativeElement.textContent.replaceAll(/\s+/g, ' ').trim();
+
+describe('MembersHubComponent', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(async () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: 0,
+          retry: false,
+        },
+      },
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [MembersHubComponent],
+      providers: [
+        provideTanStackQuery(queryClient),
+        { provide: MembersHubQueries, useValue: membersHubQueries },
+      ],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('shows the loading state while hub roles are pending', async () => {
+    hubRolesQuery.mockReturnValue(
+      new Promise<AdminHubRoleRecord[]>((resolve) => {
+        void resolve;
+      }),
+    );
+
+    const fixture = TestBed.createComponent(MembersHubComponent);
+    fixture.detectChanges();
+
+    expect(normalizeText(fixture)).toContain('Members Hub');
+    expect(normalizeText(fixture)).toContain("Who's who");
+    expect(normalizeText(fixture)).toContain('Loading roles...');
+  });
+
+  it('renders hub roles, descriptions, member counts, and users', async () => {
+    hubRolesQuery.mockResolvedValue([
+      {
+        description: 'Coordinates the relaunch',
+        id: 'launch-team',
+        name: 'Launch team',
+        userCount: 2,
+        users: [
+          { firstName: 'Ada', id: 'ada', lastName: 'Lovelace' },
+          { firstName: 'Grace', id: 'grace', lastName: 'Hopper' },
+        ],
+      },
+      {
+        description: null,
+        id: 'solo-reviewer',
+        name: 'Solo reviewer',
+        userCount: 1,
+        users: [
+          { firstName: 'Margaret', id: 'margaret', lastName: 'Hamilton' },
+        ],
+      },
+    ]);
+
+    const fixture = TestBed.createComponent(MembersHubComponent);
+    fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      fixture.detectChanges();
+      expect(normalizeText(fixture)).toContain('Launch team');
+    });
+
+    const text = normalizeText(fixture);
+    expect(text).toContain('Coordinates the relaunch');
+    expect(text).toContain('2 members');
+    expect(text).toContain('Ada Lovelace, Grace Hopper');
+    expect(text).toContain('Solo reviewer');
+    expect(text).toContain('Margaret Hamilton');
+    expect(text).not.toContain('1 members');
+  });
+
+  it('shows a readable error when hub roles fail to load', async () => {
+    hubRolesQuery.mockRejectedValue(new Error('Hub roles unavailable'));
+
+    const fixture = TestBed.createComponent(MembersHubComponent);
+    fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      fixture.detectChanges();
+      expect(normalizeText(fixture)).toContain(
+        'Error loading roles: Hub roles unavailable',
+      );
+    });
+  });
+});

--- a/src/app/internal-pages/members-hub/members-hub.component.ts
+++ b/src/app/internal-pages/members-hub/members-hub.component.ts
@@ -1,8 +1,22 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  Injectable,
+} from '@angular/core';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import { AppRpc } from '../../core/effect-rpc-angular-client';
 import { getErrorMessage } from '../../core/error-message';
+
+@Injectable({ providedIn: 'root' })
+export class MembersHubQueries {
+  private readonly rpc = AppRpc.injectClient();
+
+  hubRoles() {
+    return this.rpc.admin.roles.findHubRoles.queryOptions();
+  }
+}
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -14,10 +28,8 @@ import { getErrorMessage } from '../../core/error-message';
   templateUrl: './members-hub.component.html',
 })
 export class MembersHubComponent {
-  private readonly rpc = AppRpc.injectClient();
-  protected readonly rolesQuery = injectQuery(() =>
-    this.rpc.admin.roles.findHubRoles.queryOptions(),
-  );
+  private readonly queries = inject(MembersHubQueries);
+  protected readonly rolesQuery = injectQuery(() => this.queries.hubRoles());
 
   protected errorMessage(error: unknown): string {
     return getErrorMessage(error, 'Unknown error');

--- a/src/server/config/test-runtime-config.ts
+++ b/src/server/config/test-runtime-config.ts
@@ -123,11 +123,11 @@ const configFailure = (message: string) =>
 const assertKnownProjectNames = (
   projectNames: readonly string[],
 ): Effect.Effect<readonly string[], Config.ConfigError> => {
-  const unknownProjectNames = projectNames.filter(
-    (projectName) =>
-      !PLAYWRIGHT_PROJECT_NAMES.some((knownProjectName) =>
-        matchesProjectPattern(projectName, knownProjectName),
-      ),
+  const unknownProjectNames = projectNames.filter((projectName) =>
+    PLAYWRIGHT_PROJECT_NAMES.every(
+      (knownProjectName) =>
+        !matchesProjectPattern(projectName, knownProjectName),
+    ),
   );
   if (unknownProjectNames.length > 0) {
     return Effect.fail(

--- a/src/server/effect/rpc/handlers/admin.handlers.ts
+++ b/src/server/effect/rpc/handlers/admin.handlers.ts
@@ -730,10 +730,8 @@ export const adminHandlers = {
               }
 
               if (localeMoneySettingsChanged(tenant, input)) {
-                const hasDependentData = yield* tenantHasLocaleMoneyDependentData(
-                  tx,
-                  tenant.id,
-                );
+                const hasDependentData =
+                  yield* tenantHasLocaleMoneyDependentData(tx, tenant.id);
                 if (hasDependentData) {
                   return yield* Effect.fail(
                     tenantLocaleMoneySettingsLockedError(),

--- a/tests/docs/finance/receipt-review-reimbursement.doc.ts
+++ b/tests/docs/finance/receipt-review-reimbursement.doc.ts
@@ -1,11 +1,200 @@
-import { test } from '../../support/fixtures/parallel-test';
+import { eq } from 'drizzle-orm';
 
-test.skip(
-  true,
-  'Receipt reimbursement docs are completed by a later stacked docs slice.',
-);
+import { getId } from '../../../helpers/get-id';
+import {
+  adminStateFile,
+  usersToAuthenticate,
+} from '../../../helpers/user-data';
+import * as schema from '../../../src/db/schema';
+import { expect, test } from '../../support/fixtures/parallel-test';
+import { takeScreenshot } from '../../support/reporters/documentation-reporter';
 
-test('Review and reimburse receipts @finance', async () => {
-  // Placeholder only: the runnable reimbursement documentation flow lands in a
-  // later stacked slice with the finance reimbursement UI.
+test.use({ storageState: adminStateFile });
+
+test('Review and reimburse receipts @finance', async ({
+  database,
+  page,
+  seedDate,
+  seeded,
+  tenant,
+}, testInfo) => {
+  const organizerUser = usersToAuthenticate.find(
+    (user) => user.roles === 'organizer',
+  );
+  if (!organizerUser) {
+    throw new Error('Expected seeded organizer user for receipt docs');
+  }
+
+  const originalOrganizer = await database.query.users.findFirst({
+    where: { id: organizerUser.id },
+  });
+  if (!originalOrganizer) {
+    throw new Error('Expected organizer user record for receipt docs');
+  }
+
+  const eventId = seeded.scenario.events.past.eventId;
+  const receiptId = getId();
+  const receiptFileName = `receipt-review-doc-${seedDate.getTime()}.pdf`;
+  let refundTransactionId: string | undefined;
+
+  try {
+    await database
+      .update(schema.users)
+      .set({
+        iban: 'DE00123456781234567890',
+        paypalEmail: 'organizer-refunds@example.com',
+      })
+      .where(eq(schema.users.id, organizerUser.id));
+
+    await database.insert(schema.financeReceipts).values({
+      alcoholAmount: 150,
+      attachmentFileName: receiptFileName,
+      attachmentMimeType: 'application/pdf',
+      attachmentSizeBytes: 1024,
+      depositAmount: 150,
+      eventId,
+      hasAlcohol: true,
+      hasDeposit: true,
+      id: receiptId,
+      purchaseCountry: 'DE',
+      receiptDate: new Date(seedDate.getTime() - 1000 * 60 * 60 * 24 * 2),
+      status: 'submitted',
+      submittedByUserId: organizerUser.id,
+      taxAmount: 0,
+      tenantId: tenant.id,
+      totalAmount: 1450,
+    });
+
+    await testInfo.attach('markdown', {
+      body: `
+# Review and reimburse receipts
+
+Finance users review submitted receipts before recording manual reimbursement. This guide starts with a receipt that an event organizer has already submitted for a past event.
+`,
+    });
+
+    await page.goto('/finance/receipts-approval');
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Receipt approvals' }),
+    ).toBeVisible();
+    await expect(page.getByText(receiptFileName)).toBeVisible();
+    await takeScreenshot(
+      testInfo,
+      page.locator('app-receipt-approval-list'),
+      page,
+      'Receipt approval queue',
+    );
+
+    await testInfo.attach('markdown', {
+      body: `
+## Review the submitted receipt
+
+Open a receipt from the approval queue to inspect the attachment metadata, submitted amounts, country, alcohol/deposit flags, and the manual submitter-notification notice.
+`,
+    });
+
+    await page.getByRole('link', { name: new RegExp(receiptFileName) }).click();
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Review receipt' }),
+    ).toBeVisible();
+    await expect(page.getByText(receiptFileName)).toBeVisible();
+    await takeScreenshot(
+      testInfo,
+      page.locator('app-receipt-approval-detail'),
+      page,
+      'Receipt approval detail',
+    );
+
+    await page.getByRole('button', { name: 'Approve' }).click();
+    await expect(page).toHaveURL(/\/finance\/receipts-approval$/);
+
+    const approvedReceipt = await database.query.financeReceipts.findFirst({
+      where: { id: receiptId, tenantId: tenant.id },
+    });
+    expect(approvedReceipt).toEqual(
+      expect.objectContaining({
+        reviewedByUserId: expect.any(String),
+        status: 'approved',
+      }),
+    );
+
+    await testInfo.attach('markdown', {
+      body: `
+## Record reimbursement
+
+After approval, the receipt appears on **Receipt reimbursements**, grouped by submitter. Select the approved row, confirm the payout method and payout details, then record the reimbursement after the money has been transferred outside Evorto.
+`,
+    });
+
+    await page.goto('/finance/receipts-refunds');
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Receipt reimbursements' }),
+    ).toBeVisible();
+    await expect(page.getByText(receiptFileName)).toBeVisible();
+    await takeScreenshot(
+      testInfo,
+      page.locator('app-receipt-refund-list'),
+      page,
+      'Receipt reimbursement queue',
+    );
+
+    const reimbursementSection = page.locator('section', {
+      has: page.getByText(receiptFileName),
+    });
+    await reimbursementSection
+      .locator('tr.mat-mdc-row input[type="checkbox"]')
+      .check();
+    await expect(
+      reimbursementSection.getByText('Selected total: 14.50 €'),
+    ).toBeVisible();
+    await reimbursementSection
+      .getByRole('button', { name: 'Record reimbursement' })
+      .click();
+    await expect(
+      page.getByText('Reimbursement transaction recorded'),
+    ).toBeVisible();
+
+    await expect
+      .poll(() =>
+        database.query.financeReceipts.findFirst({
+          where: { id: receiptId, tenantId: tenant.id },
+        }),
+      )
+      .toMatchObject({
+        refundedByUserId: expect.any(String),
+        status: 'refunded',
+      });
+    const refundedReceipt = await database.query.financeReceipts.findFirst({
+      where: { id: receiptId, tenantId: tenant.id },
+    });
+    if (!refundedReceipt?.refundTransactionId) {
+      throw new Error('Expected receipt reimbursement to create a transaction');
+    }
+    refundTransactionId = refundedReceipt.refundTransactionId;
+
+    await testInfo.attach('markdown', {
+      body: `
+Recording reimbursement updates the receipt to **refunded** and creates a successful manual refund transaction in Evorto. The actual bank or PayPal transfer remains an external finance action.
+`,
+    });
+  } finally {
+    await database
+      .update(schema.users)
+      .set({
+        communicationEmail: originalOrganizer.communicationEmail,
+        firstName: originalOrganizer.firstName,
+        iban: originalOrganizer.iban,
+        lastName: originalOrganizer.lastName,
+        paypalEmail: originalOrganizer.paypalEmail,
+      })
+      .where(eq(schema.users.id, organizerUser.id));
+    await database
+      .delete(schema.financeReceipts)
+      .where(eq(schema.financeReceipts.id, receiptId));
+    if (refundTransactionId) {
+      await database
+        .delete(schema.transactions)
+        .where(eq(schema.transactions.id, refundTransactionId));
+    }
+  }
 });

--- a/tests/docs/templates/templates.doc.ts
+++ b/tests/docs/templates/templates.doc.ts
@@ -1,4 +1,5 @@
 import { and, eq } from 'drizzle-orm';
+import { DateTime } from 'luxon';
 
 import { getId } from '../../../helpers/get-id';
 import { adminStateFile } from '../../../helpers/user-data';
@@ -25,6 +26,7 @@ test('Manage templates', async ({
   const addOnDescription = 'Reusable snack add-on for docs coverage.';
   const questionTitle = `Docs accessibility needs ${getId().slice(0, 6)}`;
   const questionDescription = 'Tell organizers what support you need.';
+  const eventTitle = `Docs event from template ${getId().slice(0, 6)}`;
 
   await page.goto('.');
   await testInfo.attach('markdown', {
@@ -314,6 +316,94 @@ You will be redirected to the detail page for that template.
       required: true,
     }),
   );
+
+  await testInfo.attach('markdown', {
+    body: `
+## Creating an event from a template
+Open the template detail page and click **Create event**. The event form starts with the template title, description, registration options, reusable add-ons, registration questions, and organizer planning tips already copied into the event draft.
+`,
+  });
+  await page.getByRole('link', { name: 'Create event' }).click();
+  await expect(page).toHaveURL(`/templates/${createdTemplate.id}/create-event`);
+  await expect(page.getByLabel('Event title')).toHaveValue(templateTitle);
+  await page.getByLabel('Event title').fill(eventTitle);
+
+  const eventForm = page.locator('app-event-general-form');
+  const futureStart = DateTime.now().plus({ months: 2 });
+  await eventForm
+    .getByRole('textbox', { name: 'Start date' })
+    .fill(futureStart.toFormat('M/d/yyyy'));
+  await eventForm.getByRole('combobox', { name: 'Start time' }).fill('1:00 PM');
+  await eventForm
+    .getByRole('textbox', { name: 'End date' })
+    .fill(futureStart.toFormat('M/d/yyyy'));
+  await eventForm.getByRole('combobox', { name: 'End time' }).fill('5:00 PM');
+  await takeScreenshot(
+    testInfo,
+    eventForm,
+    page,
+    'Event created from template',
+  );
+
+  await page.getByRole('button', { name: 'Create event' }).click();
+  await page.waitForURL(/\/events\//, { timeout: 20_000 });
+  await expect(
+    page.getByRole('heading', { name: eventTitle }).last(),
+  ).toBeVisible();
+
+  const createdEvent = await database.query.eventInstances.findFirst({
+    where: {
+      templateId: createdTemplate.id,
+      tenantId: tenant.id,
+      title: eventTitle,
+    },
+  });
+  if (!createdEvent) {
+    throw new Error(
+      'Expected template docs flow to persist an event from the template',
+    );
+  }
+  const createdEventOptions =
+    await database.query.eventRegistrationOptions.findMany({
+      where: { eventId: createdEvent.id },
+    });
+  expect(createdEventOptions.length).toBe(registrationOptions.length);
+
+  const createdEventAddOn = await database.query.eventAddons.findFirst({
+    where: {
+      eventId: createdEvent.id,
+      title: addOnTitle,
+    },
+  });
+  if (!createdEventAddOn) {
+    throw new Error(
+      'Expected template docs flow to copy reusable add-ons into the event',
+    );
+  }
+  const createdEventQuestion =
+    await database.query.eventRegistrationQuestions.findFirst({
+      where: {
+        eventId: createdEvent.id,
+        title: questionTitle,
+      },
+    });
+  if (!createdEventQuestion) {
+    throw new Error(
+      'Expected template docs flow to copy registration questions into the event',
+    );
+  }
+
+  await database
+    .delete(schema.eventRegistrationOptions)
+    .where(eq(schema.eventRegistrationOptions.eventId, createdEvent.id));
+  await database
+    .delete(schema.eventInstances)
+    .where(
+      and(
+        eq(schema.eventInstances.id, createdEvent.id),
+        eq(schema.eventInstances.tenantId, tenant.id),
+      ),
+    );
 
   await database
     .delete(schema.addonToTemplateRegistrationOptions)

--- a/tests/docs/users/create-account.doc.ts
+++ b/tests/docs/users/create-account.doc.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { ConfigProvider, Effect } from 'effect';
+import { expect } from '@playwright/test';
 
 import * as schema from '../../../src/db/schema';
 import {
@@ -9,7 +10,7 @@ import {
   createAccountSubmitDisabled,
   isAuthEmailVerifiedForAccountCreation,
 } from '../../../src/app/core/create-account/create-account.helpers';
-import { expect, test } from '../../support/fixtures/parallel-test';
+import { test } from '../../support/fixtures/base-test';
 import { hasAuth0ManagementEnvironment } from '../../support/config/environment';
 import { takeScreenshot } from '../../support/reporters/documentation-reporter';
 
@@ -88,19 +89,19 @@ Creating the account joins the current tenant and grants the tenant's default us
 });
 
 test.describe('Auth0-backed account creation docs', () => {
-  test.skip(
-    !hasManagementEnvironment,
-    'AUTH0_MANAGEMENT_CLIENT_ID and AUTH0_MANAGEMENT_CLIENT_SECRET are required for this integration doc',
-  );
+  test.beforeAll(() => {
+    expect(
+      hasManagementEnvironment,
+      'AUTH0_MANAGEMENT_CLIENT_ID and AUTH0_MANAGEMENT_CLIENT_SECRET are required for this integration doc',
+    ).toBe(true);
+  });
 
   test('Create your account @needs-auth0-management', async ({
     database,
     newUser,
     page,
-    roles,
-    tenant,
+    tenantDomain,
   }, testInfo) => {
-    void roles; // Ensure roles are created for this tenant
     let createdUserId: string | undefined;
     let createdTenantUserId: string | undefined;
 
@@ -202,8 +203,15 @@ If the same global login already exists for another tenant, this step joins the 
         lastName: newUser.lastName,
       });
 
+      const currentTenant = await database.query.tenants.findFirst({
+        where: { domain: tenantDomain ?? 'localhost' },
+      });
+      if (!currentTenant) {
+        throw new Error('Expected seeded tenant for current host');
+      }
+
       const tenantUser = await database.query.usersToTenants.findFirst({
-        where: { tenantId: tenant.id, userId: createdUser.id },
+        where: { tenantId: currentTenant.id, userId: createdUser.id },
       });
       if (!tenantUser) {
         throw new Error(
@@ -222,17 +230,18 @@ If the same global login already exists for another tenant, this step joins the 
 You should now be on your profile page for the current tenant. From here you can review your profile, manage discount cards when the tenant supports them, and register for events.`,
       });
     } finally {
-      if (createdTenantUserId) {
-        await database
-          .delete(schema.rolesToTenantUsers)
-          .where(
-            eq(schema.rolesToTenantUsers.userTenantId, createdTenantUserId),
-          );
-        await database
-          .delete(schema.usersToTenants)
-          .where(eq(schema.usersToTenants.id, createdTenantUserId));
-      }
       if (createdUserId) {
+        const tenantUsers = await database.query.usersToTenants.findMany({
+          where: { userId: createdUserId },
+        });
+        for (const tenantUser of tenantUsers) {
+          await database
+            .delete(schema.rolesToTenantUsers)
+            .where(eq(schema.rolesToTenantUsers.userTenantId, tenantUser.id));
+          await database
+            .delete(schema.usersToTenants)
+            .where(eq(schema.usersToTenants.id, tenantUser.id));
+        }
         await database
           .delete(schema.users)
           .where(
@@ -241,6 +250,15 @@ You should now be on your profile page for the current tenant. From here you can
               eq(schema.users.email, newUser.email),
             ),
           );
+      } else if (createdTenantUserId) {
+        await database
+          .delete(schema.rolesToTenantUsers)
+          .where(
+            eq(schema.rolesToTenantUsers.userTenantId, createdTenantUserId),
+          );
+        await database
+          .delete(schema.usersToTenants)
+          .where(eq(schema.usersToTenants.id, createdTenantUserId));
       }
     }
   });

--- a/tests/specs/events/events.test.ts
+++ b/tests/specs/events/events.test.ts
@@ -6,11 +6,7 @@ test.setTimeout(120_000);
 
 test.use({ storageState: organizerStateFile });
 
-test.skip('create event form template', async ({
-  database,
-  page,
-  templates,
-}) => {
+test('create event form template', async ({ database, page, templates }) => {
   const template = templates.find((candidate) => candidate.seedKey === 'hike');
   if (!template) {
     throw new Error('Expected seeded hike template for event creation');

--- a/tests/specs/finance/receipts-flows.spec.ts
+++ b/tests/specs/finance/receipts-flows.spec.ts
@@ -39,15 +39,15 @@ const submitReceiptFromFirstEvent = async (
     receiptDialog.getByLabel('Deposit amount (EUR)'),
   ).not.toBeVisible();
   await receiptDialog
-    .locator('mat-checkbox', { hasText: 'Deposit involved' })
-    .click();
+    .getByRole('checkbox', { name: 'Deposit involved' })
+    .check();
   await expect(receiptDialog.getByLabel('Deposit amount (EUR)')).toBeVisible();
   await expect(
     receiptDialog.getByLabel('Alcohol amount (EUR)'),
   ).not.toBeVisible();
   await receiptDialog
-    .locator('mat-checkbox', { hasText: 'Alcohol purchased' })
-    .click();
+    .getByRole('checkbox', { name: 'Alcohol purchased' })
+    .check();
   await expect(receiptDialog.getByLabel('Alcohol amount (EUR)')).toBeVisible();
 
   await receiptDialog.getByLabel('Total amount (EUR)').fill('14.50');
@@ -98,7 +98,7 @@ const seedPendingReceiptForApproval = async ({
   });
 };
 
-test.skip('submit receipt from event organize page', async ({
+test('submit receipt from event organize page', async ({
   database,
   page,
   seeded,
@@ -136,95 +136,141 @@ test.skip('submit receipt from event organize page', async ({
   }
 });
 
-test.skip('approve and record receipt reimbursements in finance', async ({
+test('approve and record receipt reimbursements in finance', async ({
   database,
   page,
   seedDate,
   seeded,
   tenant,
 }) => {
-  const organizerUserId = usersToAuthenticate.find(
+  const organizerUser = usersToAuthenticate.find(
     (user) => user.roles === 'organizer',
-  )?.id;
-  if (!organizerUserId) {
+  );
+  if (!organizerUser) {
     throw new Error('Expected seeded organizer user');
+  }
+  const originalOrganizer = await database.query.users.findFirst({
+    where: { id: organizerUser.id },
+  });
+  if (!originalOrganizer) {
+    throw new Error('Expected seeded organizer user record');
   }
   const seededEventId = seeded.scenario.events.past.eventId;
   const receiptId = getId();
   const receiptFileName = `approval-reimbursement-${seedDate.getTime()}.pdf`;
-  await seedPendingReceiptForApproval({
-    database,
-    eventId: seededEventId,
-    receiptFileName,
-    receiptId,
-    seedDate,
-    submittedByUserId: organizerUserId,
-    tenantId: tenant.id,
-  });
+  let refundTransactionId: string | undefined;
+  try {
+    await database
+      .update(schema.users)
+      .set({
+        iban: 'DE00123456781234567890',
+        paypalEmail: 'organizer-refunds@example.com',
+      })
+      .where(eq(schema.users.id, organizerUser.id));
 
-  const escapedReceiptFileName = receiptFileName.replace(
-    /[.*+?^${}()|[\]\\]/g,
-    '\\$&',
-  );
-  await page.goto('/finance/receipts-approval');
-  const pendingReceipt = page.getByRole('link', {
-    name: new RegExp(escapedReceiptFileName),
-  });
-  await expect(pendingReceipt).toHaveAttribute(
-    'href',
-    `/finance/receipts-approval/${receiptId}`,
-  );
-  await pendingReceipt.click();
-  await page.getByRole('button', { name: 'Approve' }).click();
-  await expect(page).toHaveURL(/\/finance\/receipts-approval$/);
-
-  await page.goto('/finance/receipts-refunds');
-  await expect(
-    page.getByText(
-      'Recording a reimbursement creates the Evorto finance transaction only. Transfer the money manually through the selected payout method.',
-    ),
-  ).toBeVisible();
-  await expect(
-    page.getByText('No approved receipts are waiting for reimbursement.'),
-  ).not.toBeVisible();
-
-  const refundSection = page.locator('section', {
-    has: page.getByText(receiptFileName),
-  });
-  await expect(refundSection).toBeVisible();
-
-  await expect(refundSection.locator('table[mat-table]')).toBeVisible();
-  await refundSection
-    .locator('tr.mat-mdc-row input[type="checkbox"]')
-    .first()
-    .check();
-
-  const issueRefundButton = refundSection.getByRole('button', {
-    name: 'Record reimbursement',
-  });
-  await expect(issueRefundButton).toBeEnabled();
-  await issueRefundButton.click();
-
-  await expect(page.getByText('Selected total: 0.00 €').first()).toBeVisible();
-
-  const refundedReceipt = await database.query.financeReceipts.findFirst({
-    where: {
-      id: receiptId,
+    await seedPendingReceiptForApproval({
+      database,
+      eventId: seededEventId,
+      receiptFileName,
+      receiptId,
+      seedDate,
+      submittedByUserId: organizerUser.id,
       tenantId: tenant.id,
-    },
-  });
-  if (!refundedReceipt) {
-    throw new Error('Expected seeded receipt after reimbursement recording');
+    });
+
+    const escapedReceiptFileName = receiptFileName.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&',
+    );
+    await page.goto('/finance/receipts-approval');
+    const pendingReceipt = page.getByRole('link', {
+      name: new RegExp(escapedReceiptFileName),
+    });
+    await expect(pendingReceipt).toHaveAttribute(
+      'href',
+      `/finance/receipts-approval/${receiptId}`,
+    );
+    await pendingReceipt.click();
+    await page.getByRole('button', { name: 'Approve' }).click();
+    await expect(page).toHaveURL(/\/finance\/receipts-approval$/);
+
+    await page.goto('/finance/receipts-refunds');
+    await expect(
+      page.getByText(
+        'Recording a reimbursement creates the Evorto finance transaction only. Transfer the money manually through the selected payout method.',
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByText('No approved receipts are waiting for reimbursement.'),
+    ).not.toBeVisible();
+
+    const refundSection = page.locator('section', {
+      has: page.getByText(receiptFileName),
+    });
+    await expect(refundSection).toBeVisible();
+
+    await expect(refundSection.locator('table[mat-table]')).toBeVisible();
+    await refundSection
+      .locator('tr.mat-mdc-row input[type="checkbox"]')
+      .first()
+      .check();
+
+    const issueRefundButton = refundSection.getByRole('button', {
+      name: 'Record reimbursement',
+    });
+    await expect(issueRefundButton).toBeEnabled();
+    await issueRefundButton.click();
+
+    await expect(
+      page.getByText('Reimbursement transaction recorded'),
+    ).toBeVisible();
+
+    await expect
+      .poll(() =>
+        database.query.financeReceipts.findFirst({
+          where: {
+            id: receiptId,
+            tenantId: tenant.id,
+          },
+        }),
+      )
+      .toMatchObject({
+        refundTransactionId: expect.any(String),
+        status: 'refunded',
+      });
+    const refundedReceipt = await database.query.financeReceipts.findFirst({
+      where: {
+        id: receiptId,
+        tenantId: tenant.id,
+      },
+    });
+    if (!refundedReceipt?.refundTransactionId) {
+      throw new Error('Expected seeded receipt after reimbursement recording');
+    }
+    refundTransactionId = refundedReceipt.refundTransactionId;
+  } finally {
+    await database
+      .update(schema.users)
+      .set({
+        communicationEmail: originalOrganizer.communicationEmail,
+        firstName: originalOrganizer.firstName,
+        iban: originalOrganizer.iban,
+        lastName: originalOrganizer.lastName,
+        paypalEmail: originalOrganizer.paypalEmail,
+      })
+      .where(eq(schema.users.id, organizerUser.id));
+    await database
+      .delete(schema.financeReceipts)
+      .where(eq(schema.financeReceipts.id, receiptId));
+    if (refundTransactionId) {
+      await database
+        .delete(schema.transactions)
+        .where(eq(schema.transactions.id, refundTransactionId));
+    }
   }
-  expect(refundedReceipt).toEqual(
-    expect.objectContaining({
-      refundTransactionId: expect.any(String),
-      status: 'refunded',
-    }),
-  );
 });
 
-test.skip('receipt dialog shows Other option when tenant allows it', async ({
+test('receipt dialog shows Other option when tenant allows it', async ({
   database,
   page,
   seeded,

--- a/tests/specs/finance/stripe-webhook-replay.spec.ts
+++ b/tests/specs/finance/stripe-webhook-replay.spec.ts
@@ -13,10 +13,12 @@ const regularUserId =
   usersToAuthenticate[0].id;
 const webhookSecret = process.env['STRIPE_WEBHOOK_SECRET'] ?? '';
 
-test.skip(
-  webhookSecret.length === 0,
-  'STRIPE_WEBHOOK_SECRET is required for webhook replay tests',
-);
+test.beforeAll(() => {
+  expect(
+    webhookSecret.length,
+    'STRIPE_WEBHOOK_SECRET is required for webhook replay tests',
+  ).toBeGreaterThan(0);
+});
 
 test('replaying the same Stripe webhook is idempotent @finance @stripe', async ({
   database,

--- a/tests/specs/finance/tax-rates/admin-import-tax-rates.spec.ts
+++ b/tests/specs/finance/tax-rates/admin-import-tax-rates.spec.ts
@@ -5,7 +5,7 @@ import { openAdminTools } from '../../../support/utils/admin-tools';
 test.use({ storageState: adminStateFile });
 
 test.describe('Admin Tax Rates Import', () => {
-  test.skip('admin with tax permission can open tax rates settings and import dialog @finance @taxRates', async ({
+  test('admin with tax permission can open tax rates settings and import dialog @finance @taxRates', async ({
     isMobile,
     page,
     permissionOverride,

--- a/tests/specs/permissions/matrix.spec.ts
+++ b/tests/specs/permissions/matrix.spec.ts
@@ -5,7 +5,7 @@ import { openAdminTools } from '../../support/utils/admin-tools';
 for (const [index, matrixCase] of permissionMatrix.entries()) {
   const reqIdBase = `PERMISSION-MATRIX-SPEC-${String(index + 1).padStart(2, '0')}`;
 
-  test.describe.skip(matrixCase.capability, () => {
+  test.describe(matrixCase.capability, () => {
     test.use({ storageState: matrixCase.storageState });
 
     test(`allows capability when required permissions are present @permissions`, async ({

--- a/tests/specs/permissions/override.test.ts
+++ b/tests/specs/permissions/override.test.ts
@@ -1,16 +1,82 @@
+import { and, eq } from 'drizzle-orm';
+
+import { getId } from '../../../helpers/get-id';
 import { userStateFile } from '../../../helpers/user-data';
+import * as schema from '../../../src/db/schema';
 import { expect, test } from '../../support/fixtures/permissions-test';
 
 test.use({ storageState: userStateFile });
 
-test('adds internal:viewInternalPages to Regular user shows Internal link', async ({
+test('adds internal:viewInternalPages to Regular user opens Members Hub', async ({
+  database,
   page,
   permissionOverride,
+  tenant,
 }) => {
-  await permissionOverride({
-    roleName: 'Regular user',
-    add: ['internal:viewInternalPages'],
+  const roleId = getId();
+  const userId = getId();
+  const userTenantId = getId();
+
+  await database.insert(schema.users).values({
+    auth0Id: `test|${userId}`,
+    communicationEmail: `hub-${userId}@evorto.test`,
+    email: `hub-${userId}@evorto.test`,
+    firstName: 'Hub',
+    id: userId,
+    lastName: 'Reviewer',
   });
-  await page.goto('.');
-  await expect(page.getByRole('link', { name: 'Internal' })).toBeVisible();
+  await database.insert(schema.usersToTenants).values({
+    id: userTenantId,
+    tenantId: tenant.id,
+    userId,
+  });
+  await database.insert(schema.roles).values({
+    description: 'Visible in the internal hub',
+    displayInHub: true,
+    id: roleId,
+    name: 'Members Hub Test Team',
+    permissions: [],
+    tenantId: tenant.id,
+  });
+  await database.insert(schema.rolesToTenantUsers).values({
+    roleId,
+    userTenantId,
+  });
+
+  try {
+    await permissionOverride({
+      roleName: 'Regular user',
+      add: ['internal:viewInternalPages'],
+    });
+
+    await page.goto('.');
+    const internalLink = page.getByRole('link', { name: 'Internal' });
+    await expect(internalLink).toBeVisible();
+
+    await internalLink.click();
+    await expect(page).toHaveURL(/\/internal\/members-hub$/);
+    await expect(
+      page.getByRole('heading', { name: 'Members Hub' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: "Who's who" }),
+    ).toBeVisible();
+    await expect(page.getByText('Members Hub Test Team')).toBeVisible();
+    await expect(page.getByText('Visible in the internal hub')).toBeVisible();
+    await expect(page.getByText('Hub Reviewer')).toBeVisible();
+  } finally {
+    await database
+      .delete(schema.rolesToTenantUsers)
+      .where(
+        and(
+          eq(schema.rolesToTenantUsers.roleId, roleId),
+          eq(schema.rolesToTenantUsers.userTenantId, userTenantId),
+        ),
+      );
+    await database.delete(schema.roles).where(eq(schema.roles.id, roleId));
+    await database
+      .delete(schema.usersToTenants)
+      .where(eq(schema.usersToTenants.id, userTenantId));
+    await database.delete(schema.users).where(eq(schema.users.id, userId));
+  }
 });

--- a/tests/specs/profile/create-account.spec.ts
+++ b/tests/specs/profile/create-account.spec.ts
@@ -1,9 +1,10 @@
 import { and, eq } from 'drizzle-orm';
 import { ConfigProvider, Effect } from 'effect';
+import { expect } from '@playwright/test';
 
 import * as schema from '../../../src/db/schema';
 import { hasAuth0ManagementEnvironment } from '../../support/config/environment';
-import { expect, test } from '../../support/fixtures/parallel-test';
+import { test } from '../../support/fixtures/base-test';
 
 const hasManagementEnvironment = Effect.runSync(
   hasAuth0ManagementEnvironment.pipe(
@@ -18,15 +19,13 @@ test('creates tenant account for a new Auth0 user @needs-auth0-management', asyn
   database,
   newUser,
   page,
-  roles,
-  tenant,
+  tenantDomain,
 }) => {
-  test.skip(
-    !hasManagementEnvironment,
+  expect(
+    hasManagementEnvironment,
     'AUTH0_MANAGEMENT_CLIENT_ID and AUTH0_MANAGEMENT_CLIENT_SECRET are required for create-account integration coverage',
-  );
+  ).toBe(true);
 
-  void roles;
   let createdUserId: string | undefined;
   let createdTenantUserId: string | undefined;
 
@@ -107,8 +106,15 @@ test('creates tenant account for a new Auth0 user @needs-auth0-management', asyn
       lastName: newUser.lastName,
     });
 
+    const currentTenant = await database.query.tenants.findFirst({
+      where: { domain: tenantDomain ?? 'localhost' },
+    });
+    if (!currentTenant) {
+      throw new Error('Expected seeded tenant for current host');
+    }
+
     const tenantUser = await database.query.usersToTenants.findFirst({
-      where: { tenantId: tenant.id, userId: createdUser.id },
+      where: { tenantId: currentTenant.id, userId: createdUser.id },
     });
     if (!tenantUser) {
       throw new Error('Expected account creation to join the current tenant');
@@ -120,15 +126,18 @@ test('creates tenant account for a new Auth0 user @needs-auth0-management', asyn
     });
     expect(roleAssignments.length).toBeGreaterThan(0);
   } finally {
-    if (createdTenantUserId) {
-      await database
-        .delete(schema.rolesToTenantUsers)
-        .where(eq(schema.rolesToTenantUsers.userTenantId, createdTenantUserId));
-      await database
-        .delete(schema.usersToTenants)
-        .where(eq(schema.usersToTenants.id, createdTenantUserId));
-    }
     if (createdUserId) {
+      const tenantUsers = await database.query.usersToTenants.findMany({
+        where: { userId: createdUserId },
+      });
+      for (const tenantUser of tenantUsers) {
+        await database
+          .delete(schema.rolesToTenantUsers)
+          .where(eq(schema.rolesToTenantUsers.userTenantId, tenantUser.id));
+        await database
+          .delete(schema.usersToTenants)
+          .where(eq(schema.usersToTenants.id, tenantUser.id));
+      }
       await database
         .delete(schema.users)
         .where(
@@ -137,6 +146,13 @@ test('creates tenant account for a new Auth0 user @needs-auth0-management', asyn
             eq(schema.users.email, newUser.email),
           ),
         );
+    } else if (createdTenantUserId) {
+      await database
+        .delete(schema.rolesToTenantUsers)
+        .where(eq(schema.rolesToTenantUsers.userTenantId, createdTenantUserId));
+      await database
+        .delete(schema.usersToTenants)
+        .where(eq(schema.usersToTenants.id, createdTenantUserId));
     }
   }
 });

--- a/tests/specs/scanning/scanner.test.ts
+++ b/tests/specs/scanning/scanner.test.ts
@@ -69,7 +69,7 @@ const requireScannerFixture = async ({
   };
 };
 
-test.skip('scan confirmed registration records check-in', async ({
+test('scan confirmed registration records check-in', async ({
   database,
   page,
   seeded,
@@ -97,7 +97,7 @@ test.skip('scan confirmed registration records check-in', async ({
     await page.getByRole('button', { name: 'Confirm 3 check-ins' }).click();
     await expect(page.getByText('Check-in recorded')).toBeVisible();
     await expect(
-      page.getByRole('button', { name: 'Confirm check-in' }),
+      page.getByRole('button', { name: 'Checked in' }),
     ).toBeDisabled();
 
     await expect

--- a/tests/test-inventory.md
+++ b/tests/test-inventory.md
@@ -111,7 +111,12 @@ by adding or tightening a spec/doc journey instead of leaving only manual notes.
   - `docs/roles/about-permissions.doc.ts`
   - `docs/roles/roles.doc.ts`
   - `specs/permissions/**`
+  - `specs/permissions/override.test.ts` grants a regular user the internal
+    page permission and verifies the Members Hub route renders a hub-visible
+    role through the real page.
   - shared permission-guard denial coverage in `src/app/core/guards`
+  - app Members Hub loading, success, and error state coverage in
+    `src/app/internal-pages/members-hub`
   - route-manifest and event-review queue action coverage in `src/app/admin`
   - route-manifest specs in `src/app/finance`, `src/app/global-admin`, and
     `src/app/templates`


### PR DESCRIPTION
## Summary

This PR removes stale launch-critical Playwright skips and replaces placeholder coverage with runnable local coverage for the relaunch-critical paths. It focuses on test repair and documentation coverage rather than product changes.

## Scope

- Unskips and repairs coverage for receipt submission/review/reimbursement/settings, template-to-event creation, tax-rate import, permission matrix checks, scanner check-in, Auth0 create-account, and Stripe webhook replay.
- Adds executable docs coverage for receipt review/reimbursement and template-to-event creation.
- Converts Auth0 and Stripe environment gates from silent skips into explicit failures when required local secrets are missing.
- Keeps one existing skip only for the external live ESN-card provider test, which still requires a live provider identifier.

## Runtime and schema impact

No schema changes. No intended runtime behavior changes outside test/docs coverage. The two touched server files are lint/format autofixes from the required lint pass.

## Local validation

All commands below were rerun fresh before opening this PR. The local stack was run on `APP_HOST_PORT=4200` so Auth0 callback URLs matched local configuration.

- `bun run format:write`
- `bunx node@24.15.0 ./node_modules/@angular/cli/bin/ng.js lint --fix`
- `rg -n "test\.(skip|fixme)|describe\.skip|\.skip\(" tests src --glob "*.{ts,tsx,js,mjs}"`
  - Remaining result: `tests/specs/profile/user-profile-live-esncard.spec.ts:14:test.skip(` only.
- `APP_HOST_PORT=4200 bun run env:runtime && node_modules/.bin/dotenv -c dev -- node_modules/.bin/playwright test --project=local-chrome-baseline tests/specs/events/events.test.ts tests/specs/finance/receipts-flows.spec.ts tests/specs/finance/tax-rates/admin-import-tax-rates.spec.ts tests/specs/permissions/matrix.spec.ts tests/specs/scanning/scanner.test.ts`
  - Result: 38 passed.
- `APP_HOST_PORT=4200 bun run env:runtime && node_modules/.bin/dotenv -c dev -- node_modules/.bin/playwright test --project=docs-baseline tests/docs/finance/receipt-review-reimbursement.doc.ts tests/docs/templates/templates.doc.ts`
  - Result: 9 passed.
- `APP_HOST_PORT=4200 bun run env:runtime && node_modules/.bin/dotenv -c dev -- node_modules/.bin/playwright test --project=local-chrome-integration tests/specs/profile/create-account.spec.ts`
  - Result: 8 passed.
- `APP_HOST_PORT=4200 bun run env:runtime && node_modules/.bin/dotenv -c dev -- node_modules/.bin/playwright test --project=docs-integration tests/docs/users/create-account.doc.ts`
  - Result: 8 passed.
- `APP_HOST_PORT=4200 bun run env:runtime && node_modules/.bin/dotenv -c dev -- node_modules/.bin/playwright test --project=local-chrome-baseline tests/specs/finance/stripe-webhook-replay.spec.ts`
  - Result: 13 passed.

## Browser debugging

The in-app Browser was used during local debugging to confirm the generated local port caused Auth0 Callback URL mismatch. The local stack was then run with `APP_HOST_PORT=4200`, after which the Auth0 spec and docs integration flows passed locally.

- `main` <!-- branch-stack -->
  - **test: harden launch-critical Playwright coverage** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader end-to-end coverage for Members Hub, including loading, success, and error states.
  * Enabled additional real-world flows for creating events, submitting receipts, reimbursements, permissions, and account creation.

* **Bug Fixes**
  * Improved finance reimbursement and approval flows, including clearer confirmations and more reliable cleanup.
  * Updated several tests to reflect current UI labels and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->