### PR TITLE
test: wait for template edit hydration

### DIFF
--- a/.changeset/wait-template-edit-hydration.md
+++ b/.changeset/wait-template-edit-hydration.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+# Wait for template edit hydration in documentation coverage
+
+Prevent the server-rendered template edit form from restoring stale controlled
+field values after Playwright starts editing it.

--- a/tests/docs/templates/templates.doc.ts
+++ b/tests/docs/templates/templates.doc.ts
@@ -679,14 +679,23 @@ The event now has its own copy of the registration setup. Editing the template c
 `,
   });
   await page.goto(`/templates/${createdTemplate.id}/edit`);
+  const editTemplateForm = page.locator('app-template-edit form');
+  // SSR exposes the controlled fields before Angular attaches the live submit
+  // listener. Wait for event replay to hand the form to the hydrated app so a
+  // subsequent model initialization cannot restore the server-rendered values.
+  await expect(editTemplateForm).not.toHaveAttribute('jsaction', /submit/, {
+    timeout: 20_000,
+  });
   const participantOptionEditor = await templateOptionEditorByTitle(
     page,
     'Participant registration',
   );
   const updatedParticipantTitle = 'Participant registration updated';
-  await participantOptionEditor
-    .getByLabel('Registration option name')
-    .fill(updatedParticipantTitle);
+  const participantTitleInput = participantOptionEditor.getByLabel(
+    'Registration option name',
+  );
+  await participantTitleInput.fill(updatedParticipantTitle);
+  await expect(participantTitleInput).toHaveValue(updatedParticipantTitle);
   await page
     .locator('app-template-addon-editor')
     .filter({ hasText: addOnTitle })


### PR DESCRIPTION
## Purpose\n\nFix the exact-main protected E2E failure where Angular hydration could restore the server-rendered template option title after Playwright had already edited it.\n\n## Scope\n\n- wait for the template edit form to finish hydration before changing controlled fields\n- assert the edited title remains in the input before saving\n- add a patch release note\n\n## Runtime and schema impact\n\nNone. This changes documentation coverage only.\n\n## Local verification\n\n- format and lint: pass\n- server unit: 1,408/1,408\n- app unit: 799/799\n- PostgreSQL integration: 55/55\n- Playwright baseline: 150/150\n- Playwright docs: 52/52\n- provider integration: 11/11\n- live ESNcard component: 27/27\n- live-provider browser: 9/9\n- build, Terraform validation/static scan, release metadata, and image security/size/SBOM checks: pass\n- zero skips, retries, flakes, todos, fixmes, or focused tests\n

- `main` <!-- branch-stack -->
  - **test: wait for template edit hydration** :point\_left:
