### PR TITLE
fix: use Scaleway private database IP

### DIFF
--- a/.changeset/fix-scaleway-private-database-output.md
+++ b/.changeset/fix-scaleway-private-database-output.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+# Fix Scaleway private database deployment output
+
+Use the private database endpoint IP when constructing role-scoped database
+secrets because Scaleway private RDB endpoints do not provide a hostname.

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -63,6 +63,9 @@ describe('Scaleway hosting source', () => {
     const database = source(
       'infrastructure/scaleway/modules/environment/database.tf',
     );
+    const outputs = source(
+      'infrastructure/scaleway/modules/environment/outputs.tf',
+    );
     const moduleVariables = source(
       'infrastructure/scaleway/modules/environment/variables.tf',
     );
@@ -75,6 +78,12 @@ describe('Scaleway hosting source', () => {
     expect(database).toContain('backup_schedule_frequency = 24');
     expect(database).toContain('private_network {');
     expect(database).not.toContain('load_balancer');
+    expect(outputs).toContain(
+      'host          = scaleway_rdb_instance.application.private_network[0].ip',
+    );
+    expect(outputs).not.toContain(
+      'scaleway_rdb_instance.application.private_network[0].hostname',
+    );
     expect(database).toContain('user_name           = "schema_owner"');
     expect(database).toContain('name                = "application_runtime"');
     expect(database).toContain('is_admin            = false');

--- a/infrastructure/scaleway/modules/environment/outputs.tf
+++ b/infrastructure/scaleway/modules/environment/outputs.tf
@@ -14,7 +14,7 @@ output "database" {
   value = {
     certificate   = scaleway_rdb_instance.application.certificate
     database_name = scaleway_rdb_database.application.name
-    host          = scaleway_rdb_instance.application.private_network[0].hostname
+    host          = scaleway_rdb_instance.application.private_network[0].ip
     port          = scaleway_rdb_instance.application.private_network[0].port
     runtime_user  = scaleway_rdb_user.runtime.name
     schema_user   = scaleway_rdb_instance.application.user_name


### PR DESCRIPTION
## Purpose

Unblock the first full Scaleway staging deployment. Secret reconciliation failed because the private RDB endpoint exposes an IP while the Terraform output selected an empty hostname.

## Scope

- construct the role-scoped database endpoint from the private-network IP and port
- assert the output cannot regress to the unavailable hostname attribute
- add a patch release note

## Schema and runtime impact

No schema or application-runtime behavior changes. This changes only the infrastructure output consumed while synchronizing deployment secrets.

## Local verification

- format, lint, release validation, app build
- server unit: 1,406/1,406
- app unit: 799/799
- PostgreSQL 17 integration: 55/55
- Terraform validation and Trivy IaC scan: green, 0 misconfigurations
- Linux/amd64 image security and size gate: green, 0 vulnerabilities, 152,122,980 bytes
- Playwright baseline: 150/150
- Playwright docs: 52/52
- protected provider suite: 11/11
- live ESNcard provider error tests: 27/27
- live ESNcard browser certification: 9/9

All accepted runs completed with zero skips, retries, flakes, todos, fixmes, focused tests, or expected failures.

- `main` <!-- branch-stack -->
  - **fix: use Scaleway private database IP** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed private Scaleway database deployments to use the database’s private IP address when generating connection details.
  * Prevented unavailable private database hostnames from being exposed in deployment outputs.

* **Tests**
  * Added validation confirming private database outputs include the expected IP address and omit hostname values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->