### PR TITLE
fix(security): harden tenant permission boundaries

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -376,7 +376,12 @@ The exact capability list may evolve with the product, but these areas are expec
 
 Role and user management are essential tenant-admin workflows. Authorized
 administrators can assign and remove existing users' roles in the current
-tenant without changing the role definitions themselves.
+tenant without changing the role definitions themselves. The
+`users:assignRoles` capability deliberately grants unrestricted assignment of
+any existing tenant role, including self-assignment, and must therefore be
+treated as full tenant-administrator authority rather than limited delegation.
+Tenant roles never grant platform-global permissions; those belong only to an
+explicit platform principal.
 
 Capability dependencies matter. For example, a user who can publish events likely needs to see pending/unpublished events, including events created by other users.
 

--- a/helpers/testing/user-list-source.spec.ts
+++ b/helpers/testing/user-list-source.spec.ts
@@ -1,14 +1,13 @@
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // Source guard: the relaunch user-list owns tenant-scoped role assignment for
 // existing users, so review-only copy should not reappear.
 const repositoryRoot = new URL('../..', import.meta.url).pathname;
 
-const readSource = (path: string): string =>
-  readFileSync(join(repositoryRoot, path), 'utf8');
+const readSource = (sourcePath: string): string =>
+  readFileSync(path.join(repositoryRoot, sourcePath), 'utf8');
 
 describe('tenant user role assignment source', () => {
   it('keeps the user-list table scoped to review columns', () => {
@@ -37,6 +36,16 @@ describe('tenant user role assignment source', () => {
     expect(template).not.toContain('mat-checkbox');
   });
 
+  it('warns that unrestricted role assignment is tenant-admin authority', () => {
+    const roleForm = readSource(
+      'src/app/admin/components/role-form/role-form.component.html',
+    );
+
+    expect(roleForm).toContain('Full tenant-administrator authority.');
+    expect(roleForm).toContain('form.permissions["users:assignRoles"]');
+    expect(roleForm).toContain('including to themselves');
+  });
+
   it('keeps user-list role names tenant-scoped in the read-only RPC', () => {
     const source = readSource(
       'src/server/effect/rpc/handlers/users.handlers.ts',
@@ -58,6 +67,7 @@ describe('tenant user role assignment source', () => {
     expect(source).toContain(
       'Assigning roles to existing users happens from the **All users** page and is guarded by **users:assignRoles**.',
     );
+    expect(source).toContain('full tenant-administrator authority');
     expect(source).not.toContain('existing-user role assignment is deferred');
     expect(source).not.toContain('Edit user roles');
   });

--- a/src/app/admin/components/role-form/role-form.component.html
+++ b/src/app/admin/components/role-form/role-form.component.html
@@ -67,6 +67,18 @@
         </div>
       }
     </div>
+
+    @if (form.permissions["users:assignRoles"]().value()) {
+      <div
+        class="bg-error-container text-on-error-container rounded-lg p-4 lg:col-span-2"
+        role="alert"
+      >
+        <strong>Full tenant-administrator authority.</strong>
+        Anyone with this capability can assign any existing tenant role,
+        including to themselves, and gain every tenant capability granted by
+        those roles.
+      </div>
+    }
   </div>
   <button
     type="submit"

--- a/src/app/admin/components/role-form/role-form.component.ts
+++ b/src/app/admin/components/role-form/role-form.component.ts
@@ -15,10 +15,10 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import {
   ALL_PERMISSIONS,
-  Permission,
   PERMISSION_DEPENDENCIES,
   PERMISSION_GROUPS,
   permissionLabel,
+  TenantRolePermission,
 } from '../../../../shared/permissions/permissions';
 import {
   DEPENDENT_PERMISSION_PARENTS,
@@ -109,13 +109,13 @@ export class RoleFormComponent {
         description: formValue.description || null,
         permissions: ALL_PERMISSIONS.filter(
           (permission) => formValue.permissions[permission],
-        ) as Permission[],
+        ),
       });
     });
   }
 
   toggleGroup(
-    group: { permissions: { key: Permission }[] },
+    group: { permissions: { key: TenantRolePermission }[] },
     checked: boolean,
   ): void {
     if (!checked) {
@@ -124,17 +124,21 @@ export class RoleFormComponent {
     this.setGroupPermissions(group, checked);
   }
 
-  protected getDependentPermissionLabels(permission: Permission): string {
+  protected getDependentPermissionLabels(
+    permission: TenantRolePermission,
+  ): string {
     return this.getDependentPermissions(permission)
       .map((dependentPermission) => permissionLabel(dependentPermission))
       .join(', ');
   }
 
-  protected getDependentPermissions(permission: Permission): Permission[] {
+  protected getDependentPermissions(
+    permission: TenantRolePermission,
+  ): TenantRolePermission[] {
     return PERMISSION_DEPENDENCIES[permission] || [];
   }
 
-  protected getPermissionTooltip(permission: Permission): string {
+  protected getPermissionTooltip(permission: TenantRolePermission): string {
     const form = this.roleForm();
     const parents = DEPENDENT_PERMISSION_PARENTS[permission];
     if (parents.length === 0) return '';
@@ -151,7 +155,7 @@ export class RoleFormComponent {
   }
 
   private setGroupPermissions(
-    group: { permissions: { key: Permission }[] },
+    group: { permissions: { key: TenantRolePermission }[] },
     checked: boolean,
   ): void {
     const form = this.roleForm();

--- a/src/app/admin/components/role-form/role-form.schema.ts
+++ b/src/app/admin/components/role-form/role-form.schema.ts
@@ -2,8 +2,8 @@ import { readonly, required, schema } from '@angular/forms/signals';
 
 import {
   ALL_PERMISSIONS,
-  Permission,
   PERMISSION_DEPENDENCIES,
+  TenantRolePermission,
 } from '../../../../shared/permissions/permissions';
 
 export interface RoleFormData {
@@ -13,7 +13,7 @@ export interface RoleFormData {
   description: null | string;
   displayInHub: boolean;
   name: string;
-  permissions: Permission[];
+  permissions: TenantRolePermission[];
 }
 
 export interface RoleFormModel {
@@ -23,23 +23,25 @@ export interface RoleFormModel {
   description: string;
   displayInHub: boolean;
   name: string;
-  permissions: Record<Permission, boolean>;
+  permissions: Record<TenantRolePermission, boolean>;
 }
 
 export interface RoleFormOverrides extends Partial<
   Omit<RoleFormModel, 'description' | 'permissions'>
 > {
   description?: null | string;
-  permissions?: Partial<Record<Permission, boolean>> | Permission[];
+  permissions?:
+    Partial<Record<TenantRolePermission, boolean>> | TenantRolePermission[];
 }
 
 const emptyPermissions = Object.fromEntries(
   ALL_PERMISSIONS.map((permission) => [permission, false]),
-) as Record<Permission, boolean>;
+) as Record<TenantRolePermission, boolean>;
 
 const buildPermissions = (
-  selected?: Partial<Record<Permission, boolean>> | Permission[],
-): Record<Permission, boolean> => {
+  selected?:
+    Partial<Record<TenantRolePermission, boolean>> | TenantRolePermission[],
+): Record<TenantRolePermission, boolean> => {
   const next = { ...emptyPermissions };
   if (Array.isArray(selected)) {
     for (const permission of selected) {
@@ -83,12 +85,15 @@ export const mergeRoleFormOverrides = (
 };
 
 export const DEPENDENT_PERMISSION_PARENTS = Object.fromEntries(
-  ALL_PERMISSIONS.map((permission) => [permission, [] as Permission[]]),
-) as Record<Permission, Permission[]>;
+  ALL_PERMISSIONS.map((permission) => [
+    permission,
+    [] as TenantRolePermission[],
+  ]),
+) as Record<TenantRolePermission, TenantRolePermission[]>;
 
 for (const [permission, dependencies] of Object.entries(
   PERMISSION_DEPENDENCIES,
-) as [Permission, Permission[]][]) {
+) as [TenantRolePermission, TenantRolePermission[]][]) {
   for (const dependent of dependencies) {
     DEPENDENT_PERMISSION_PARENTS[dependent].push(permission);
   }

--- a/src/app/admin/role-details/role-details.component.ts
+++ b/src/app/admin/role-details/role-details.component.ts
@@ -7,8 +7,8 @@ import { faArrowLeft, faEdit } from '@fortawesome/duotone-regular-svg-icons';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 import {
-  Permission,
   PERMISSION_GROUPS,
+  type TenantRolePermission,
 } from '../../../shared/permissions/permissions';
 import { AppRpc } from '../../core/effect-rpc-angular-client';
 import { getErrorMessage } from '../../core/error-message';
@@ -33,7 +33,7 @@ export class RoleDetailsComponent {
     }),
   );
 
-  hasPermission(permission: Permission) {
+  hasPermission(permission: TenantRolePermission) {
     return this.roleQuery.data()?.permissions.includes(permission) ?? false;
   }
 

--- a/src/db/schema/roles.ts
+++ b/src/db/schema/roles.ts
@@ -7,7 +7,7 @@ import {
   unique,
 } from 'drizzle-orm/pg-core';
 
-import { Permission } from '../../shared/permissions/permissions';
+import { TenantRolePermission } from '../../shared/permissions/permissions';
 import { modelOfTenant } from './model';
 
 export const roles = pgTable(
@@ -20,7 +20,7 @@ export const roles = pgTable(
     description: text(),
     displayInHub: boolean().notNull().default(false),
     name: text().notNull(),
-    permissions: jsonb().$type<Permission[]>().notNull().default([]),
+    permissions: jsonb().$type<TenantRolePermission[]>().notNull().default([]),
     sortOrder: integer().notNull().default(2_147_483_647),
   },
   (t) => [unique().on(t.tenantId, t.name)],

--- a/src/server/context/request-context-resolver.spec.ts
+++ b/src/server/context/request-context-resolver.spec.ts
@@ -266,4 +266,71 @@ describe('request-context-resolver', () => {
       expect(attributesExecute).not.toHaveBeenCalled();
     }),
   );
+
+  it.effect(
+    'discards poisoned platform permissions while preserving tenant role permissions',
+    () =>
+      Effect.gen(function* () {
+        const database = createPreparedDatabase({
+          userExecute: vi.fn(() =>
+            Effect.succeed({
+              auth0Id: 'auth0|tenant-user',
+              communicationEmail: null,
+              email: 'member@example.com',
+              firstName: 'Tenant',
+              iban: null,
+              id: 'user-1',
+              lastName: 'Member',
+              paypalEmail: null,
+              tenantAssignments: [
+                {
+                  roles: [
+                    {
+                      id: 'role-mixed',
+                      permissions: [
+                        'events:viewPublic',
+                        'events:*',
+                        'globalAdmin:*',
+                        'globalAdmin:manageTenants',
+                      ],
+                    },
+                  ],
+                },
+              ],
+            }),
+          ),
+        });
+
+        const user = yield* resolveUserContext({
+          isAuthenticated: true,
+          oidcUser: { sub: 'auth0|tenant-user' },
+          tenantId: 'tenant-1',
+        }).pipe(Effect.provide(Layer.succeed(Database, database as never)));
+
+        expect(user?.permissions).toEqual(['events:viewPublic', 'events:*']);
+        expect(user?.roleIds).toEqual(['role-mixed']);
+        expect(
+          resolveRequestPermissions({
+            oidcUser: { sub: 'auth0|tenant-user' },
+            user,
+          }),
+        ).not.toContain('globalAdmin:manageTenants');
+      }),
+  );
+
+  it('retains platform-global authority for genuine platform principals', () => {
+    const permissions = resolveRequestPermissions({
+      oidcUser: {
+        'evorto.app/app_metadata': {
+          globalAdmin: true,
+        },
+      },
+      user: {
+        permissions: ['events:viewPublic'],
+      },
+    });
+
+    expect(permissions).toContain('events:viewPublic');
+    expect(permissions).toContain('globalAdmin:manageTenants');
+  });
 });

--- a/src/server/context/request-context-resolver.ts
+++ b/src/server/context/request-context-resolver.ts
@@ -5,6 +5,7 @@ import { Database, type DatabaseClient } from '../../db';
 import { getPreparedStatements } from '../../db/prepared-statements';
 import {
   ALL_PERMISSIONS,
+  partitionTenantRolePermissions,
   type Permission,
 } from '../../shared/permissions/permissions';
 import { type Authentication } from '../../types/custom/authentication';
@@ -60,11 +61,16 @@ export const resolveRequestPermissions = (input: {
     | {
         permissions: readonly Permission[];
       };
-}) =>
-  normalizePermissions([
+}) => {
+  const tenantPermissions = partitionTenantRolePermissions(
+    input.user?.permissions ?? [],
+  ).accepted;
+
+  return normalizePermissions([
     ...resolveGlobalAdminPermissions(input.oidcUser),
-    ...(input.user?.permissions ?? []),
+    ...tenantPermissions,
   ]);
+};
 
 const asString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined;
@@ -196,13 +202,33 @@ export const resolveUserContext = (input: {
       return;
     }
 
-    const permissions = user.tenantAssignments
+    const assignedRoles = user.tenantAssignments
       .flatMap((assignment) => assignment.roles)
-      .flatMap((role) => role.permissions);
+      .map((role) => ({
+        ...role,
+        permissions: partitionTenantRolePermissions(role.permissions),
+      }));
 
-    const roleIds = user.tenantAssignments
-      .flatMap((assignment) => assignment.roles)
-      .flatMap((role) => role.id);
+    for (const role of assignedRoles) {
+      if (role.permissions.rejected.length === 0) continue;
+
+      yield* Effect.logWarning(
+        'Discarded platform-global permissions from tenant role',
+      ).pipe(
+        Effect.annotateLogs({
+          rejectedPermissions: role.permissions.rejected,
+          roleId: role.id,
+          tenantId: input.tenantId,
+          userId: user.id,
+        }),
+      );
+    }
+
+    const permissions = assignedRoles.flatMap(
+      (role) => role.permissions.accepted,
+    );
+
+    const roleIds = assignedRoles.map((role) => role.id);
 
     const attributeResponse = yield* databaseEffect((database) =>
       Effect.map(

--- a/src/server/effect/rpc/handlers/admin.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/admin.handlers.spec.ts
@@ -145,7 +145,11 @@ describe('adminHandlers role permissions', () => {
                 displayInHub: true,
                 id: 'role-1',
                 name: 'Member',
-                permissions: ['events:viewPublic'],
+                permissions: [
+                  'events:viewPublic',
+                  'globalAdmin:*',
+                  'globalAdmin:manageTenants',
+                ],
                 sortOrder: 1,
               }),
           },
@@ -161,6 +165,7 @@ describe('adminHandlers role permissions', () => {
         displayInHub: true,
         id: 'role-1',
         name: 'Member',
+        permissions: ['events:viewPublic'],
       });
       expect(role).not.toHaveProperty('showInHub');
     }),

--- a/src/server/effect/rpc/handlers/admin.handlers.ts
+++ b/src/server/effect/rpc/handlers/admin.handlers.ts
@@ -22,6 +22,7 @@ import { Database, type DatabaseClient } from '../../../../db';
 import { roles, tenants, tenantStripeTaxRates } from '../../../../db/schema';
 import {
   includesPermission,
+  partitionTenantRolePermissions,
   type Permission,
 } from '../../../../shared/permissions/permissions';
 import { type AdminHubRoleRecord } from '../../../../shared/rpc-contracts/app-rpcs/admin.rpcs';
@@ -230,6 +231,15 @@ const normalizeHubRoleRecord = (role: {
   };
 };
 
+const normalizeAdminRoleRecord = <
+  Role extends { permissions: readonly Permission[] },
+>(
+  role: Role,
+) => ({
+  ...role,
+  permissions: partitionTenantRolePermissions(role.permissions).accepted,
+});
+
 const ensureAuthenticated = (
   headers: Headers.Headers,
 ): Effect.Effect<void, RpcUnauthorizedError> =>
@@ -295,7 +305,7 @@ export const adminHandlers = {
         return yield* Effect.die(new Error('Role insert returned no rows'));
       }
 
-      return createdRole;
+      return normalizeAdminRoleRecord(createdRole);
     }),
   'admin.roles.delete': ({ id }, options) =>
     Effect.gen(function* () {
@@ -391,7 +401,7 @@ export const adminHandlers = {
         }),
       );
 
-      return tenantRoles;
+      return tenantRoles.map((role) => normalizeAdminRoleRecord(role));
     }),
   'admin.roles.findOne': ({ id }, options) =>
     Effect.gen(function* () {
@@ -422,7 +432,7 @@ export const adminHandlers = {
         );
       }
 
-      return role;
+      return normalizeAdminRoleRecord(role);
     }),
   'admin.roles.search': ({ search }, options) =>
     Effect.gen(function* () {
@@ -453,7 +463,7 @@ export const adminHandlers = {
         }),
       );
 
-      return matchingRoles;
+      return matchingRoles.map((role) => normalizeAdminRoleRecord(role));
     }),
   'admin.roles.update': ({ id, ...input }, options) =>
     Effect.gen(function* () {
@@ -494,7 +504,7 @@ export const adminHandlers = {
         );
       }
 
-      return updatedRole;
+      return normalizeAdminRoleRecord(updatedRole);
     }),
   'admin.tenant.importStripeTaxRates': ({ ids }, options) =>
     Effect.gen(function* () {

--- a/src/server/effect/rpc/handlers/events/events-query.handlers.ts
+++ b/src/server/effect/rpc/handlers/events/events-query.handlers.ts
@@ -74,6 +74,52 @@ export const organizerRegistrationTransferAvailable = ({
 const canInspectTenantEvents = (permissions: readonly Permission[]): boolean =>
   includesPermission('globalAdmin:manageTenants', permissions);
 
+export const canOrganizeEvent = Effect.fn('events.canOrganizeEvent')(
+  function* ({
+    eventId,
+    tenantId,
+    user,
+  }: {
+    eventId: string;
+    tenantId: string;
+    user: { id: string; permissions: readonly Permission[] };
+  }) {
+    if (
+      includesPermission('events:organizeAll', user.permissions) ||
+      includesPermission('finance:manageReceipts', user.permissions)
+    ) {
+      return true;
+    }
+
+    const registrations = yield* databaseEffect((database) =>
+      database
+        .select({
+          id: eventRegistrations.id,
+        })
+        .from(eventRegistrations)
+        .innerJoin(
+          eventRegistrationOptions,
+          eq(
+            eventRegistrations.registrationOptionId,
+            eventRegistrationOptions.id,
+          ),
+        )
+        .where(
+          and(
+            eq(eventRegistrations.tenantId, tenantId),
+            eq(eventRegistrations.eventId, eventId),
+            eq(eventRegistrations.userId, user.id),
+            eq(eventRegistrations.status, 'CONFIRMED'),
+            eq(eventRegistrationOptions.organizingRegistration, true),
+          ),
+        )
+        .limit(1),
+    );
+
+    return registrations.length > 0;
+  },
+);
+
 export const eventQueryHandlers = {
   'events.canOrganize': ({ eventId }, _options) =>
     Effect.gen(function* () {
@@ -81,39 +127,11 @@ export const eventQueryHandlers = {
       const { tenant } = yield* RpcAccess.current();
       const user = yield* RpcAccess.requireUser();
 
-      if (
-        includesPermission('events:organizeAll', user.permissions) ||
-        includesPermission('finance:manageReceipts', user.permissions)
-      ) {
-        return true;
-      }
-
-      const registrations = yield* databaseEffect((database) =>
-        database
-          .select({
-            id: eventRegistrations.id,
-          })
-          .from(eventRegistrations)
-          .innerJoin(
-            eventRegistrationOptions,
-            eq(
-              eventRegistrations.registrationOptionId,
-              eventRegistrationOptions.id,
-            ),
-          )
-          .where(
-            and(
-              eq(eventRegistrations.tenantId, tenant.id),
-              eq(eventRegistrations.eventId, eventId),
-              eq(eventRegistrations.userId, user.id),
-              eq(eventRegistrations.status, 'CONFIRMED'),
-              eq(eventRegistrationOptions.organizingRegistration, true),
-            ),
-          )
-          .limit(1),
-      );
-
-      return registrations.length > 0;
+      return yield* canOrganizeEvent({
+        eventId,
+        tenantId: tenant.id,
+        user,
+      });
     }),
   'events.eventList': (input, _options) =>
     Effect.gen(function* () {
@@ -830,6 +848,21 @@ export const eventQueryHandlers = {
     Effect.gen(function* () {
       yield* RpcAccess.ensureAuthenticated();
       const { tenant } = yield* RpcAccess.current();
+      const user = yield* RpcAccess.requireUser();
+
+      const canOrganize = yield* canOrganizeEvent({
+        eventId,
+        tenantId: tenant.id,
+        user,
+      });
+      if (!canOrganize) {
+        return yield* Effect.fail(
+          new RpcForbiddenError({
+            message: 'Organizer access required',
+            permission: 'events:organizeAll',
+          }),
+        );
+      }
 
       const registrations = yield* databaseEffect((database) =>
         database.query.eventRegistrations.findMany({

--- a/src/server/effect/rpc/handlers/events/events.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/events/events.handlers.spec.ts
@@ -1,7 +1,102 @@
-import { describe, expect, it } from '@effect/vitest';
+import { describe, expect, it, vi } from '@effect/vitest';
+import { Effect, Layer } from 'effect';
+import * as Headers from 'effect/unstable/http/Headers';
 
-import { organizerRegistrationTransferAvailable } from './events-query.handlers';
+import { Database, type DatabaseClient } from '../../../../../db';
+import { type Permission } from '../../../../../shared/permissions/permissions';
+import {
+  RpcRequestContext,
+  type RpcRequestContextShape,
+} from '../../../../../shared/rpc-contracts/app-rpcs';
+import { RpcAccess } from '../shared/rpc-access.service';
+import {
+  eventQueryHandlers,
+  organizerRegistrationTransferAvailable,
+} from './events-query.handlers';
 import { eventHandlers } from './events.handlers';
+
+const emptyHandlerOptions = { headers: Headers.fromInput({}) };
+
+const tenant = {
+  currency: 'EUR' as const,
+  defaultLocation: null,
+  discountProviders: null,
+  domain: 'tenant.example.com',
+  id: 'tenant-1',
+  locale: 'en',
+  name: 'Tenant',
+  receiptSettings: null,
+  stripeAccountId: null,
+  theme: 'evorto' as const,
+  timezone: 'Europe/Amsterdam',
+};
+
+const createUser = (permissions: readonly Permission[] = []) => ({
+  attributes: [],
+  auth0Id: 'auth0|user-1',
+  communicationEmail: undefined,
+  email: 'member@example.com',
+  firstName: 'Tenant',
+  iban: undefined,
+  id: 'user-1',
+  lastName: 'Member',
+  paypalEmail: undefined,
+  permissions,
+  roleIds: [],
+});
+
+const createEventQueryDatabase = ({
+  organizerRegistration = false,
+}: {
+  organizerRegistration?: boolean;
+} = {}) => {
+  const attendeeQuery = vi.fn(() => Effect.succeed([]));
+  const organizerQuery = {
+    from: () => organizerQuery,
+    innerJoin: () => organizerQuery,
+    limit: vi.fn(() =>
+      Effect.succeed(organizerRegistration ? [{ id: 'registration-1' }] : []),
+    ),
+    where: () => organizerQuery,
+  };
+  const select = vi.fn(() => organizerQuery);
+
+  return {
+    attendeeQuery,
+    database: {
+      query: {
+        eventRegistrations: {
+          findMany: attendeeQuery,
+        },
+      },
+      select,
+    },
+    select,
+  };
+};
+
+const createContextLayer = ({
+  database,
+  user = createUser(),
+}: {
+  database: object;
+  user?: ReturnType<typeof createUser>;
+}) => {
+  const context = {
+    authData: {},
+    authenticated: true,
+    permissions: user.permissions,
+    tenant,
+    user,
+    userAssigned: true,
+  } satisfies RpcRequestContextShape;
+
+  return Layer.mergeAll(
+    RpcAccess.Default,
+    Layer.succeed(RpcRequestContext, context),
+    Layer.succeed(Database, database as DatabaseClient),
+  );
+};
 
 describe('eventHandlers composition', () => {
   it('contains the full events rpc handler set', () => {
@@ -72,4 +167,68 @@ describe('organizerRegistrationTransferAvailable', () => {
       }),
     ).toBe(false);
   });
+});
+
+describe('organizer overview authorization', () => {
+  it.effect('denies a non-organizer before querying attendee data', () =>
+    Effect.gen(function* () {
+      const { attendeeQuery, database } = createEventQueryDatabase();
+
+      const error = yield* eventQueryHandlers['events.getOrganizeOverview'](
+        { eventId: 'event-1' },
+        emptyHandlerOptions,
+      ).pipe(Effect.flip, Effect.provide(createContextLayer({ database })));
+
+      expect(error._tag).toBe('RpcForbiddenError');
+      expect(error.permission).toBe('events:organizeAll');
+      expect(attendeeQuery).not.toHaveBeenCalled();
+    }),
+  );
+
+  it.effect('uses confirmed organizer registration access in both RPCs', () =>
+    Effect.gen(function* () {
+      const { attendeeQuery, database } = createEventQueryDatabase({
+        organizerRegistration: true,
+      });
+      const layer = createContextLayer({ database });
+
+      const canOrganize = yield* eventQueryHandlers['events.canOrganize'](
+        { eventId: 'event-1' },
+        emptyHandlerOptions,
+      ).pipe(Effect.provide(layer));
+      const overview = yield* eventQueryHandlers['events.getOrganizeOverview'](
+        { eventId: 'event-1' },
+        emptyHandlerOptions,
+      ).pipe(Effect.provide(layer));
+
+      expect(canOrganize).toBe(true);
+      expect(overview).toEqual([]);
+      expect(attendeeQuery).toHaveBeenCalledOnce();
+    }),
+  );
+
+  it.effect.each([
+    'events:organizeAll' as const,
+    'finance:manageReceipts' as const,
+  ])('allows tenant-wide organizer authority through %s', (permission) =>
+    Effect.gen(function* () {
+      const { attendeeQuery, database, select } = createEventQueryDatabase();
+
+      const overview = yield* eventQueryHandlers['events.getOrganizeOverview'](
+        { eventId: 'event-1' },
+        emptyHandlerOptions,
+      ).pipe(
+        Effect.provide(
+          createContextLayer({
+            database,
+            user: createUser([permission]),
+          }),
+        ),
+      );
+
+      expect(overview).toEqual([]);
+      expect(select).not.toHaveBeenCalled();
+      expect(attendeeQuery).toHaveBeenCalledOnce();
+    }),
+  );
 });

--- a/src/server/effect/rpc/handlers/users.handlers.spec.ts
+++ b/src/server/effect/rpc/handlers/users.handlers.spec.ts
@@ -249,7 +249,7 @@ describe('userHandlers', () => {
   );
 
   it.effect(
-    'assignRoles replaces tenant role assignments transactionally',
+    'assignRoles allows full tenant-admin self-assignment transactionally',
     () =>
       Effect.gen(function* () {
         const deleteWhere = vi.fn(() => Effect.void);
@@ -297,7 +297,7 @@ describe('userHandlers', () => {
         yield* userHandlers['users.assignRoles'](
           {
             roleIds: ['role-1', 'role-2', 'role-1'],
-            userId: 'user-2',
+            userId: 'user-1',
           },
           {
             headers: createUserHandlerHeaders({

--- a/src/shared/permissions/permissions.spec.ts
+++ b/src/shared/permissions/permissions.spec.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from 'vitest';
 import {
   ALL_PERMISSIONS,
   includesPermission,
+  partitionTenantRolePermissions,
   PERMISSION_GROUPS,
   permissionLabel,
   PermissionSchema,
+  TenantRolePermissionSchema,
 } from './permissions';
 
 describe('PermissionSchema', () => {
@@ -31,6 +33,40 @@ describe('PermissionSchema', () => {
   });
 });
 
+describe('TenantRolePermissionSchema', () => {
+  it('accepts concrete tenant permissions, tenant wildcards, and legacy tax aliases', () => {
+    expect(
+      Schema.decodeUnknownSync(Schema.Array(TenantRolePermissionSchema))([
+        'events:viewPublic',
+        'events:*',
+        'admin:manageTaxes',
+      ]),
+    ).toEqual(['events:viewPublic', 'events:*', 'admin:manageTaxes']);
+  });
+
+  it('rejects both platform-global permissions', () => {
+    for (const permission of ['globalAdmin:*', 'globalAdmin:manageTenants']) {
+      expect(() =>
+        Schema.decodeUnknownSync(TenantRolePermissionSchema)(permission),
+      ).toThrow();
+    }
+  });
+
+  it('partitions only platform-global permissions from stored tenant roles', () => {
+    expect(
+      partitionTenantRolePermissions([
+        'events:viewPublic',
+        'events:*',
+        'globalAdmin:*',
+        'globalAdmin:manageTenants',
+      ]),
+    ).toEqual({
+      accepted: ['events:viewPublic', 'events:*'],
+      rejected: ['globalAdmin:*', 'globalAdmin:manageTenants'],
+    });
+  });
+});
+
 describe('PERMISSION_GROUPS', () => {
   it('defines admin-facing labels and descriptions for every visible permission', () => {
     for (const permission of PERMISSION_GROUPS.flatMap(
@@ -48,10 +84,10 @@ describe('PERMISSION_GROUPS', () => {
       expect.arrayContaining([
         expect.objectContaining({
           description: expect.stringContaining(
-            'not available in the current admin UI',
+            'full tenant-administrator authority',
           ),
           key: 'users:assignRoles',
-          label: 'Assign user roles (future)',
+          label: 'Assign all user roles (tenant admin)',
         }),
       ]),
     );

--- a/src/shared/permissions/permissions.ts
+++ b/src/shared/permissions/permissions.ts
@@ -61,7 +61,7 @@ const FINANCE_GROUP = {
   ] as const,
 } as const;
 
-// Union type of all possible permissions
+// Union type of all effective permissions and permission checks.
 export type Permission =
   | AdminPermissions
   | AdminPermissionsLegacy
@@ -81,9 +81,13 @@ export interface PermissionGroup {
 
 export interface PermissionMeta {
   description?: string;
-  key: Permission;
+  key: TenantRolePermission;
   label: string;
 }
+
+// Tenant roles may grant tenant-scoped capabilities and tenant-group
+// wildcards. Platform globals are resolved outside tenant role persistence.
+export type TenantRolePermission = Exclude<Permission, GlobalAdminPermissions>;
 
 // Type definitions using the const groups
 
@@ -225,8 +229,8 @@ const PERMISSION_METADATA = {
   },
   'users:assignRoles': {
     description:
-      'Assign and remove existing users from tenant roles without changing the role definitions.',
-    label: 'Assign user roles',
+      'Assign any existing tenant role to any tenant user, including yourself. Treat this as full tenant-administrator authority because assigned roles can grant every tenant capability.',
+    label: 'Assign all user roles (tenant admin)',
   },
   'users:viewAll': {
     description:
@@ -234,14 +238,11 @@ const PERMISSION_METADATA = {
     label: 'View all users',
   },
 } satisfies Record<
-  Exclude<
-    Permission,
-    'admin:manageTaxes' | `${string}:*` | `globalAdmin:${string}`
-  >,
+  Exclude<TenantRolePermission, 'admin:manageTaxes' | `${string}:*`>,
   Omit<PermissionMeta, 'key'>
 >;
 
-const permissionMeta = (key: Permission): PermissionMeta => ({
+const permissionMeta = (key: TenantRolePermission): PermissionMeta => ({
   key,
   ...PERMISSION_METADATA[key as keyof typeof PERMISSION_METADATA],
 });
@@ -256,7 +257,7 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
     key: ADMIN_GROUP.key,
     label: 'Admin',
     permissions: ADMIN_GROUP.permissions.map((perm) =>
-      permissionMeta(`${ADMIN_GROUP.key}:${perm}` as Permission),
+      permissionMeta(`${ADMIN_GROUP.key}:${perm}` as TenantRolePermission),
     ),
   },
   {
@@ -264,7 +265,7 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
     key: INTERNAL_GROUP.key,
     label: 'Internal',
     permissions: INTERNAL_GROUP.permissions.map((perm) =>
-      permissionMeta(`${INTERNAL_GROUP.key}:${perm}` as Permission),
+      permissionMeta(`${INTERNAL_GROUP.key}:${perm}` as TenantRolePermission),
     ),
   },
   {
@@ -272,7 +273,7 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
     key: EVENTS_GROUP.key,
     label: 'Events',
     permissions: EVENTS_GROUP.permissions.map((perm) =>
-      permissionMeta(`${EVENTS_GROUP.key}:${perm}` as Permission),
+      permissionMeta(`${EVENTS_GROUP.key}:${perm}` as TenantRolePermission),
     ),
   },
   {
@@ -280,7 +281,7 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
     key: TEMPLATES_GROUP.key,
     label: 'Templates',
     permissions: TEMPLATES_GROUP.permissions.map((perm) =>
-      permissionMeta(`${TEMPLATES_GROUP.key}:${perm}` as Permission),
+      permissionMeta(`${TEMPLATES_GROUP.key}:${perm}` as TenantRolePermission),
     ),
   },
   {
@@ -288,7 +289,7 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
     key: USERS_GROUP.key,
     label: 'Users',
     permissions: USERS_GROUP.permissions.map((perm) =>
-      permissionMeta(`${USERS_GROUP.key}:${perm}` as Permission),
+      permissionMeta(`${USERS_GROUP.key}:${perm}` as TenantRolePermission),
     ),
   },
   {
@@ -296,7 +297,7 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
     key: FINANCE_GROUP.key,
     label: 'Finance',
     permissions: FINANCE_GROUP.permissions.map((perm) =>
-      permissionMeta(`${FINANCE_GROUP.key}:${perm}` as Permission),
+      permissionMeta(`${FINANCE_GROUP.key}:${perm}` as TenantRolePermission),
     ),
   },
 ] as const;
@@ -344,43 +345,85 @@ export const PERMISSIONS = {
 // Get all permission keys as a flat array with proper typing
 export const ALL_PERMISSIONS = PERMISSION_GROUPS.flatMap((group) =>
   group.permissions.map((perm) => perm.key),
-) satisfies Permission[];
+) satisfies TenantRolePermission[];
+
+const TENANT_ROLE_PERMISSION_LITERALS = [
+  'admin:manageTaxes',
+  'admin:*',
+  'events:*',
+  'finance:*',
+  'internal:*',
+  'templates:*',
+  'users:*',
+  ...ALL_PERMISSIONS,
+] as const satisfies readonly TenantRolePermission[];
+
+export const TenantRolePermissionSchema = Schema.Union(
+  TENANT_ROLE_PERMISSION_LITERALS.map((permission) =>
+    Schema.Literal(permission),
+  ),
+);
+
+const isPlatformGlobalPermission = (
+  permission: Permission,
+): permission is GlobalAdminPermissions =>
+  permission === 'globalAdmin:*' || permission === 'globalAdmin:manageTenants';
+
+export const partitionTenantRolePermissions = (
+  permissions: readonly Permission[],
+): {
+  accepted: TenantRolePermission[];
+  rejected: GlobalAdminPermissions[];
+} => {
+  const accepted: TenantRolePermission[] = [];
+  const rejected: GlobalAdminPermissions[] = [];
+
+  for (const permission of permissions) {
+    if (isPlatformGlobalPermission(permission)) {
+      rejected.push(permission);
+    } else {
+      accepted.push(permission);
+    }
+  }
+
+  return { accepted, rejected };
+};
 
 const PERMISSION_LITERALS = [
-  'admin:manageTaxes',
+  ...TENANT_ROLE_PERMISSION_LITERALS,
   'globalAdmin:*',
   'globalAdmin:manageTenants',
-  ...ALL_PERMISSIONS,
 ] as const satisfies readonly Permission[];
 
 export const PermissionSchema = Schema.Union(
   PERMISSION_LITERALS.map((permission) => Schema.Literal(permission)),
 );
 
-export const PERMISSION_DEPENDENCIES: Record<Permission, Permission[]> =
-  Object.fromEntries(
-    PERMISSION_GROUPS.flatMap((group) =>
-      group.permissions.map((perm) => {
-        switch (perm.key) {
-          case 'events:changeListing': {
-            return [perm.key, ['events:seeUnlisted']];
-          }
-          case 'events:create': {
-            return [perm.key, ['templates:view']];
-          }
-          case 'events:review': {
-            return [perm.key, ['events:seeDrafts', 'events:seeUnlisted']];
-          }
-          case 'users:assignRoles': {
-            return [perm.key, ['users:viewAll']];
-          }
-          default: {
-            return [perm.key, []];
-          }
+export const PERMISSION_DEPENDENCIES: Partial<
+  Record<TenantRolePermission, TenantRolePermission[]>
+> = Object.fromEntries(
+  PERMISSION_GROUPS.flatMap((group) =>
+    group.permissions.map((perm) => {
+      switch (perm.key) {
+        case 'events:changeListing': {
+          return [perm.key, ['events:seeUnlisted']];
         }
-      }),
-    ),
-  ) as Record<Permission, Permission[]>;
+        case 'events:create': {
+          return [perm.key, ['templates:view']];
+        }
+        case 'events:review': {
+          return [perm.key, ['events:seeDrafts', 'events:seeUnlisted']];
+        }
+        case 'users:assignRoles': {
+          return [perm.key, ['users:viewAll']];
+        }
+        default: {
+          return [perm.key, []];
+        }
+      }
+    }),
+  ),
+) as Partial<Record<TenantRolePermission, TenantRolePermission[]>>;
 
 export const includesPermission = (
   permission: Permission,
@@ -402,6 +445,10 @@ export const includesPermission = (
   const [group] = permission.split(':');
   if (permissions.includes(`${group}:*` as Permission)) {
     return true;
+  }
+
+  if (isPlatformGlobalPermission(permission)) {
+    return false;
   }
 
   return Object.entries(PERMISSION_DEPENDENCIES).some(

--- a/src/shared/rpc-contracts/app-rpcs/admin.rpcs.spec.ts
+++ b/src/shared/rpc-contracts/app-rpcs/admin.rpcs.spec.ts
@@ -2,9 +2,54 @@ import { Schema } from 'effect';
 import { describe, expect, it } from 'vitest';
 
 import {
+  AdminRolesCreateInput,
+  AdminRolesUpdateInput,
   AdminTenantBrandAssetKind,
   AdminTenantUpdateSettingsInput,
 } from './admin.rpcs';
+
+const currentRoleInput = {
+  collapseMembersInHup: false,
+  defaultOrganizerRole: false,
+  defaultUserRole: true,
+  description: 'Default tenant member',
+  displayInHub: true,
+  name: 'Member',
+  permissions: ['events:viewPublic', 'events:*'],
+};
+
+describe('admin role input schemas', () => {
+  it('accepts tenant-scoped role permissions for create and update', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(AdminRolesCreateInput)(currentRoleInput),
+    ).not.toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(AdminRolesUpdateInput)({
+        ...currentRoleInput,
+        id: 'role-1',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects platform-global permissions on create and update', () => {
+    for (const permission of ['globalAdmin:*', 'globalAdmin:manageTenants']) {
+      expect(() =>
+        Schema.decodeUnknownSync(AdminRolesCreateInput)({
+          ...currentRoleInput,
+          defaultUserRole: true,
+          permissions: [permission],
+        }),
+      ).toThrow();
+      expect(() =>
+        Schema.decodeUnknownSync(AdminRolesUpdateInput)({
+          ...currentRoleInput,
+          id: 'role-1',
+          permissions: [permission],
+        }),
+      ).toThrow();
+    }
+  });
+});
 
 const currentTenantSettingsInput = {
   allowOther: true,

--- a/src/shared/rpc-contracts/app-rpcs/admin.rpcs.ts
+++ b/src/shared/rpc-contracts/app-rpcs/admin.rpcs.ts
@@ -6,7 +6,7 @@ import * as Rpc from 'effect/unstable/rpc/Rpc';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 
 import { Tenant } from '../../../types/custom/tenant';
-import { PermissionSchema } from '../../permissions/permissions';
+import { TenantRolePermissionSchema } from '../../permissions/permissions';
 import { AdminRoleRpcError, AdminTenantRpcError } from './admin.errors';
 
 const UrlString = Schema.String.pipe(
@@ -55,7 +55,7 @@ export const AdminRoleRecord = Schema.Struct({
   displayInHub: Schema.Boolean,
   id: Schema.NonEmptyString,
   name: Schema.NonEmptyString,
-  permissions: Schema.mutable(Schema.Array(PermissionSchema)),
+  permissions: Schema.mutable(Schema.Array(TenantRolePermissionSchema)),
   sortOrder: Schema.Number,
 });
 
@@ -123,7 +123,7 @@ export const AdminRolesCreateInput = Schema.Struct({
   description: Schema.NullOr(Schema.NonEmptyString),
   displayInHub: Schema.Boolean,
   name: Schema.NonEmptyString,
-  permissions: Schema.mutable(Schema.Array(PermissionSchema)),
+  permissions: Schema.mutable(Schema.Array(TenantRolePermissionSchema)),
 });
 
 export type AdminRolesCreateInput = Schema.Schema.Type<
@@ -158,19 +158,19 @@ export const AdminRolesSearch = asRpcQuery(
   }),
 );
 
+export const AdminRolesUpdateInput = Schema.Struct({
+  ...AdminRolesCreateInput.fields,
+  id: Schema.NonEmptyString,
+});
+
+export type AdminRolesUpdateInput = Schema.Schema.Type<
+  typeof AdminRolesUpdateInput
+>;
+
 export const AdminRolesUpdate = asRpcMutation(
   Rpc.make('admin.roles.update', {
     error: AdminRoleRpcError,
-    payload: Schema.Struct({
-      collapseMembersInHup: Schema.Boolean,
-      defaultOrganizerRole: Schema.Boolean,
-      defaultUserRole: Schema.Boolean,
-      description: Schema.NullOr(Schema.NonEmptyString),
-      displayInHub: Schema.Boolean,
-      id: Schema.NonEmptyString,
-      name: Schema.NonEmptyString,
-      permissions: Schema.mutable(Schema.Array(PermissionSchema)),
-    }),
+    payload: AdminRolesUpdateInput,
     success: AdminRoleRecord,
   }),
 );

--- a/src/shared/rpc-contracts/app-rpcs/events.errors.ts
+++ b/src/shared/rpc-contracts/app-rpcs/events.errors.ts
@@ -53,6 +53,9 @@ export class EventRegistrationNotFoundError extends Schema.TaggedErrorClass<Even
 export const EventsRpcError = UnauthorizedRpcError;
 export type EventsRpcError = UnauthorizedRpcError;
 
+export const EventsOrganizeRpcError = ForbiddenOrUnauthorizedRpcError;
+export type EventsOrganizeRpcError = ForbiddenOrUnauthorizedRpcError;
+
 export const EventsReviewRpcError = ForbiddenOrUnauthorizedRpcError;
 export type EventsReviewRpcError = ForbiddenOrUnauthorizedRpcError;
 

--- a/src/shared/rpc-contracts/app-rpcs/events.rpcs.ts
+++ b/src/shared/rpc-contracts/app-rpcs/events.rpcs.ts
@@ -14,11 +14,11 @@ import {
   EventsEventListRpcError,
   EventsFindOneForEditRpcError,
   EventsFindOneRpcError,
+  EventsOrganizeRpcError,
   EventsRegisterForEventError,
   EventsRegistrationScannedError,
   EventsReviewEventRpcError,
   EventsReviewRpcError,
-  EventsRpcError,
   EventsSubmitForReviewRpcError,
   EventsUpdateListingRpcError,
   EventsUpdateRpcError,
@@ -55,7 +55,7 @@ export const EventsWritableRegistrationMode = literalUnion(
 
 export const EventsCanOrganize = asRpcQuery(
   Rpc.make('events.canOrganize', {
-    error: EventsRpcError,
+    error: EventsOrganizeRpcError,
     payload: Schema.Struct({
       eventId: Schema.NonEmptyString,
     }),
@@ -396,7 +396,7 @@ export const EventsGetOrganizeOverviewOption = Schema.Struct({
 
 export const EventsGetOrganizeOverview = asRpcQuery(
   Rpc.make('events.getOrganizeOverview', {
-    error: EventsRpcError,
+    error: EventsOrganizeRpcError,
     payload: Schema.Struct({
       eventId: Schema.NonEmptyString,
     }),

--- a/tests/docs/roles/roles.doc.ts
+++ b/tests/docs/roles/roles.doc.ts
@@ -30,6 +30,7 @@ test('Manage tenant roles and review users @admin', async ({
 For this guide, we assume you have an admin account with all required permissions. These are:
 - **admin:manageRoles**: This permission is required to create and manage roles.
 - **users:viewAll**: This permission is required to review the tenant user list.
+- **users:assignRoles**: This full tenant-administrator permission can assign any existing tenant role to any tenant user, including yourself.
 {% /callout %}
 Roles are the way to manage permissions in the app.
 You can create roles with different permissions.
@@ -72,7 +73,7 @@ Start by navigating to **Admin tools**. The current relaunch admin surface separ
       body: `
 ## User review
 
-The **All users** page supports searching tenant users by name or email and, for administrators with **users:assignRoles**, exposes tenant-scoped role assignment controls for existing users. Users without that permission still see read-only role chips.
+The **All users** page supports searching tenant users by name or email and, for administrators with **users:assignRoles**, exposes tenant-scoped role assignment controls for existing users. Users without that permission still see read-only role chips. Because the capability allows assigning any existing tenant role, including to yourself, it is full tenant-administrator authority rather than limited delegation.
 
 Navigate to the **User roles** page to create or edit tenant roles.
 `,
@@ -104,6 +105,8 @@ There are some flags you can set:
 You can also add permissions to the role. The permissions are grouped by category. Learn more at [about permissions](/docs/about-permissions).
 
 Permissions that are required by another permission are automatically included and shown as non-editable dependent permissions with the same admin-facing labels used in the permission reference.
+
+Selecting **Assign all user roles (tenant admin)** displays an explicit warning: this capability can assign any existing tenant role to any tenant user, including the current administrator, and can therefore acquire every tenant capability present in those roles.
 `,
     });
     const roleForm = page.locator('app-role-form');
@@ -121,6 +124,15 @@ Permissions that are required by another permission are automatically included a
     await expect(roleFormCheckbox(/^Create events$/)).toBeChecked();
     await expect(roleForm.getByText('Includes: View templates')).toBeVisible();
     await expect(roleFormCheckbox(/^View templates$/)).toBeChecked();
+    const fullTenantAdminPermission = roleFormCheckbox(
+      /^Assign all user roles \(tenant admin\)$/,
+    );
+    await fullTenantAdminPermission.setChecked(true);
+    await expect(
+      roleForm.getByText('Full tenant-administrator authority.'),
+    ).toBeVisible();
+    await expect(roleForm.getByText(/including to themselves/)).toBeVisible();
+    await fullTenantAdminPermission.setChecked(false);
     await takeScreenshot(
       testInfo,
       roleForm,
@@ -148,7 +160,7 @@ Permissions that are required by another permission are automatically included a
       body: `
 After you have saved your newly configured role, you will be redirected to the role details page.
 The role can now be used by flows that reference tenant roles, such as event and template eligibility.
-Assigning roles to existing users happens from the **All users** page and is guarded by **users:assignRoles**. Role changes apply only inside the current tenant.
+Assigning roles to existing users happens from the **All users** page and is guarded by **users:assignRoles**. This capability is full tenant-administrator authority: it may assign any existing tenant role, including to the current user. Role changes apply only inside the current tenant.
 `,
     });
   } finally {

--- a/tools/audit-tenant-role-global-permissions.sql
+++ b/tools/audit-tenant-role-global-permissions.sql
@@ -1,0 +1,32 @@
+-- Manual security audit for platform-global permissions stored in tenant roles.
+--
+-- The SELECT is safe to run read-only. The cleanup block remains commented out
+-- intentionally: inspect every returned role and coordinate the change with the
+-- environment owner before removing poisoned values. Application startup and
+-- deployment must never execute this file automatically.
+
+SELECT
+  r.id,
+  r."tenantId",
+  r.name,
+  p.permission
+FROM roles AS r
+CROSS JOIN LATERAL jsonb_array_elements_text(r.permissions) AS p(permission)
+WHERE p.permission IN ('globalAdmin:*', 'globalAdmin:manageTenants')
+ORDER BY r."tenantId", r.name, p.permission;
+
+-- Manual cleanup after the audit result has been reviewed:
+--
+-- BEGIN;
+--
+-- UPDATE roles
+-- SET permissions =
+--   permissions - 'globalAdmin:*' - 'globalAdmin:manageTenants'
+-- WHERE permissions ?| ARRAY[
+--   'globalAdmin:*',
+--   'globalAdmin:manageTenants'
+-- ]
+-- RETURNING id, "tenantId", name, permissions;
+--
+-- Re-run the read-only SELECT above and commit only when it returns no rows.
+-- COMMIT;


### PR DESCRIPTION
## Summary

- fix DSC-001 by sharing one organizer-authority predicate and denying organizer overview access before attendee data is queried
- fix DSC-006 by separating tenant-role permissions from effective platform permissions and filtering poisoned role literals at context resolution
- document DSC-016 as intentional full tenant-administrator authority for `users:assignRoles`, including UI and generated-doc warnings

## Stack

Slice 1 of 4. This PR targets `main`; the trusted URL and media slice is stacked immediately above it.

## Schema and rollout

- tenant roles now persist `TenantRolePermission`; genuine platform principals still use the broader effective permission schema
- `tools/audit-tenant-role-global-permissions.sql` is audit-only and does not mutate deployed data
- existing poisoned tenant roles are neutralized at runtime and logged with structured security warnings

## Verification

The assembled stack passed formatting, lint, app/spec type checks, 426 server tests, 347 Angular tests, and `bun run build:app`. This slice adds focused organizer denial, role-contract, context filtering, and intentional full-admin assignment coverage.

Local review commands:

```sh
bun run lint
bun run test:unit:server
bun run test:unit
bun run build:app
```

Browser/E2E runtime verification remains environment-gated because the local Docker preflight lacks `NEON_API_KEY`, `CLIENT_SECRET`, and `STRIPE_API_KEY`.

- `main` <!-- branch-stack -->
  - **fix(security): harden tenant permission boundaries** :point\_left:
    - \#88
      - \#89
        - \#90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clear warning that granting “Assign all user roles” provides full tenant-administrator authority, including self-assignment.
  - Added organizer authorization checks for event organization overviews and related actions.
- **Bug Fixes**
  - Prevented platform-wide permissions from being granted through tenant roles.
  - Role management responses now show only valid tenant-scoped permissions.
- **Documentation**
  - Clarified tenant administrator capabilities and confirmed that tenant roles cannot grant platform-global access.
- **Tests**
  - Expanded coverage for permission validation, role assignment, and organizer access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
