### PR TITLE
fix: classify managed database TLS failures

### DIFF
--- a/.changeset/classify-database-tls-failures.md
+++ b/.changeset/classify-database-tls-failures.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Classify managed database TLS failures
+
+Distinguish hostname, trust-chain, expired, and not-yet-valid certificate
+failures in bounded ops logs so staging deployment diagnostics identify the
+safe remediation without exposing provider command output.

--- a/src/server/ops/schema-operations.spec.ts
+++ b/src/server/ops/schema-operations.spec.ts
@@ -19,8 +19,28 @@ const result = (value: unknown) => ({
 describe('ops schema operations', () => {
   it.each([
     [
-      'TLS certificate failures',
+      'TLS hostname mismatches',
       'hostname/IP does not match certificate altnames',
+      'database-tls-hostname-mismatch',
+    ],
+    [
+      'expired TLS certificates',
+      'Error: CERT_HAS_EXPIRED',
+      'database-tls-certificate-expired',
+    ],
+    [
+      'not-yet-valid TLS certificates',
+      'Error: CERT_NOT_YET_VALID',
+      'database-tls-certificate-not-yet-valid',
+    ],
+    [
+      'untrusted TLS certificate authorities',
+      'Error: UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+      'database-tls-ca-untrusted',
+    ],
+    [
+      'other TLS verification failures',
+      'TLS handshake failed while validating certificate purpose',
       'database-tls-verification-failed',
     ],
     [

--- a/src/server/ops/schema-operations.ts
+++ b/src/server/ops/schema-operations.ts
@@ -17,6 +17,10 @@ export type OpsCommandFailureKind =
   | 'database-host-resolution-failed'
   | 'database-not-found'
   | 'database-permission-denied'
+  | 'database-tls-ca-untrusted'
+  | 'database-tls-certificate-expired'
+  | 'database-tls-certificate-not-yet-valid'
+  | 'database-tls-hostname-mismatch'
   | 'database-tls-verification-failed'
   | 'database-unreachable'
   | 'drizzle-cli-incompatible'
@@ -81,13 +85,37 @@ const commandFailurePatterns: readonly {
     patterns: [/database .* does not exist/iu],
   },
   {
+    kind: 'database-tls-hostname-mismatch',
+    patterns: [
+      /err_tls_cert_altname_invalid/iu,
+      /hostname\/ip does not match/iu,
+    ],
+  },
+  {
+    kind: 'database-tls-certificate-expired',
+    patterns: [/cert_has_expired/iu, /certificate has expired/iu],
+  },
+  {
+    kind: 'database-tls-certificate-not-yet-valid',
+    patterns: [/cert_not_yet_valid/iu, /certificate is not yet valid/iu],
+  },
+  {
+    kind: 'database-tls-ca-untrusted',
+    patterns: [
+      /depth_zero_self_signed_cert/iu,
+      /self_signed_cert_in_chain/iu,
+      /self[- ]signed/iu,
+      /unable_to_get_issuer_cert/iu,
+      /unable_to_verify_leaf_signature/iu,
+      /unable to get local issuer/iu,
+      /unable to verify/iu,
+    ],
+  },
+  {
     kind: 'database-tls-verification-failed',
     patterns: [
       /certificate/iu,
       /err_tls/iu,
-      /hostname\/ip does not match/iu,
-      /self[- ]signed/iu,
-      /unable to verify/iu,
       /ssl (?:connection|error|handshake|routines)/iu,
       /tls (?:connection|error|handshake)/iu,
     ],


### PR DESCRIPTION
## Purpose

Make failed staging schema operations distinguish hostname mismatch, CA trust, expired certificate, and not-yet-valid certificate failures without logging raw provider output.

## Scope

- classify bounded Drizzle diagnostic output into actionable TLS categories
- retain the broad TLS fallback for unknown certificate failures
- cover every category with focused tests
- add a patch release note

## Runtime and schema impact

Diagnostic logging only. No schema change and no application data mutation.

## Local verification

- release metadata, format, lint, and diff checks
- server/helper tests: 1,423 passed
- app tests: 799 passed
- PostgreSQL integration: 55 passed
- build and Terraform validation/static scan
- Linux/amd64 runtime image: 152,124,579 bytes and zero vulnerability findings
- Playwright baseline: 150 passed
- Playwright docs: 52 passed
- provider integration: 11 passed
- ESNcard component: 27 passed
- live ESNcard release browser suite: 9 passed

Every collected test passed with zero skips, retries, flakes, todos, fixmes, or expected failures.

- `main` <!-- branch-stack -->
  - **fix: classify managed database TLS failures** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed database TLS failure classification in operations logs.
  * TLS issues are now identified more specifically, including hostname mismatches, expired certificates, certificates that are not yet valid, and untrusted certificate authorities.
  * Diagnostics continue to use safe, categorized messages without exposing raw provider command output.

* **Chores**
  * Added release tracking for the updated TLS failure categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->