### PR TITLE
fix: normalize Scaleway Secret Manager IDs

### DIFF
--- a/.changeset/normalize-scaleway-secret-ids.md
+++ b/.changeset/normalize-scaleway-secret-ids.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+# Normalize Scaleway Secret Manager IDs for deployment
+
+Expose bare Secret Manager UUIDs to the deployment scripts because the
+Scaleway CLI accepts the region separately from each secret identifier.

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -330,6 +330,9 @@ describe('Scaleway hosting source', () => {
     const containers = source(
       'infrastructure/scaleway/modules/environment/containers.tf',
     );
+    const outputs = source(
+      'infrastructure/scaleway/modules/environment/outputs.tf',
+    );
 
     for (const requiredName of [
       'CLIENT_SECRET',
@@ -353,6 +356,8 @@ describe('Scaleway hosting source', () => {
     ).toHaveLength(3);
     expect(containers.match(/ignore_changes = \[/gu)).toHaveLength(3);
     expect(containers).not.toMatch(/^\s+SCW_[A-Z0-9_]+\s+=/gmu);
+    expect(outputs).toContain('key => trimprefix(secret.id, "${var.region}/")');
+    expect(outputs).not.toContain('key => secret.id');
   });
 
   it('uses native container telemetry, custom traces, all provider alerts, and release-aware logs', () => {

--- a/infrastructure/scaleway/modules/environment/outputs.tf
+++ b/infrastructure/scaleway/modules/environment/outputs.tf
@@ -53,7 +53,7 @@ output "role_application_ids" {
 
 output "role_secret_ids" {
   value = {
-    for key, secret in scaleway_secret.role : key => secret.id
+    for key, secret in scaleway_secret.role : key => trimprefix(secret.id, "${var.region}/")
   }
 }
 


### PR DESCRIPTION
## Purpose

Unblock the Scaleway staging deployment after Terraform returned region-qualified Secret Manager resource IDs that the Scaleway CLI could not resolve.

## Scope

- strip the configured region prefix from the role\_secret\_ids Terraform output
- keep region selection in the existing CLI configuration
- add source-level regression coverage for the output contract
- add patch release metadata

## Schema and runtime impact

No database schema or application runtime behavior changes. Deployment secret synchronization and role injection now receive bare Secret Manager UUIDs.

## Local verification

- release metadata, format, lint, and application build
- server unit: 1406/1406
- app unit: 799/799
- PostgreSQL integration: 55/55
- Terraform validation and scan: 0 findings
- Linux/amd64 image: 152122982 bytes, 0 vulnerabilities
- Playwright baseline: 150/150
- Playwright docs: 52/52
- protected provider suite: 11/11
- ESNcard unit: 27/27
- live ESNcard browser certification: 9/9

Every collected test passed with zero skips, todos, fixmes, retries, flakes, interruptions, or focused tests.

- `main` <!-- branch-stack -->
  - **fix: normalize Scaleway Secret Manager IDs** :point\_left:
