### PR TITLE
fix: normalize Scaleway container IDs

### DIFF
--- a/.changeset/normalize-scaleway-container-ids.md
+++ b/.changeset/normalize-scaleway-container-ids.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Normalize Scaleway container IDs for deployment updates
+
+Strip Terraform's regional resource prefix before passing a container UUID to
+the Scaleway CLI, and report which deployment boundary fails without exposing
+protected values.

--- a/helpers/testing/scaleway-deploy-role.spec.ts
+++ b/helpers/testing/scaleway-deploy-role.spec.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const deployRoleScript = path.join(
+  process.cwd(),
+  'ops/scaleway/deploy-role.sh',
+);
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+const runDeployRole = (containerResourceId: string): string[] => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'evorto-scaleway-deploy-role-'),
+  );
+  temporaryDirectories.push(directory);
+
+  const platformPath = path.join(directory, 'platform.json');
+  const fakeCliPath = path.join(directory, 'scw');
+  const commandLogPath = path.join(directory, 'scw.log');
+  const containerId = '11111111-2222-3333-4444-555555555555';
+  const digest = `sha256:${'a'.repeat(64)}`;
+
+  fs.writeFileSync(
+    platformPath,
+    JSON.stringify({
+      containers: {
+        ops: {
+          environment_variables: {
+            APP_ENVIRONMENT: 'staging',
+            APP_ROLE: 'ops',
+          },
+          id: containerResourceId,
+        },
+      },
+      role_secret_ids: {},
+    }),
+  );
+  fs.writeFileSync(
+    fakeCliPath,
+    String.raw`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "${'$'}{FAKE_SCW_LOG:?}"
+`,
+  );
+  fs.chmodSync(fakeCliPath, 0o700);
+
+  execFileSync(
+    deployRoleScript,
+    [
+      platformPath,
+      'ops',
+      `rg.fr-par.scw.cloud/evorto-staging/evorto@${digest}`,
+      'b'.repeat(40),
+      digest,
+      'c'.repeat(64),
+    ],
+    {
+      env: {
+        ...process.env,
+        FAKE_SCW_LOG: commandLogPath,
+        SCW_CLI: fakeCliPath,
+        SCW_DEFAULT_REGION: 'fr-par',
+      },
+      stdio: 'pipe',
+    },
+  );
+
+  const arguments_ = fs
+    .readFileSync(commandLogPath, 'utf8')
+    .trimEnd()
+    .split('\n');
+  expect(arguments_).toContain(containerId);
+  expect(arguments_).toContain('region=fr-par');
+  return arguments_;
+};
+
+describe('Scaleway role deployment', () => {
+  const containerId = '11111111-2222-3333-4444-555555555555';
+
+  it.each([containerId, `fr-par/${containerId}`])(
+    'passes a bare container UUID to the Scaleway CLI for %s',
+    (containerResourceId) => {
+      const arguments_ = runDeployRole(containerResourceId);
+
+      expect(arguments_).not.toContain(`fr-par/${containerId}`);
+    },
+  );
+});

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -412,6 +412,11 @@ describe('Scaleway hosting source', () => {
       'Roll back production traffic roles on failure',
     );
     expect(deployRole).toContain('APP_BOOTSTRAP: "false"');
+    expect(deployRole).toContain(
+      'container_id="${container_resource_id#"${region}/"}"',
+    );
+    expect(deployRole).toContain('region="${region}"');
+    expect(deployRole).toContain('Failed to update the ${role} container');
   });
 
   it('gates ordinary CI and destructive staging reset separately', () => {

--- a/ops/scaleway/deploy-role.sh
+++ b/ops/scaleway/deploy-role.sh
@@ -9,6 +9,7 @@ readonly revision="${4:?Pass the full Git revision}"
 readonly image_digest="${5:?Pass the sha256 image digest}"
 readonly schema_hash="${6:?Pass the packaged schema sha256}"
 readonly scw_cli="${SCW_CLI:-scw}"
+readonly region="${SCW_DEFAULT_REGION:-fr-par}"
 
 if [[ "${role}" != 'web' && "${role}" != 'worker' && "${role}" != 'ops' ]]; then
   echo "Unsupported application role: ${role}" >&2
@@ -27,12 +28,17 @@ if [[ ! "${schema_hash}" =~ ^[0-9a-f]{64}$ ]]; then
   exit 1
 fi
 
-container_id="$(
+container_resource_id="$(
   jq --exit-status --raw-output \
     --arg role "${role}" \
     '.containers[$role].id' \
     "${platform_output_file}"
 )"
+container_id="${container_resource_id#"${region}/"}"
+if [[ ! "${container_id}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+  echo "Terraform returned an unexpected ${role} container ID" >&2
+  exit 1
+fi
 
 temporary_directory="$(mktemp -d)"
 trap 'rm -rf "${temporary_directory}"' EXIT
@@ -77,11 +83,14 @@ mask_value() {
 while IFS=$'\t' read -r contract_key secret_id; do
   secret_name="${contract_key#*/}"
   value_file="${temporary_directory}/${secret_name}"
-  "${scw_cli}" secret version access \
+  if ! "${scw_cli}" secret version access \
     "${secret_id}" \
     revision=latest \
     raw=true \
-    >"${value_file}"
+    >"${value_file}"; then
+    echo "Failed to access Secret Manager value for ${contract_key}" >&2
+    exit 1
+  fi
   if [[ ! -s "${value_file}" ]]; then
     echo "Secret Manager returned an empty value for ${contract_key}" >&2
     exit 1
@@ -100,10 +109,13 @@ done < <(
     "${platform_output_file}"
 )
 
-"${scw_cli}" container container update \
+if ! "${scw_cli}" container container update \
   "${update_arguments[@]}" \
-  region=fr-par \
+  region="${region}" \
   --wait \
-  >/dev/null
+  >/dev/null; then
+  echo "Failed to update the ${role} container" >&2
+  exit 1
+fi
 
 echo "Deployed ${role} at ${revision} (${image_digest})"


### PR DESCRIPTION
## Purpose

Unblock staging deployment after Terraform returned regional Scaleway Serverless Container resource IDs that the CLI update command rejected as Not Found.

## Scope

- strip the configured region prefix before passing container IDs to the Scaleway CLI
- pass the configured region explicitly
- add non-secret diagnostics for Secret Manager access and container update failures
- exercise the real deployment script with both bare and region-qualified IDs

## Schema and runtime impact

No schema change. Runtime application behavior is unchanged. This only changes the deployment boundary used to update the web, worker, and ops containers.

## Local verification

- format, lint, release metadata, unit, build, Terraform validation/static scan, PostgreSQL integration, and Linux/amd64 image security/size gates: passed
- server unit: 1408/1408
- app unit: 799/799
- PostgreSQL integration: 55/55
- Playwright baseline: 150/150
- Playwright docs: 52/52
- provider integration: 11/11
- live ESNcard release: 27/27 unit and 9/9 browser
- focused Scaleway deployment regression: 14/14

All collected tests passed with zero skips, retries, flakes, todos, fixmes, expected failures, focused tests, or interruptions.

- `main` <!-- branch-stack -->
  - **fix: normalize Scaleway container IDs** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Scaleway deployment updates by correctly handling region-prefixed container IDs.
  - Deployments now use the configured Scaleway region instead of a fixed default.
  - Added validation to prevent updates with invalid container IDs.
  - Secret retrieval and container update failures now stop deployment with clear error messages.

- **Tests**
  - Added coverage for regional and non-regional container IDs and deployment failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->