### PR TITLE
test: await event review completion

### DIFF
--- a/.changeset/stabilize-event-review-docs.md
+++ b/.changeset/stabilize-event-review-docs.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+# Stabilize event review documentation coverage
+
+Wait for event review mutations to complete before checking the persisted event
+status, preventing transient queue rerenders from racing the documentation test.

--- a/tests/docs/events/event-approval.doc.ts
+++ b/tests/docs/events/event-approval.doc.ts
@@ -398,6 +398,12 @@ The **Open Event** link is available for context, but this account has no **Orga
   await clickHydratedAction(
     returnToDraftDialog.getByRole('button', { name: 'Return to Draft' }),
   );
+  await expect(
+    reviewerPage.page.getByText(
+      `Event "${eventTitle}" was returned to draft with review feedback`,
+      { exact: true },
+    ),
+  ).toBeVisible();
   await expect(reviewQueueItem).toHaveCount(0);
   const returnedEvent = await readGeneratedEvent();
   expect(returnedEvent.status).toBe('DRAFT');
@@ -459,6 +465,11 @@ This gives creators clear guidance before they re-submit.
   await clickHydratedAction(
     reviewQueueItem.getByRole('button', { name: 'Approve' }),
   );
+  await expect(
+    reviewerPage.page.getByText(`Event "${eventTitle}" has been approved`, {
+      exact: true,
+    }),
+  ).toBeVisible();
   await expect(reviewQueueItem).toHaveCount(0);
 
   await page.reload();


### PR DESCRIPTION
## Purpose

Wait for the review mutation success notification before asserting queue removal and persisted status. This removes the CI timing race that appeared after the production-readiness merge.

## Scope

- Stabilize return-to-draft verification
- Stabilize approval verification
- No runtime, schema, or UI changes

## Local verification

- 1,406 server unit tests
- 799 application unit tests
- 55 PostgreSQL integration tests
- 150 baseline Playwright tests
- 52 documentation Playwright tests
- 11 provider integration Playwright tests
- 27 ESNcard provider-error unit tests
- 9 live ESNcard release-certification tests
- Build, Terraform/static scan, and Linux/amd64 image security/size gates

* `main` <!-- branch-stack -->
  - **test: await event review completion** :point\_left:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded event approval workflow coverage to verify confirmation messages when an event is returned to draft and when it is approved.
  - Confirmations now include the relevant event title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
