### PR TITLE
fix: diagnose silent schema failures

### DIFF
--- a/.changeset/diagnose-silent-drizzle-failures.md
+++ b/.changeset/diagnose-silent-drizzle-failures.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Diagnose silent Drizzle schema failures
+
+Retry failed, empty Drizzle JSON responses with a non-mutating text-mode
+explain command so staging deployment logs retain a redacted database failure
+category without exposing provider output.

--- a/src/server/ops/schema-operations.spec.ts
+++ b/src/server/ops/schema-operations.spec.ts
@@ -64,6 +64,58 @@ describe('ops schema operations', () => {
     }),
   );
 
+  it.effect(
+    'uses a non-mutating text diagnostic when Drizzle JSON failures are silent',
+    () =>
+      Effect.gen(function* () {
+        const commands: string[][] = [];
+        const runner: OpsCommandRunner = {
+          run: (command) => {
+            commands.push([...command]);
+            return Effect.succeed(
+              commands.length === 1
+                ? { exitCode: 1, stderr: '', stdout: '' }
+                : {
+                    exitCode: 1,
+                    stderr: '',
+                    stdout:
+                      'connect EHOSTUNREACH 10.0.0.8:6432 sensitive-marker',
+                  },
+            );
+          },
+        };
+
+        const error = yield* explainSchema(runner).pipe(Effect.flip);
+
+        expect(error.message).toBe(
+          'Drizzle failed (database-unreachable; exit 1)',
+        );
+        expect(error.message).not.toContain('sensitive-marker');
+        expect(commands).toEqual([
+          [
+            'bun',
+            'ops/drizzle-kit.cjs',
+            'push',
+            '--config',
+            'ops/drizzle.config.mjs',
+            '--explain',
+            '--output',
+            'json',
+          ],
+          [
+            'bun',
+            'ops/drizzle-kit.cjs',
+            'push',
+            '--config',
+            'ops/drizzle.config.mjs',
+            '--explain',
+            '--output',
+            'text',
+          ],
+        ]);
+      }),
+  );
+
   it('accepts expand-only plans', () => {
     const analysis = analyzeSchemaPlan({
       dialect: 'postgresql',
@@ -181,6 +233,55 @@ describe('ops schema operations', () => {
           'dist/evorto/ops/database-prerequisites.mjs',
         ]);
       }),
+  );
+
+  it.effect('never reapplies a failed schema command while diagnosing it', () =>
+    Effect.gen(function* () {
+      const plan = {
+        dialect: 'postgresql',
+        hints: [],
+        statements: [],
+        status: 'ok',
+      };
+      const commands: string[][] = [];
+      const runner: OpsCommandRunner = {
+        run: (command) => {
+          commands.push([...command]);
+          if (commands.length === 1) return Effect.succeed(result(plan));
+          if (commands.length === 2) {
+            return Effect.succeed({ exitCode: 0, stderr: '', stdout: '' });
+          }
+          if (commands.length === 3) {
+            return Effect.succeed({ exitCode: 1, stderr: '', stdout: '' });
+          }
+          return Effect.succeed({
+            exitCode: 1,
+            stderr: 'permission denied for schema public',
+            stdout: '',
+          });
+        },
+      };
+
+      const error = yield* applySchema(
+        analyzeSchemaPlan(plan).digest,
+        runner,
+      ).pipe(Effect.flip);
+
+      expect(error.message).toBe(
+        'Drizzle failed (database-permission-denied; exit 1)',
+      );
+      expect(commands[3]).toEqual([
+        'bun',
+        'ops/drizzle-kit.cjs',
+        'push',
+        '--config',
+        'ops/drizzle.config.mjs',
+        '--output',
+        'text',
+        '--explain',
+      ]);
+      expect(commands[3]).not.toContain('--force');
+    }),
   );
 
   it.effect(

--- a/src/server/ops/schema-operations.ts
+++ b/src/server/ops/schema-operations.ts
@@ -446,10 +446,48 @@ const applyCommand = [
   'json',
 ] as const;
 
+const hasCommandOutput = (result: OpsCommandResult): boolean =>
+  result.stderr.length > 0 || result.stdout.length > 0;
+
+const asSafeTextDiagnosticCommand = (
+  command: readonly string[],
+): readonly string[] => {
+  const diagnosticCommand = command.filter(
+    (argument) => argument !== '--force',
+  );
+  const outputIndex = diagnosticCommand.indexOf('--output');
+  if (outputIndex !== -1 && diagnosticCommand[outputIndex + 1] === 'json') {
+    diagnosticCommand[outputIndex + 1] = 'text';
+  }
+  if (!diagnosticCommand.includes('--explain')) {
+    diagnosticCommand.push('--explain');
+  }
+  return diagnosticCommand;
+};
+
+const runDrizzleCommand = Effect.fn('runDrizzleCommand')(function* (
+  runner: OpsCommandRunner,
+  command: readonly string[],
+) {
+  const result = yield* runner.run(command);
+  if (result.exitCode === 0 || hasCommandOutput(result)) {
+    return result;
+  }
+
+  const diagnosticResult = yield* runner.run(
+    asSafeTextDiagnosticCommand(command),
+  );
+  return {
+    exitCode: result.exitCode,
+    stderr: diagnosticResult.stderr,
+    stdout: diagnosticResult.stdout,
+  };
+});
+
 export const explainSchema = (
   runner: OpsCommandRunner = liveOpsCommandRunner,
 ) =>
-  runner.run(explainCommand).pipe(
+  runDrizzleCommand(runner, explainCommand).pipe(
     Effect.flatMap((result) => parseCommandJson(result)),
     Effect.map((plan) => analyzeSchemaPlan(plan)),
   );
@@ -485,7 +523,7 @@ export const applySchema = (
       return yield* failOpsCommand('Database prerequisites', prerequisites);
     }
 
-    const result = yield* runner.run(applyCommand);
+    const result = yield* runDrizzleCommand(runner, applyCommand);
     const envelope = yield* parseCommandJson(result);
     const status = asRecord(envelope)?.['status'];
     if (status !== 'ok' && status !== 'no_changes') {
@@ -525,7 +563,7 @@ export const seedStaging = (
       prerequisitesResult,
     );
 
-    const applyResult = yield* runner.run(applyCommand);
+    const applyResult = yield* runDrizzleCommand(runner, applyCommand);
     const applyEnvelope = yield* parseCommandJson(applyResult);
     const applyStatus = asRecord(applyEnvelope)?.['status'];
     if (applyStatus !== 'ok' && applyStatus !== 'no_changes') {


### PR DESCRIPTION
## Purpose

Make failed staging schema operations observable when Drizzle Kit exits nonzero but suppresses all output in JSON mode.

## Scope

- retry only silent, failed Drizzle commands with a non-mutating text-mode `--explain`
- strip `--force` before diagnostics so a failed apply is never reapplied
- retain the original nonzero exit status and expose only the existing redacted failure category
- cover silent explain and apply failures, including secret-redaction and no-mutation assertions

## Schema and runtime impact

No schema change. The ops role may perform one additional read-only Drizzle explain after a silent command failure. Web and worker behavior are unchanged.

## Local validation

- release metadata, format, lint, and diff checks
- server unit: 1,419 passed
- app unit: 799 passed
- PostgreSQL integration: 55 passed
- application and ops build
- Terraform validation and static scan: clean
- Linux/amd64 image size, source-map, secret, SBOM, and vulnerability gates: clean
- Playwright baseline: 150 passed
- Playwright docs: 52 passed
- protected provider suite: 11 passed
- live ESNcard component: 27 passed
- live ESNcard browser release certification: 9 passed

All collected tests passed locally with zero skips, retries, flakes, todos, fixmes, focused tests, or expected failures.

- `main` <!-- branch-stack -->
  - **fix: diagnose silent schema failures** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema operation error diagnostics when failures return no useful output.
  * Added safer text-based diagnostic details for failed schema explanations, applications, and staging seeds.
  * Prevented diagnostic retries from reapplying changes or using forceful options.
  * Improved classification of database connectivity and permission errors while avoiding exposure of sensitive provider output.

* **Tests**
  * Added coverage for silent failures, diagnostic fallback behavior, and safe schema application handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->