### PR TITLE
fix: copy main environment into Codex worktrees

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -40,11 +40,33 @@ fi
 
 echo "[setup] Copying environment files"
 if [ "$(pwd -P)" != "$SOURCE_ROOT" ]; then
-  for file in .env .env.dev.local .npmrc; do
+  for file in .env.dev.local .npmrc; do
     if [ -f "$SOURCE_ROOT/$file" ]; then
       cp "$SOURCE_ROOT/$file" .
     fi
   done
+fi
+
+MAIN_CHECKOUT_WITH_SENTINEL=$(
+  git worktree list --porcelain -z 2>/dev/null |
+    perl -0ne 'if (!$found && /^worktree /) { chomp; s/^worktree //; print "$_."; $found = 1 }' ||
+    true
+)
+MAIN_CHECKOUT=${MAIN_CHECKOUT_WITH_SENTINEL%?}
+if [ -n "$MAIN_CHECKOUT" ] && [ "$(pwd -P)" != "$MAIN_CHECKOUT" ] && [ ! -e .env ] && [ ! -L .env ] && [ -f "$MAIN_CHECKOUT/.env" ]; then
+  (
+    umask 077
+    ENV_TEMP=$(mktemp .env.tmp.XXXXXX)
+    trap 'rm -f "$ENV_TEMP"' EXIT
+    cp "$MAIN_CHECKOUT/.env" "$ENV_TEMP"
+    chmod 600 "$ENV_TEMP"
+    if ln "$ENV_TEMP" .env 2>/dev/null; then
+      echo "[setup] Copied .env from the main checkout."
+    elif [ ! -e .env ] && [ ! -L .env ]; then
+      echo "[setup] Could not publish .env in the new worktree." >&2
+      exit 1
+    fi
+  )
 fi
 if [ -z "${FONT_AWESOME_TOKEN:-}" ]; then
   echo "[setup] FONT_AWESOME_TOKEN is not set; cannot install private @fortawesome packages."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ More specific guidance may exist deeper in some subtrees.
 Codex environment setup refreshes a clean worktree to the parent/source branch
 tip before installing dependencies and generating `.env.dev`. If local changes
 already exist, setup skips branch refresh rather than overwriting work.
+For a new linked worktree, setup also copies a missing `.env` from the primary
+checkout with owner-only permissions. An existing worktree `.env` is preserved.
 
 Supported local env files:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This repo uses three local env files:
 - `.env.dev.local` — tracked shared default dev config
 - `.env.dev` — generated worktree-specific overrides via `bun run env:runtime`
 
+When Codex initializes a new linked worktree, it copies a missing `.env` from
+the primary checkout with owner-only permissions. It leaves an existing
+worktree `.env` unchanged, while `.env.dev` remains generated per worktree.
+
 Use `.env.example` as the no-secret checklist for values that must be copied
 into `.env` or exported before Docker can start. `bun run docker:check` reports
 which required values are still missing before any Docker containers are

--- a/helpers/testing/codex-environment-setup.spec.ts
+++ b/helpers/testing/codex-environment-setup.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from '@effect/vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const setupConfigPath = path.join(
+  repositoryRoot,
+  '.codex',
+  'environments',
+  'environment.toml',
+);
+
+const readSetupScript = (): string => {
+  const config = fs.readFileSync(setupConfigPath, 'utf8');
+  const scriptMatch = /\[setup\]\nscript = '''\n([\s\S]*?)\n'''/.exec(config);
+
+  if (!scriptMatch) {
+    throw new Error('Missing setup script in Codex environment config');
+  }
+
+  return scriptMatch[1];
+};
+
+const testEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([name]) => name !== 'CODEX_SOURCE_ROOT' && !name.startsWith('GIT_'),
+  ),
+);
+const gitEnvironment = {
+  ...testEnvironment,
+  GIT_CONFIG_GLOBAL: os.devNull,
+  GIT_CONFIG_NOSYSTEM: '1',
+};
+
+const runGit = (cwd: string, ...commandArguments: readonly string[]): string =>
+  execFileSync(
+    'git',
+    ['-c', `core.hooksPath=${os.devNull}`, ...commandArguments],
+    {
+      cwd,
+      encoding: 'utf8',
+      env: gitEnvironment,
+    },
+  );
+
+const createFixture = () => {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'evorto env setup '),
+  );
+
+  try {
+    const mainCheckout = path.join(
+      fixtureRoot,
+      'main checkout\nwith a newline',
+    );
+    const worktree = path.join(fixtureRoot, 'linked worktree');
+    const stubBin = path.join(fixtureRoot, 'stub bin');
+
+    fs.mkdirSync(mainCheckout);
+    fs.mkdirSync(stubBin);
+    fs.writeFileSync(path.join(mainCheckout, '.gitignore'), '.env*\n');
+    fs.writeFileSync(path.join(mainCheckout, 'tracked.txt'), 'fixture\n');
+
+    runGit(mainCheckout, 'init', '--initial-branch=main');
+    runGit(mainCheckout, 'config', 'user.email', 'codex@example.test');
+    runGit(mainCheckout, 'config', 'user.name', 'Codex Test');
+    runGit(mainCheckout, 'add', '.gitignore', 'tracked.txt');
+    runGit(mainCheckout, 'commit', '--no-gpg-sign', '-m', 'Create fixture');
+    runGit(mainCheckout, 'worktree', 'add', '-b', 'fixture-worktree', worktree);
+    runGit(mainCheckout, 'remote', 'add', 'origin', mainCheckout);
+
+    const bunStub = path.join(stubBin, 'bun');
+    fs.writeFileSync(bunStub, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(bunStub, 0o755);
+
+    return {
+      fixtureRoot,
+      mainCheckout,
+      runSetup: (cwd = worktree) => {
+        const environment = {
+          ...gitEnvironment,
+          FONT_AWESOME_TOKEN: 'fixture-token',
+          PATH: `${stubBin}${path.delimiter}${process.env['PATH'] ?? ''}`,
+        };
+
+        const result = spawnSync('bash', ['-c', readSetupScript()], {
+          cwd,
+          encoding: 'utf8',
+          env: environment,
+        });
+
+        if (result.error) {
+          throw result.error;
+        }
+        if (result.status !== 0) {
+          throw new Error(
+            `Setup failed with status ${result.status}: ${result.stderr}`,
+          );
+        }
+
+        return {
+          stderr: result.stderr,
+          stdout: result.stdout,
+        };
+      },
+      worktree,
+    };
+  } catch (error) {
+    fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    throw error;
+  }
+};
+
+describe('Codex environment setup', () => {
+  it('copies a missing .env from the main checkout into a linked worktree', () => {
+    const fixture = createFixture();
+    const secret = 'SECRET_VALUE=do-not-log-this\n';
+
+    try {
+      fs.writeFileSync(path.join(fixture.mainCheckout, '.env'), secret);
+
+      const output = fixture.runSetup();
+      const worktreeEnvironmentPath = path.join(fixture.worktree, '.env');
+
+      expect(fs.readFileSync(worktreeEnvironmentPath, 'utf8')).toBe(secret);
+      expect(fs.statSync(worktreeEnvironmentPath).mode & 0o777).toBe(0o600);
+      expect(output.stdout).toContain('Copied .env from the main checkout.');
+      expect(`${output.stdout}\n${output.stderr}`).not.toContain(secret.trim());
+    } finally {
+      fs.rmSync(fixture.fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('preserves an existing worktree .env', () => {
+    const fixture = createFixture();
+    const worktreeEnvironmentPath = path.join(fixture.worktree, '.env');
+
+    try {
+      fs.writeFileSync(
+        path.join(fixture.mainCheckout, '.env'),
+        'SOURCE=main\n',
+      );
+      fs.writeFileSync(worktreeEnvironmentPath, 'SOURCE=worktree\n');
+
+      const output = fixture.runSetup();
+
+      expect(fs.readFileSync(worktreeEnvironmentPath, 'utf8')).toBe(
+        'SOURCE=worktree\n',
+      );
+      expect(output.stdout).not.toContain(
+        'Copied .env from the main checkout.',
+      );
+    } finally {
+      fs.rmSync(fixture.fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('succeeds when the main checkout has no .env', () => {
+    const fixture = createFixture();
+
+    try {
+      expect(() => fixture.runSetup()).not.toThrow();
+      expect(fs.existsSync(path.join(fixture.worktree, '.env'))).toBe(false);
+    } finally {
+      fs.rmSync(fixture.fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('does not copy over the main checkout .env when setup runs there', () => {
+    const fixture = createFixture();
+    const mainEnvironmentPath = path.join(fixture.mainCheckout, '.env');
+
+    try {
+      fs.writeFileSync(mainEnvironmentPath, 'SOURCE=main\n');
+
+      expect(() => fixture.runSetup(fixture.mainCheckout)).not.toThrow();
+      expect(fs.readFileSync(mainEnvironmentPath, 'utf8')).toBe(
+        'SOURCE=main\n',
+      );
+    } finally {
+      fs.rmSync(fixture.fixtureRoot, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Purpose

Ensure new Codex linked worktrees inherit the untracked .env from the primary checkout even when CODEX\_SOURCE\_ROOT is unavailable.

## Scope

- Resolve the primary checkout through Git worktree metadata.
- Copy a missing .env atomically with owner-only permissions without overwriting an existing file.
- Keep .env.dev generated independently per worktree.
- Add real linked-worktree integration coverage and document the behavior.

## Runtime and schema impact

Developer environment setup only. No database schema or production runtime impact.

## Verification

- bun run lint
- bun run format:write
- bunx eslint helpers/testing/codex-environment-setup.spec.ts
- bunx vitest run --config vitest.config.ts helpers/testing/codex-environment-setup.spec.ts
- Bash syntax validation for the embedded setup script
- Targeted Vitest execution from outside the repository root

* `main` <!-- branch-stack -->
  - **fix: copy main environment into Codex worktrees** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linked worktrees now receive a missing `.env` file from the primary checkout with owner-only permissions.
  * Existing worktree `.env` files remain unchanged.
  * Worktree-specific `.env.dev` files continue to be generated independently.

* **Documentation**
  * Updated local environment guidance to describe `.env` handling for linked worktrees.

* **Tests**
  * Added coverage for copying, preserving, and safely handling `.env` files across worktree setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->