### PR TITLE
fix: report private schema failures

### DIFF
--- a/.changeset/report-private-ops-failures.md
+++ b/.changeset/report-private-ops-failures.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Report private ops failures safely
+
+Return only a fixed failure category from private schema operations so a
+failed deployment is actionable without exposing database output, and verify
+managed PostgreSQL certificates against IP connection identities explicitly.

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -167,6 +167,7 @@ describe('Scaleway hosting source', () => {
             port: 6432,
             ssl: {
               ca: caCertificate,
+              checkServerIdentity: expect.any(Function),
               rejectUnauthorized: true,
             },
             user: 'schema_owner',

--- a/helpers/testing/scaleway-invoke-private-container.spec.ts
+++ b/helpers/testing/scaleway-invoke-private-container.spec.ts
@@ -1,0 +1,119 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const invokeScript = path.join(
+  process.cwd(),
+  'ops/scaleway/invoke-private-container.sh',
+);
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+const invokeWithFakeCurl = ({
+  responseBody,
+  status,
+}: {
+  responseBody: string;
+  status: number;
+}) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'evorto-scaleway-private-invocation-'),
+  );
+  temporaryDirectories.push(directory);
+  const fakeCurlPath = path.join(directory, 'curl');
+  const responsePath = path.join(directory, 'response.json');
+  fs.writeFileSync(responsePath, responseBody, { mode: 0o600 });
+  fs.writeFileSync(
+    fakeCurlPath,
+    String.raw`#!/usr/bin/env bash
+set -euo pipefail
+output=''
+while (($# > 0)); do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --data-binary|--header|--request|--retry|--write-out)
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cp "${'$'}{FAKE_CURL_RESPONSE:?}" "${'$'}{output:?}"
+printf '%s' "${'$'}{FAKE_CURL_STATUS:?}"
+if ((FAKE_CURL_STATUS >= 400)); then
+  exit 22
+fi
+`,
+    { mode: 0o700 },
+  );
+
+  return spawnSync(
+    invokeScript,
+    ['https://ops.example', '/internal/ops/schema-explain', '{}'],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FAKE_CURL_RESPONSE: responsePath,
+        FAKE_CURL_STATUS: String(status),
+        PATH: `${directory}:${process.env['PATH'] ?? ''}`,
+        SCW_SECRET_KEY: 'test-only-secret-key',
+      },
+    },
+  );
+};
+
+describe('Scaleway private-container invocation', () => {
+  it('prints an allowlisted ops diagnostic without the response envelope', () => {
+    const result = invokeWithFakeCurl({
+      responseBody: JSON.stringify({
+        detail: 'database-authentication-failed',
+        error: 'ops-command-failed',
+      }),
+      status: 500,
+    });
+
+    expect(result.status).toBe(22);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('database-authentication-failed');
+    expect(result.stderr).not.toContain('ops-command-failed');
+  });
+
+  it('does not print arbitrary failure response bodies', () => {
+    const result = invokeWithFakeCurl({
+      responseBody: JSON.stringify({
+        detail: 'database-password=must-not-appear',
+        error: 'ops-command-failed',
+      }),
+      status: 500,
+    });
+
+    expect(result.status).toBe(22);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(
+      'Private-container request failed with HTTP 500',
+    );
+    expect(result.stderr).not.toContain('must-not-appear');
+  });
+
+  it('returns the successful JSON response', () => {
+    const responseBody = JSON.stringify({ safe: true });
+    const result = invokeWithFakeCurl({ responseBody, status: 200 });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(responseBody);
+    expect(result.stderr).toBe('');
+  });
+});

--- a/ops/drizzle.config.mjs
+++ b/ops/drizzle.config.mjs
@@ -1,3 +1,6 @@
+import { isIP } from "node:net";
+import { checkServerIdentity } from "node:tls";
+
 const databaseUrl = process.env.DATABASE_URL;
 
 if (!databaseUrl) {
@@ -31,6 +34,7 @@ const managedDatabaseCredentials = () => {
       "DATABASE_URL must include host, database, user, and password for managed schema operations",
     );
   }
+  const serverIdentity = tlsServerName || parsedUrl.hostname;
 
   return {
     database,
@@ -39,8 +43,12 @@ const managedDatabaseCredentials = () => {
     port: parsedUrl.port ? Number(parsedUrl.port) : 5432,
     ssl: {
       ca: caCertificate,
+      checkServerIdentity: (_hostname, certificate) =>
+        checkServerIdentity(serverIdentity, certificate),
       rejectUnauthorized: true,
-      ...(tlsServerName && { servername: tlsServerName }),
+      ...(tlsServerName && isIP(tlsServerName) === 0
+        ? { servername: tlsServerName }
+        : {}),
     },
     user,
   };

--- a/ops/scaleway/invoke-private-container.sh
+++ b/ops/scaleway/invoke-private-container.sh
@@ -17,13 +17,59 @@ if ! jq --exit-status 'type == "object"' <<<"${body}" >/dev/null; then
   exit 1
 fi
 
-curl \
+response_file="$(mktemp)"
+chmod 600 "${response_file}"
+trap 'rm -f "${response_file}"' EXIT
+
+curl_exit=0
+http_status="$(
+  curl \
   --fail-with-body \
   --header 'Content-Type: application/json' \
   --header "X-Auth-Token: ${SCW_SECRET_KEY}" \
+  --output "${response_file}" \
   --request POST \
   --retry 3 \
   --silent \
   --show-error \
   --data-binary "${body}" \
+  --write-out '%{http_code}' \
   "${endpoint%/}${path}"
+)" || curl_exit=$?
+
+if ((curl_exit != 0)); then
+  if jq --exit-status '
+    . as $response
+    | type == "object"
+      and (keys == ["detail", "error"])
+      and .error == "ops-command-failed"
+      and ([
+        "bounded-command-failed",
+        "command-failed",
+        "database-authentication-failed",
+        "database-configuration-invalid",
+        "database-host-resolution-failed",
+        "database-not-found",
+        "database-permission-denied",
+        "database-tls-ca-untrusted",
+        "database-tls-certificate-expired",
+        "database-tls-certificate-not-yet-valid",
+        "database-tls-hostname-mismatch",
+        "database-tls-verification-failed",
+        "database-unreachable",
+        "drizzle-application-unconfirmed",
+        "drizzle-cli-incompatible",
+        "drizzle-invalid-json",
+        "runtime-artifact-missing",
+        "staging-schema-unconfirmed"
+      ] | index($response.detail)) != null
+  ' "${response_file}" >/dev/null 2>&1; then
+    diagnostic="$(jq --raw-output '.detail' "${response_file}")"
+    echo "Private-container ops request failed: ${diagnostic}" >&2
+  else
+    echo "Private-container request failed with HTTP ${http_status:-unknown}" >&2
+  fi
+  exit "${curl_exit}"
+fi
+
+cat "${response_file}"

--- a/src/db/pg-connection-config.spec.ts
+++ b/src/db/pg-connection-config.spec.ts
@@ -6,6 +6,23 @@ import {
   createPgClientConfig,
 } from './pg-connection-config';
 
+const expectVerifiedTlsOptions = (
+  ssl: unknown,
+  expectedServerName?: string,
+) => {
+  expect(ssl).toEqual(
+    expect.objectContaining({
+      ca: '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----',
+      checkServerIdentity: expect.any(Function),
+      rejectUnauthorized: true,
+    }),
+  );
+  if (typeof ssl !== 'object' || ssl === null) {
+    throw new Error('Expected PostgreSQL TLS options');
+  }
+  expect(Reflect.get(ssl, 'servername')).toBe(expectedServerName);
+};
+
 describe('pg-connection-config', () => {
   const databaseUrl =
     'postgresql://evorto:local@localhost:55432/appdb?sslmode=disable';
@@ -55,14 +72,12 @@ describe('pg-connection-config', () => {
     const caCertificate =
       '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----';
 
-    expect(createNodePgPoolConfig({ caCertificate, databaseUrl }).ssl).toEqual({
-      ca: caCertificate,
-      rejectUnauthorized: true,
-    });
-    expect(createPgClientConfig({ caCertificate, databaseUrl }).ssl).toEqual({
-      ca: caCertificate,
-      rejectUnauthorized: true,
-    });
+    expectVerifiedTlsOptions(
+      createNodePgPoolConfig({ caCertificate, databaseUrl }).ssl,
+    );
+    expectVerifiedTlsOptions(
+      createPgClientConfig({ caCertificate, databaseUrl }).ssl,
+    );
   });
 
   it('supports an explicit TLS server-name override', () => {
@@ -70,28 +85,41 @@ describe('pg-connection-config', () => {
       '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----';
     const tlsServerName = 'rw-database.rdb.fr-par.scw.cloud';
 
-    expect(
+    expectVerifiedTlsOptions(
       createNodePgPoolConfig({
         caCertificate,
         databaseUrl,
         tlsServerName,
       }).ssl,
-    ).toEqual({
-      ca: caCertificate,
-      rejectUnauthorized: true,
-      servername: tlsServerName,
-    });
-    expect(
+      tlsServerName,
+    );
+    expectVerifiedTlsOptions(
       createPgClientConfig({
         caCertificate,
         databaseUrl,
         tlsServerName,
       }).ssl,
-    ).toEqual({
-      ca: caCertificate,
-      rejectUnauthorized: true,
-      servername: tlsServerName,
-    });
+      tlsServerName,
+    );
+  });
+
+  it('verifies IP endpoints without sending an IP server name', () => {
+    const caCertificate =
+      '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----';
+    const ipDatabaseUrl = 'postgresql://evorto:local@172.16.4.2:5432/appdb';
+
+    expectVerifiedTlsOptions(
+      createNodePgPoolConfig({
+        caCertificate,
+        databaseUrl: ipDatabaseUrl,
+      }).ssl,
+    );
+    expectVerifiedTlsOptions(
+      createPgClientConfig({
+        caCertificate,
+        databaseUrl: ipDatabaseUrl,
+      }).ssl,
+    );
   });
 
   it('rejects an inverted pool range', () => {

--- a/src/db/pg-connection-config.ts
+++ b/src/db/pg-connection-config.ts
@@ -1,7 +1,10 @@
 import type { PgPoolConfig } from '@effect/sql-pg/PgClient';
+import type { ConnectionOptions } from 'node:tls';
 import type { PoolConfig } from 'pg';
 
 import { Redacted } from 'effect';
+import { isIP } from 'node:net';
+import { checkServerIdentity } from 'node:tls';
 import { types } from 'pg';
 
 export interface DatabasePoolSettings {
@@ -41,6 +44,37 @@ const validatePoolSettings = (
   return pool;
 };
 
+const databaseServerIdentity = (
+  databaseUrl: string,
+  tlsServerName?: string,
+): string => {
+  const parsedUrl = new URL(databaseUrl);
+  if (
+    (parsedUrl.protocol !== 'postgresql:' &&
+      parsedUrl.protocol !== 'postgres:') ||
+    !parsedUrl.hostname
+  ) {
+    throw new Error('DATABASE_URL must identify a PostgreSQL host');
+  }
+  return tlsServerName || parsedUrl.hostname;
+};
+
+const createDatabaseTlsOptions = (
+  caCertificate: string,
+  databaseUrl: string,
+  tlsServerName?: string,
+): ConnectionOptions => {
+  const identity = databaseServerIdentity(databaseUrl, tlsServerName);
+  return {
+    ca: caCertificate,
+    checkServerIdentity: (_hostname, certificate) =>
+      checkServerIdentity(identity, certificate),
+    rejectUnauthorized: true,
+    ...(tlsServerName &&
+      isIP(tlsServerName) === 0 && { servername: tlsServerName }),
+  };
+};
+
 export const createPgClientConfig = ({
   caCertificate,
   databaseUrl,
@@ -59,11 +93,7 @@ export const createPgClientConfig = ({
     maxConnections: boundedPool.max,
     minConnections: boundedPool.min,
     ...(caCertificate && {
-      ssl: {
-        ca: caCertificate,
-        rejectUnauthorized: true,
-        ...(tlsServerName && { servername: tlsServerName }),
-      },
+      ssl: createDatabaseTlsOptions(caCertificate, databaseUrl, tlsServerName),
     }),
     types: pgTypes,
     url: Redacted.make(databaseUrl),
@@ -89,11 +119,7 @@ export const createNodePgPoolConfig = ({
     max: boundedPool.max,
     min: boundedPool.min,
     ...(caCertificate && {
-      ssl: {
-        ca: caCertificate,
-        rejectUnauthorized: true,
-        ...(tlsServerName && { servername: tlsServerName }),
-      },
+      ssl: createDatabaseTlsOptions(caCertificate, databaseUrl, tlsServerName),
     }),
     types: pgTypes,
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,12 +62,12 @@ import {
 } from './server/http/browser-error-telemetry.web-handler';
 import { handleHealthzWebRequest } from './server/http/healthz.web-handler';
 import {
-  handleInternalJsonTriggerWebRequest,
   handleInternalTriggerWebRequest,
   type InternalTriggerArguments,
   MAX_INTERNAL_TRIGGER_BODY_SIZE_BYTES,
 } from './server/http/internal-trigger.web-handler';
 import { resolveNodeRequestBoundary } from './server/http/node-request-boundary';
+import { handleOpsJsonTriggerWebRequest } from './server/http/ops-trigger.web-handler';
 import { handleQrRegistrationCodeWebRequest } from './server/http/qr-code.web-handler';
 import {
   discardNodeRequestBody,
@@ -96,6 +96,7 @@ import {
 import {
   applySchema,
   explainSchema,
+  type OpsCommandError,
   seedStaging,
 } from './server/ops/schema-operations';
 import {
@@ -443,10 +444,10 @@ const SeedStagingArguments = Schema.Struct({
   confirmation: Schema.Literal('reset-and-seed-staging'),
 });
 
-const handleOpsTrigger = <S extends Schema.Constraint, A, E, R>(
+const handleOpsTrigger = <S extends Schema.Constraint, A, R>(
   request: HttpServerRequest.HttpServerRequest,
   schema: S,
-  operation: (arguments_: S['Type']) => Effect.Effect<A, E, R>,
+  operation: (arguments_: S['Type']) => Effect.Effect<A, OpsCommandError, R>,
 ) =>
   Effect.gen(function* () {
     const deployment = yield* DeploymentRuntimeConfig;
@@ -456,7 +457,7 @@ const handleOpsTrigger = <S extends Schema.Constraint, A, E, R>(
     }
 
     const webRequest = yield* HttpServerRequest.toWeb(request);
-    const webResponse = yield* handleInternalJsonTriggerWebRequest(
+    const webResponse = yield* handleOpsJsonTriggerWebRequest(
       webRequest,
       schema,
       operation,

--- a/src/server/http/ops-trigger.web-handler.spec.ts
+++ b/src/server/http/ops-trigger.web-handler.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@effect/vitest';
+import { Effect, Schema } from 'effect';
+
+import { OpsCommandError } from '../ops/schema-operations';
+import { handleOpsJsonTriggerWebRequest } from './ops-trigger.web-handler';
+
+describe('ops trigger web handler', () => {
+  it.effect('returns only the bounded ops diagnostic on failure', () =>
+    Effect.gen(function* () {
+      const response = yield* handleOpsJsonTriggerWebRequest(
+        new Request('https://ops.example/internal/ops/schema-explain', {
+          body: '{}',
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+        }),
+        Schema.Struct({}),
+        () =>
+          Effect.fail(
+            new OpsCommandError({
+              diagnostic: 'database-authentication-failed',
+              message:
+                'sensitive database URL and provider output must remain private',
+            }),
+          ),
+      );
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        detail: 'database-authentication-failed',
+        error: 'ops-command-failed',
+      });
+    }),
+  );
+
+  it.effect('preserves successful bounded responses', () =>
+    Effect.gen(function* () {
+      const response = yield* handleOpsJsonTriggerWebRequest(
+        new Request('https://ops.example/internal/ops/schema-explain', {
+          body: '{}',
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+        }),
+        Schema.Struct({}),
+        () => Effect.succeed({ safe: true }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        safe: true,
+      });
+    }),
+  );
+});

--- a/src/server/http/ops-trigger.web-handler.ts
+++ b/src/server/http/ops-trigger.web-handler.ts
@@ -1,0 +1,31 @@
+import { Effect, Schema } from 'effect';
+
+import { type OpsCommandError } from '../ops/schema-operations';
+import { handleInternalJsonTriggerWebRequest } from './internal-trigger.web-handler';
+
+const noStoreHeaders = {
+  'Cache-Control': 'no-store',
+};
+
+export const handleOpsJsonTriggerWebRequest = <
+  S extends Schema.Constraint,
+  A,
+  R,
+>(
+  request: Request,
+  schema: S,
+  operation: (arguments_: S['Type']) => Effect.Effect<A, OpsCommandError, R>,
+) =>
+  handleInternalJsonTriggerWebRequest(request, schema, operation).pipe(
+    Effect.catchTag('OpsCommandError', (error) =>
+      Effect.succeed(
+        Response.json(
+          {
+            detail: error.diagnostic,
+            error: 'ops-command-failed',
+          },
+          { headers: noStoreHeaders, status: 500 },
+        ),
+      ),
+    ),
+  );

--- a/src/server/ops/schema-operations.ts
+++ b/src/server/ops/schema-operations.ts
@@ -10,21 +10,34 @@ const databasePrerequisitesExecutable =
 const stagingResetExecutable = 'dist/evorto/ops/reset-staging-database.mjs';
 const stagingSeedExecutable = 'dist/evorto/ops/seed-staging.mjs';
 
-export type OpsCommandFailureKind =
-  | 'command-failed'
-  | 'database-authentication-failed'
-  | 'database-configuration-invalid'
-  | 'database-host-resolution-failed'
-  | 'database-not-found'
-  | 'database-permission-denied'
-  | 'database-tls-ca-untrusted'
-  | 'database-tls-certificate-expired'
-  | 'database-tls-certificate-not-yet-valid'
-  | 'database-tls-hostname-mismatch'
-  | 'database-tls-verification-failed'
-  | 'database-unreachable'
-  | 'drizzle-cli-incompatible'
-  | 'runtime-artifact-missing';
+export const opsCommandFailureKinds = [
+  'command-failed',
+  'database-authentication-failed',
+  'database-configuration-invalid',
+  'database-host-resolution-failed',
+  'database-not-found',
+  'database-permission-denied',
+  'database-tls-ca-untrusted',
+  'database-tls-certificate-expired',
+  'database-tls-certificate-not-yet-valid',
+  'database-tls-hostname-mismatch',
+  'database-tls-verification-failed',
+  'database-unreachable',
+  'drizzle-cli-incompatible',
+  'runtime-artifact-missing',
+] as const;
+
+export type OpsCommandFailureKind = (typeof opsCommandFailureKinds)[number];
+
+export const opsCommandDiagnostics = [
+  ...opsCommandFailureKinds,
+  'bounded-command-failed',
+  'drizzle-application-unconfirmed',
+  'drizzle-invalid-json',
+  'staging-schema-unconfirmed',
+] as const;
+
+export type OpsCommandDiagnostic = (typeof opsCommandDiagnostics)[number];
 
 export interface OpsCommandResult {
   readonly exitCode: number;
@@ -44,6 +57,7 @@ export interface OpsCommandRunner {
 export class OpsCommandError extends Schema.TaggedErrorClass<OpsCommandError>()(
   'OpsCommandError',
   {
+    diagnostic: Schema.Literals(opsCommandDiagnostics),
     message: Schema.String,
   },
 ) {}
@@ -168,6 +182,7 @@ const failOpsCommand = Effect.fn('failOpsCommand')(function* (
     }),
   );
   return yield* new OpsCommandError({
+    diagnostic: failureKind,
     message: `${operation} failed (${failureKind}; exit ${result.exitCode})`,
   });
 });
@@ -186,7 +201,10 @@ export const liveOpsCommandRunner: OpsCommandRunner = {
   run: (command, options) =>
     Effect.tryPromise({
       catch: () =>
-        new OpsCommandError({ message: 'The bounded ops command failed' }),
+        new OpsCommandError({
+          diagnostic: 'bounded-command-failed',
+          message: 'The bounded ops command failed',
+        }),
       try: async () => {
         const subprocess = Bun.spawn([...command], {
           env: {
@@ -446,6 +464,7 @@ const parseCommandJson = (result: OpsCommandResult) =>
     return yield* Effect.try({
       catch: () =>
         new OpsCommandError({
+          diagnostic: 'drizzle-invalid-json',
           message: 'Drizzle returned an invalid JSON envelope',
         }),
       try: () => JSON.parse(result.stdout),
@@ -556,6 +575,7 @@ export const applySchema = (
     const status = asRecord(envelope)?.['status'];
     if (status !== 'ok' && status !== 'no_changes') {
       return yield* new OpsCommandError({
+        diagnostic: 'drizzle-application-unconfirmed',
         message: 'Drizzle did not confirm schema application',
       });
     }
@@ -596,6 +616,7 @@ export const seedStaging = (
     const applyStatus = asRecord(applyEnvelope)?.['status'];
     if (applyStatus !== 'ok' && applyStatus !== 'no_changes') {
       return yield* new OpsCommandError({
+        diagnostic: 'staging-schema-unconfirmed',
         message: 'Drizzle did not confirm the staging reset schema',
       });
     }


### PR DESCRIPTION
## Purpose

Make private Scaleway schema failures diagnosable without exposing arbitrary response bodies, and verify PostgreSQL TLS identity correctly when the managed private endpoint is an IP address.

## Scope

- return only allowlisted, bounded diagnostics from the private ops schema endpoint
- preserve no-store responses and redact arbitrary command output
- make the private-container invocation helper surface only the safe diagnostic
- verify PostgreSQL certificates against the configured host or explicit identity for both runtime and Drizzle tooling
- add focused handler, helper, TLS, and source-policy coverage

## Schema and runtime impact

No schema change. The web and worker runtime behavior is unchanged. The private ops role now reports a safe error category on schema command failure. PostgreSQL TLS remains CA-verified and now also verifies the configured endpoint identity when no DNS SNI value is available.

## Local verification

Complete release-equivalent gate passed locally:

- formatting, lint, diff, and release metadata checks
- 1,430 server/helper tests
- 799 Angular tests
- 55 PostgreSQL integration tests
- application build
- Terraform validation and Trivy configuration scan
- Linux/amd64 image build, artifact audit, source-map export, SBOM, size gate, and zero high/critical vulnerabilities
- local Docker health and readiness
- Playwright baseline 150/150
- Playwright docs 52/52
- provider integration 11/11
- live ESNcard component 27/27 and browser certification 9/9

Every collected test passed with zero skips, todos, fixmes, expected failures, retries, flakes, focused tests, or interruptions.

- `main` <!-- branch-stack -->
  - **fix: report private schema failures** :point\_left:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Operations failures now return safe, actionable diagnostics without exposing sensitive database or response details.
  - Private operation requests now handle failed and successful responses more reliably.
  - Managed PostgreSQL connections now verify server certificates against the connection identity, including IP-based endpoints.

- **Tests**
  - Added coverage for safe failure reporting, response handling, and TLS certificate verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
