### PR TITLE
fix: verify private database endpoint

### DIFF
--- a/.changeset/verify-private-database-endpoint.md
+++ b/.changeset/verify-private-database-endpoint.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+# Verify the private database endpoint
+
+Verify managed PostgreSQL certificates against the actual connection host by
+default so Scaleway's private-only database certificate matches schema and
+runtime connections, while retaining an optional server-name override for
+other providers.

--- a/.changeset/verify-scaleway-database-server-identity.md
+++ b/.changeset/verify-scaleway-database-server-identity.md
@@ -4,7 +4,7 @@ default: patch
 
 # Verify the Scaleway database server identity
 
-Keep database traffic on the private-network IP while supplying Scaleway's
-canonical database hostname for TLS SNI and certificate identity verification.
-Classify bounded schema command failures without logging provider output, and
-exclude local Terraform working data from container build contexts.
+Keep database traffic on the private-network IP while verifying Scaleway's
+certificate against that endpoint identity. Classify bounded schema command
+failures without logging provider output, and exclude local Terraform working
+data from container build contexts.

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -135,7 +135,6 @@ describe('Scaleway hosting source', () => {
     const environmentKeys = [
       'DATABASE_TLS_CA_CERTIFICATE',
       'DATABASE_TLS_REQUIRED',
-      'DATABASE_TLS_SERVER_NAME',
       'DATABASE_URL',
     ] as const;
     const originalEnvironment = Object.fromEntries(
@@ -146,12 +145,9 @@ describe('Scaleway hosting source', () => {
       'managed-database-ca',
       '-----END CERTIFICATE-----',
     ].join('\n');
-    const tlsServerName = 'rw-database.rdb.fr-par.scw.cloud';
-
     try {
       process.env['DATABASE_TLS_CA_CERTIFICATE'] = caCertificate;
       process.env['DATABASE_TLS_REQUIRED'] = 'true';
-      process.env['DATABASE_TLS_SERVER_NAME'] = tlsServerName;
       process.env['DATABASE_URL'] =
         'postgresql://schema_owner:p%40ss%2Fword@10.0.0.8:6432/evorto%20staging';
       const configUrl = pathToFileURL(
@@ -172,7 +168,6 @@ describe('Scaleway hosting source', () => {
             ssl: {
               ca: caCertificate,
               rejectUnauthorized: true,
-              servername: tlsServerName,
             },
             user: 'schema_owner',
           },
@@ -192,9 +187,7 @@ describe('Scaleway hosting source', () => {
     const containers = source(
       'infrastructure/scaleway/modules/environment/containers.tf',
     );
-    expect(containers).toContain(
-      'DATABASE_TLS_SERVER_NAME         = "rw-${trimprefix(scaleway_rdb_instance.application.id, "${var.region}/")}.rdb.${var.region}.scw.cloud"',
-    );
+    expect(containers).not.toContain('DATABASE_TLS_SERVER_NAME');
   });
 
   it('keeps web, worker, and ops isolated in one bounded container shape', () => {

--- a/infrastructure/scaleway/README.md
+++ b/infrastructure/scaleway/README.md
@@ -153,11 +153,13 @@ ops/COCKPIT_TRACES_TOKEN
 
 Production omits `worker/STAGING_EMAIL_ALLOWLIST`. The deploy workflow derives
 the three `DATABASE_URL` values and `DATABASE_TLS_CA_CERTIFICATE` values from
-Terraform's sensitive database output. Terraform also supplies the canonical
-Scaleway `DATABASE_TLS_SERVER_NAME` while the URLs retain the private-network
-IP, so clients can verify both the CA and server identity without using a
-public endpoint. Secret synchronization rejects an incomplete or surplus key
-set. Staging additionally rejects non-test Stripe secret keys.
+Terraform's sensitive database output. The private-network IP in each URL is
+also the certificate identity issued by Scaleway, so clients verify both the CA
+and private endpoint without a public endpoint or a separate server-name
+override. `DATABASE_TLS_SERVER_NAME` remains an optional application setting
+for providers whose connection address differs from the certificate identity.
+Secret synchronization rejects an incomplete or surplus key set. Staging
+additionally rejects non-test Stripe secret keys.
 
 Never use `pull_request_target` or expose Scaleway credentials to pull requests.
 The staging deploy accepts only the exact `main` revision that has passed both

--- a/infrastructure/scaleway/modules/environment/containers.tf
+++ b/infrastructure/scaleway/modules/environment/containers.tf
@@ -12,7 +12,6 @@ locals {
     DATABASE_POOL_MAX                = "5"
     DATABASE_POOL_MIN                = "0"
     DATABASE_TLS_REQUIRED            = "true"
-    DATABASE_TLS_SERVER_NAME         = "rw-${trimprefix(scaleway_rdb_instance.application.id, "${var.region}/")}.rdb.${var.region}.scw.cloud"
     NODE_ENV                         = "production"
     SERVER_LOG_LEVEL                 = "info"
   }

--- a/ops/drizzle.config.mjs
+++ b/ops/drizzle.config.mjs
@@ -8,9 +8,9 @@ const tlsRequired = process.env.DATABASE_TLS_REQUIRED === "true";
 const caCertificate = process.env.DATABASE_TLS_CA_CERTIFICATE;
 const tlsServerName = process.env.DATABASE_TLS_SERVER_NAME;
 
-if (tlsRequired && (!caCertificate || !tlsServerName)) {
+if (tlsRequired && !caCertificate) {
   throw new Error(
-    "DATABASE_TLS_CA_CERTIFICATE and DATABASE_TLS_SERVER_NAME are required for managed schema operations",
+    "DATABASE_TLS_CA_CERTIFICATE is required for managed schema operations",
   );
 }
 
@@ -40,7 +40,7 @@ const managedDatabaseCredentials = () => {
     ssl: {
       ca: caCertificate,
       rejectUnauthorized: true,
-      servername: tlsServerName,
+      ...(tlsServerName && { servername: tlsServerName }),
     },
     user,
   };

--- a/src/db/database-config.spec.ts
+++ b/src/db/database-config.spec.ts
@@ -19,34 +19,34 @@ describe('database configuration', () => {
     }),
   );
 
-  it.each([
-    [
-      'CA certificate',
-      'DATABASE_TLS_CA_CERTIFICATE',
-      new Map([
-        ['DATABASE_TLS_REQUIRED', 'true'],
-        ['DATABASE_TLS_SERVER_NAME', 'rw-database.rdb.fr-par.scw.cloud'],
-        ['DATABASE_URL', 'postgresql://private/evorto'],
-      ]),
-    ],
-    [
-      'certificate server name',
-      'DATABASE_TLS_SERVER_NAME',
-      new Map([
-        ['DATABASE_TLS_CA_CERTIFICATE', 'managed-ca'],
-        ['DATABASE_TLS_REQUIRED', 'true'],
-        ['DATABASE_URL', 'postgresql://private/evorto'],
-      ]),
-    ],
-  ])('fails closed when verified TLS has no %s', async (_, missing, values) => {
-    const error = await Effect.runPromise(
-      parseConfig(values).pipe(Effect.flip),
-    );
+  it.effect('fails closed when verified TLS has no CA certificate', () =>
+    Effect.gen(function* () {
+      const error = yield* parseConfig(
+        new Map([
+          ['DATABASE_TLS_REQUIRED', 'true'],
+          ['DATABASE_URL', 'postgresql://private/evorto'],
+        ]),
+      ).pipe(Effect.flip);
 
-    expect(String(error)).toContain(missing);
-  });
+      expect(String(error)).toContain('DATABASE_TLS_CA_CERTIFICATE');
+    }),
+  );
 
-  it.effect('retains the configured CA as a redacted value', () =>
+  it.effect('uses the connection host when no TLS server name is set', () =>
+    Effect.gen(function* () {
+      const config = yield* parseConfig(
+        new Map([
+          ['DATABASE_TLS_CA_CERTIFICATE', 'managed-ca'],
+          ['DATABASE_TLS_REQUIRED', 'true'],
+          ['DATABASE_URL', 'postgresql://10.0.0.8/evorto'],
+        ]),
+      );
+
+      expect(Option.isNone(config.DATABASE_TLS_SERVER_NAME)).toBe(true);
+    }),
+  );
+
+  it.effect('retains the configured CA and optional server name', () =>
     Effect.gen(function* () {
       const certificate =
         '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----';

--- a/src/db/database-config.ts
+++ b/src/db/database-config.ts
@@ -51,29 +51,19 @@ const databaseConfigValues = Config.all({
 });
 
 export const databaseConfig = databaseConfigValues.pipe(
-  Config.mapOrFail((config) => {
-    if (!config.DATABASE_TLS_REQUIRED) {
-      return Effect.succeed(config);
-    }
-
-    const missingValues = [
-      Option.isNone(config.DATABASE_TLS_CA_CERTIFICATE)
-        ? 'DATABASE_TLS_CA_CERTIFICATE'
-        : undefined,
-      Option.isNone(config.DATABASE_TLS_SERVER_NAME)
-        ? 'DATABASE_TLS_SERVER_NAME'
-        : undefined,
-    ].filter((value): value is string => value !== undefined);
-    return missingValues.length === 0
-      ? Effect.succeed(config)
-      : Effect.fail(
+  Config.mapOrFail((config) =>
+    config.DATABASE_TLS_REQUIRED &&
+    Option.isNone(config.DATABASE_TLS_CA_CERTIFICATE)
+      ? Effect.fail(
           new Config.ConfigError(
             new ConfigProvider.SourceError({
-              message: `${missingValues.join(' and ')} must be configured when DATABASE_TLS_REQUIRED=true`,
+              message:
+                'DATABASE_TLS_CA_CERTIFICATE must be configured when DATABASE_TLS_REQUIRED=true',
             }),
           ),
-        );
-  }),
+        )
+      : Effect.succeed(config),
+  ),
 );
 
 export type DatabaseConfig = Config.Success<typeof databaseConfig>;

--- a/src/db/pg-connection-config.spec.ts
+++ b/src/db/pg-connection-config.spec.ts
@@ -51,7 +51,21 @@ describe('pg-connection-config', () => {
     expect(effectConfig.ssl).toBeUndefined();
   });
 
-  it('verifies managed database TLS against the configured CA', () => {
+  it('verifies managed database TLS against the connection host by default', () => {
+    const caCertificate =
+      '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----';
+
+    expect(createNodePgPoolConfig({ caCertificate, databaseUrl }).ssl).toEqual({
+      ca: caCertificate,
+      rejectUnauthorized: true,
+    });
+    expect(createPgClientConfig({ caCertificate, databaseUrl }).ssl).toEqual({
+      ca: caCertificate,
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('supports an explicit TLS server-name override', () => {
     const caCertificate =
       '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----';
     const tlsServerName = 'rw-database.rdb.fr-par.scw.cloud';

--- a/src/server/ops/database-prerequisites.ts
+++ b/src/server/ops/database-prerequisites.ts
@@ -10,9 +10,9 @@ const tlsRequired = process.env['DATABASE_TLS_REQUIRED'] === 'true';
 const caCertificate = process.env['DATABASE_TLS_CA_CERTIFICATE'];
 const tlsServerName = process.env['DATABASE_TLS_SERVER_NAME'];
 const runtimeRole = process.env['DATABASE_RUNTIME_ROLE'];
-if (tlsRequired && (!caCertificate || !tlsServerName)) {
+if (tlsRequired && !caCertificate) {
   throw new Error(
-    'DATABASE_TLS_CA_CERTIFICATE and DATABASE_TLS_SERVER_NAME are required when DATABASE_TLS_REQUIRED=true',
+    'DATABASE_TLS_CA_CERTIFICATE is required when DATABASE_TLS_REQUIRED=true',
   );
 }
 if (!runtimeRole || !/^[a-z_][a-z0-9_]{0,62}$/u.test(runtimeRole)) {

--- a/src/server/ops/reset-staging-database.ts
+++ b/src/server/ops/reset-staging-database.ts
@@ -16,9 +16,9 @@ if (!databaseUrl) {
 const tlsRequired = process.env['DATABASE_TLS_REQUIRED'] === 'true';
 const caCertificate = process.env['DATABASE_TLS_CA_CERTIFICATE'];
 const tlsServerName = process.env['DATABASE_TLS_SERVER_NAME'];
-if (tlsRequired && (!caCertificate || !tlsServerName)) {
+if (tlsRequired && !caCertificate) {
   throw new Error(
-    'DATABASE_TLS_CA_CERTIFICATE and DATABASE_TLS_SERVER_NAME are required when DATABASE_TLS_REQUIRED=true',
+    'DATABASE_TLS_CA_CERTIFICATE is required when DATABASE_TLS_REQUIRED=true',
   );
 }
 


### PR DESCRIPTION
## Purpose

Make Scaleway schema operations verify the TLS certificate against the actual private database endpoint instead of forcing the public canonical hostname, which is absent from the live managed-database certificate.

## Scope

- keep CA verification mandatory when database TLS is required
- make the optional TLS server-name override provider-specific
- omit the invalid Scaleway override from web, worker, and ops containers
- cover runtime, Drizzle, ops, reset, and Terraform source behavior
- document the private-endpoint identity behavior

## Schema and runtime impact

No schema change. Deployment reconciliation removes DATABASE\_TLS\_SERVER\_NAME from the three Scaleway roles. Connections still use verified TLS and default to the hostname in DATABASE\_URL.

## Local verification

- format, lint, release metadata, and clean-diff checks
- 1,424 server/helper unit tests
- 799 Angular unit tests
- 55 PostgreSQL integration tests
- production build
- Terraform validation and static scan with zero findings
- Linux/amd64 image build, size gate, source-map gate, and zero high/critical scan findings
- Playwright baseline 150/150
- Playwright docs 52/52
- protected provider suite 11/11
- live ESNcard certification: 27/27 component and 9/9 browser

Every collected test passed locally with zero skips, retries, flakes, todos, fixmes, or expected failures.

## UI evidence

No UI behavior changed.

- `main` <!-- branch-stack -->
  - **fix: verify private database endpoint** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed PostgreSQL TLS verification for private database endpoints.
  * TLS now verifies the connection host by default, without requiring a separate server-name setting.
  * Added support for optional server-name overrides when certificate and connection identities differ.
  * TLS connections now fail clearly when the required CA certificate is missing.

* **Documentation**
  * Updated deployment documentation to clarify private endpoint certificate verification and optional overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->