### PR TITLE
fix: verify managed schema database TLS

### DIFF
--- a/.changeset/verify-drizzle-managed-postgres-tls.md
+++ b/.changeset/verify-drizzle-managed-postgres-tls.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+# Verify managed PostgreSQL TLS during schema deployment
+
+Configure the packaged Drizzle schema tool with Scaleway's managed database CA
+instead of opening an unverified URL-only connection.

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
@@ -129,6 +129,61 @@ describe('Scaleway hosting source', () => {
     expect(main).toMatch(/database_is_ha\s+= true/u);
     expect(main).toMatch(/database_backup_retention_days\s+= 30/u);
     expect(main).toContain('"IPAMReadOnly"');
+  });
+
+  it('verifies managed Drizzle schema connections against the database CA', async () => {
+    const environmentKeys = [
+      'DATABASE_TLS_CA_CERTIFICATE',
+      'DATABASE_TLS_REQUIRED',
+      'DATABASE_URL',
+    ] as const;
+    const originalEnvironment = Object.fromEntries(
+      environmentKeys.map((key) => [key, process.env[key]]),
+    );
+    const caCertificate = [
+      '-----BEGIN CERTIFICATE-----',
+      'managed-database-ca',
+      '-----END CERTIFICATE-----',
+    ].join('\n');
+
+    try {
+      process.env['DATABASE_TLS_CA_CERTIFICATE'] = caCertificate;
+      process.env['DATABASE_TLS_REQUIRED'] = 'true';
+      process.env['DATABASE_URL'] =
+        'postgresql://schema_owner:p%40ss%2Fword@10.0.0.8:6432/evorto%20staging';
+      const configUrl = pathToFileURL(
+        path.join(repositoryRoot, 'ops/drizzle.config.mjs'),
+      );
+      configUrl.searchParams.set('test', 'managed-database-tls');
+      const importedConfig: unknown = await import(
+        /* @vite-ignore */ configUrl.href
+      );
+
+      expect(importedConfig).toMatchObject({
+        default: {
+          dbCredentials: {
+            database: 'evorto staging',
+            host: '10.0.0.8',
+            password: 'p@ss/word',
+            port: 6432,
+            ssl: {
+              ca: caCertificate,
+              rejectUnauthorized: true,
+            },
+            user: 'schema_owner',
+          },
+          dialect: 'postgresql',
+        },
+      });
+    } finally {
+      for (const [key, value] of Object.entries(originalEnvironment)) {
+        if (value === undefined) {
+          Reflect.deleteProperty(process.env, key);
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
   });
 
   it('keeps web, worker, and ops isolated in one bounded container shape', () => {

--- a/ops/drizzle.config.mjs
+++ b/ops/drizzle.config.mjs
@@ -4,10 +4,47 @@ if (!databaseUrl) {
   throw new Error("DATABASE_URL must be configured for schema operations");
 }
 
+const tlsRequired = process.env.DATABASE_TLS_REQUIRED === "true";
+const caCertificate = process.env.DATABASE_TLS_CA_CERTIFICATE;
+
+if (tlsRequired && !caCertificate) {
+  throw new Error(
+    "DATABASE_TLS_CA_CERTIFICATE is required for managed schema operations",
+  );
+}
+
+const managedDatabaseCredentials = () => {
+  const parsedUrl = new URL(databaseUrl);
+  if (
+    parsedUrl.protocol !== "postgresql:" &&
+    parsedUrl.protocol !== "postgres:"
+  ) {
+    throw new Error("DATABASE_URL must use the PostgreSQL protocol");
+  }
+
+  const database = decodeURIComponent(parsedUrl.pathname.replace(/^\/+/, ""));
+  const user = decodeURIComponent(parsedUrl.username);
+  const password = decodeURIComponent(parsedUrl.password);
+  if (!parsedUrl.hostname || !database || !user || !password) {
+    throw new Error(
+      "DATABASE_URL must include host, database, user, and password for managed schema operations",
+    );
+  }
+
+  return {
+    database,
+    host: parsedUrl.hostname,
+    password,
+    port: parsedUrl.port ? Number(parsedUrl.port) : 5432,
+    ssl: { ca: caCertificate, rejectUnauthorized: true },
+    user,
+  };
+};
+
 export default {
-  dbCredentials: {
-    url: databaseUrl,
-  },
+  dbCredentials: tlsRequired
+    ? managedDatabaseCredentials()
+    : { url: databaseUrl },
   dialect: "postgresql",
   schema: "./dist/evorto/ops/schema.mjs",
 };


### PR DESCRIPTION
## Purpose

Fix the staging deployment failure in the private ops role by making packaged Drizzle schema operations use the managed PostgreSQL CA certificate.

## Scope

- parse the schema DATABASE\_URL into explicit Drizzle PostgreSQL credentials when TLS is required
- require and pass DATABASE\_TLS\_CA\_CERTIFICATE with rejectUnauthorized enabled
- retain URL-based local PostgreSQL behavior
- add executable regression coverage for encoded credentials and CA verification

## Schema and runtime impact

No schema change. This changes only the ops schema connection configuration used by deployment-time explain/apply operations.

## Verification

The complete local release gate passed on the default registered Auth0 port: format, lint, 1,409 server tests, 799 app tests, 55 PostgreSQL integration tests, production build, Terraform validation/static scan, Linux/amd64 image size/SBOM/vulnerability checks, 150 functional Playwright tests, 52 docs tests, 11 Auth0/Google Maps tests, 27 provider-error component tests, and 9 live ESNcard tests. All collected tests passed with zero skips, retries, flakes, todos, fixmes, expected failures, interruptions, or focused tests.

- `main` <!-- branch-stack -->
  - **fix: verify managed schema database TLS** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for secure TLS connections to managed PostgreSQL databases during schema deployments.
  * Validates PostgreSQL connection details and requires a trusted CA certificate when TLS is enabled.
  * Preserves existing connection behavior when managed database TLS is not required.

* **Bug Fixes**
  * Prevents managed PostgreSQL deployments from using unverified URL-only connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->