### PR TITLE
test: await profile form initialization

### DIFF
--- a/.changeset/stabilize-profile-edit-e2e.md
+++ b/.changeset/stabilize-profile-edit-e2e.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+# Stabilize profile edit browser coverage
+
+Wait for the profile form to finish initializing and commit each edited field
+before checking the persisted reimbursement details.

--- a/tests/specs/profile/user-profile-edit.spec.ts
+++ b/tests/specs/profile/user-profile-edit.spec.ts
@@ -12,6 +12,7 @@ test.use({ storageState: userStateFile });
 const fillControlledTextField = async (field: Locator, value: string) => {
   await expect(field).not.toHaveClass(/mat-input-server/);
   await field.fill(value);
+  await field.blur();
   await expect(field).toHaveValue(value);
 };
 
@@ -72,6 +73,18 @@ test('profile edit persists notification email and reimbursement details', async
       exact: true,
       name: 'Save',
     });
+    const editForm = editDialog.locator('form');
+
+    // The dialog is created after page hydration. Wait for its Signal Form to
+    // expose the seeded model before sending input events to its controls.
+    await expect(editForm).not.toHaveAttribute('jsaction', /submit/);
+    await expect(firstNameInput).toHaveValue(originalUser.firstName);
+    await expect(notificationEmailInput).toHaveValue(
+      originalUser.communicationEmail ?? originalUser.email,
+    );
+    await expect(ibanInput).toHaveValue(originalUser.iban ?? '');
+    await expect(paypalEmailInput).toHaveValue(originalUser.paypalEmail ?? '');
+    await expect(saveButton).toBeEnabled();
 
     await fillControlledTextField(firstNameInput, '');
     await expect(saveButton).toBeDisabled();
@@ -85,10 +98,6 @@ test('profile edit persists notification email and reimbursement details', async
     await expect(notificationEmailInput).toHaveValue(notificationEmail);
     await expect(ibanInput).toHaveValue(` ${iban} `);
     await expect(paypalEmailInput).toHaveValue(` ${paypalEmail} `);
-    await expect(editDialog.locator('form')).not.toHaveAttribute(
-      'jsaction',
-      /submit/,
-    );
     await expect(saveButton).toBeEnabled();
     await saveButton.click();
 


### PR DESCRIPTION
## Purpose

Stabilize the profile-edit browser test after CI exposed an initialization race in the client-created Signal Form.

## Scope

- wait for the edit form to expose its seeded model before entering values
- blur each controlled field so the edit is committed before persistence assertions
- add release metadata for the test hardening

## Schema and runtime impact

None. Test-only change.

## Local verification

- format check and lint
- server unit: 1,406/1,406
- app unit: 799/799
- PostgreSQL integration: 55/55
- application build
- Terraform validation and static scan
- Linux/amd64 image security and size gate
- Playwright baseline: 150/150
- Playwright docs: 52/52
- provider integration: 11/11
- live ESNcard certification: 27/27 unit and 9/9 browser

Every collected test passed locally with zero skips, retries, flakes, focused tests, or other incomplete outcomes.

- `main` <!-- branch-stack -->
  - **test: await profile form initialization** :point\_left:
