### PR TITLE
fix: grant schema owner database access

### DIFF
--- a/.changeset/grant-scaleway-schema-owner.md
+++ b/.changeset/grant-scaleway-schema-owner.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Grant the Scaleway schema owner database access
+
+Grant the deployment-only schema owner explicit access to create and update
+objects in the managed application database while retaining the separate
+read/write-only runtime role.

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -88,10 +88,10 @@ describe('Scaleway hosting source', () => {
     expect(database).toContain('name                = "application_runtime"');
     expect(database).toContain('is_admin            = false');
     expect(database).toMatch(
-      /resource "scaleway_rdb_privilege" "schema" \{[\s\S]*?user_name\s+= scaleway_rdb_instance\.application\.user_name[\s\S]*?permission\s+= "all"/u,
+      /resource "scaleway_rdb_privilege" "schema" \{[^}]*user_name\s+= scaleway_rdb_instance\.application\.user_name[^}]*permission\s+= "all"/u,
     );
     expect(database).toMatch(
-      /resource "scaleway_rdb_privilege" "runtime" \{[\s\S]*?user_name\s+= scaleway_rdb_user\.runtime\.name[\s\S]*?permission\s+= "readwrite"/u,
+      /resource "scaleway_rdb_privilege" "runtime" \{[^}]*user_name\s+= scaleway_rdb_user\.runtime\.name[^}]*permission\s+= "readwrite"/u,
     );
     expect(database).toContain(
       'password_wo_version = var.schema_database_password_version',

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -87,6 +87,12 @@ describe('Scaleway hosting source', () => {
     expect(database).toContain('user_name           = "schema_owner"');
     expect(database).toContain('name                = "application_runtime"');
     expect(database).toContain('is_admin            = false');
+    expect(database).toMatch(
+      /resource "scaleway_rdb_privilege" "schema" \{[\s\S]*?user_name\s+= scaleway_rdb_instance\.application\.user_name[\s\S]*?permission\s+= "all"/u,
+    );
+    expect(database).toMatch(
+      /resource "scaleway_rdb_privilege" "runtime" \{[\s\S]*?user_name\s+= scaleway_rdb_user\.runtime\.name[\s\S]*?permission\s+= "readwrite"/u,
+    );
     expect(database).toContain(
       'password_wo_version = var.schema_database_password_version',
     );

--- a/infrastructure/scaleway/modules/environment/database.tf
+++ b/infrastructure/scaleway/modules/environment/database.tf
@@ -49,6 +49,14 @@ resource "scaleway_rdb_database" "application" {
   name        = "evorto"
 }
 
+resource "scaleway_rdb_privilege" "schema" {
+  instance_id   = scaleway_rdb_instance.application.id
+  region        = var.region
+  database_name = scaleway_rdb_database.application.name
+  user_name     = scaleway_rdb_instance.application.user_name
+  permission    = "all"
+}
+
 resource "scaleway_rdb_user" "runtime" {
   instance_id         = scaleway_rdb_instance.application.id
   region              = var.region


### PR DESCRIPTION
## Purpose

Give the deployment-only Scaleway schema owner explicit access to the application database so the private ops role can explain and apply the Drizzle schema.

## Scope

- grant the managed-database admin user all privileges on the evorto database
- retain the separate runtime user at readwrite
- add source-level regression coverage
- add a patch release note

## Schema/runtime impact

Terraform-only permission change. No application schema change and no runtime-role privilege expansion.

## Local verification

- format, lint, release validation, and diff checks
- server/helper unit: 1,430 passed
- Angular unit: 799 passed
- PostgreSQL integration: 55 passed
- Playwright baseline: 150 passed
- Playwright docs: 52 passed
- provider suite: 11 passed
- live ESNcard: 27 component + 9 browser passed
- Terraform validate and Trivy configuration scan: clean
- Linux/amd64 build, runtime artifact check, SBOM, vulnerability scan, and image-size gate: clean

Every collected test passed with zero skips, retries, flakes, todos, fixmes, expected failures, or focused tests.

- `main` <!-- branch-stack -->
  - **fix: grant schema owner database access** :point\_left:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Schema-owner access is now granted full permissions on the managed application database, enabling database object creation and updates.
  - Runtime database access remains limited to read/write permissions.

- **Tests**
  - Added coverage verifying the separate schema-owner and runtime database privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
