### PR TITLE
fix: bootstrap empty staging safely

### DIFF
--- a/.changeset/bootstrap-empty-scaleway-staging.md
+++ b/.changeset/bootstrap-empty-scaleway-staging.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+# Bootstrap an empty Scaleway staging database safely
+
+Initialize deterministic staging data before deploying web only when every
+application table is empty. Preserve all existing staging data during normal
+deployment reconciliation and fail closed when partial data lacks the required
+staging tenant.
+
+Use PostgreSQL's canonical receipt-expiry default expression so repeated schema
+plans remain stable after the first application.

--- a/.github/workflows/scaleway-staging.yml
+++ b/.github/workflows/scaleway-staging.yml
@@ -433,6 +433,16 @@ jobs:
             '.applied == true and .digest == $plan_digest' \
             <<<"${apply_response}" >/dev/null
 
+          initialization_response="$(
+            ops/scaleway/invoke-private-container.sh \
+              "${ops_endpoint}" \
+              /internal/ops/seed-staging \
+              '{"mode":"initialize-empty"}'
+          )"
+          jq --exit-status \
+            '.initialized == true' \
+            <<<"${initialization_response}" >/dev/null
+
       - name: Deploy worker and web at the same digest
         env:
           DIGEST: ${{ steps.image.outputs.digest }}

--- a/helpers/database.ts
+++ b/helpers/database.ts
@@ -5,6 +5,7 @@ import { Effect, Option, Redacted } from 'effect';
 
 import { createDatabaseClient } from '../src/db/database-client';
 import { setupDatabase } from '../src/db/setup-database';
+import { inspectStagingDatabaseInitialization } from '../src/db/staging-database-initialization';
 import { formatConfigError } from '../src/server/config/config-error';
 import { makeRuntimeConfigProvider } from '../src/server/config/provider';
 
@@ -65,10 +66,36 @@ const main = Effect.gen(function* () {
     onNone: () => ({}),
     onSome: (stripeTestAccountId) => ({ stripeTestAccountId }),
   });
+  const initializeEmptyStagingOnly =
+    process.env['STAGING_INITIALIZE_ONLY'] === 'true';
 
-  yield* Effect.tryPromise(() => setupDatabase(database, setupOptions)).pipe(
-    Effect.ensuring(Effect.tryPromise(() => pool.end()).pipe(Effect.orDie)),
-  );
+  yield* Effect.tryPromise(async () => {
+    try {
+      if (initializeEmptyStagingOnly) {
+        if (process.env['APP_ENVIRONMENT'] !== 'staging') {
+          throw new Error(
+            'Empty staging initialization requires APP_ENVIRONMENT=staging',
+          );
+        }
+
+        const initializationState =
+          await inspectStagingDatabaseInitialization(pool);
+        if (initializationState === 'initialized') {
+          consola.info('Staging database is already initialized');
+          return;
+        }
+        if (initializationState === 'inconsistent') {
+          throw new Error(
+            'Staging contains application data but no staging tenant; use the protected reset workflow',
+          );
+        }
+      }
+
+      await setupDatabase(database, setupOptions);
+    } finally {
+      await pool.end();
+    }
+  });
 });
 
 BunRuntime.runMain(main);

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -464,6 +464,10 @@ describe('Scaleway hosting source', () => {
     expect(staging).toContain('--provenance=mode=max');
     expect(staging).toContain("--if-none-match '*'");
     expect(staging).toContain('/internal/ops/schema-explain');
+    expect(staging).toContain('\'{"mode":"initialize-empty"}\'');
+    expect(staging.indexOf('\'{"mode":"initialize-empty"}\'')).toBeLessThan(
+      staging.indexOf('touch deployment/traffic-changed'),
+    );
     expect(staging).toContain('Roll back traffic roles to the previous digest');
 
     expect(production).not.toContain('docker build ');

--- a/helpers/testing/scaleway-invoke-private-container.spec.ts
+++ b/helpers/testing/scaleway-invoke-private-container.spec.ts
@@ -76,6 +76,12 @@ fi
 };
 
 describe('Scaleway private-container invocation', () => {
+  it('does not retry bounded POST operations', () => {
+    const script = fs.readFileSync(invokeScript, 'utf8');
+
+    expect(script).not.toContain('--retry');
+  });
+
   it('prints an allowlisted ops diagnostic without the response envelope', () => {
     const result = invokeWithFakeCurl({
       responseBody: JSON.stringify({

--- a/infrastructure/scaleway/README.md
+++ b/infrastructure/scaleway/README.md
@@ -226,7 +226,8 @@ every 30 minutes for reconciliation. It never cancels an active deployment. It:
 3. verifies the runtime image, schema hash, SBOM, vulnerabilities, and size;
 4. reconciles Terraform and role-scoped secrets;
 5. deploys private ops, rejects a destructive Drizzle plan, and applies the
-   stable plan;
+   stable plan; initializes deterministic staging data only when every
+   application table is empty, and otherwise preserves the existing data;
 6. deploys worker and web at the same digest;
 7. verifies health, readiness, version identity, tenant resolution, Auth0/RPC,
    and staging `noindex` behavior;

--- a/ops/scaleway/invoke-private-container.sh
+++ b/ops/scaleway/invoke-private-container.sh
@@ -29,7 +29,6 @@ http_status="$(
   --header "X-Auth-Token: ${SCW_SECRET_KEY}" \
   --output "${response_file}" \
   --request POST \
-  --retry 3 \
   --silent \
   --show-error \
   --data-binary "${body}" \

--- a/src/db/schema/finance-receipts.spec.ts
+++ b/src/db/schema/finance-receipts.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@effect/vitest';
-import { getTableConfig } from 'drizzle-orm/pg-core';
+import { is, SQL } from 'drizzle-orm';
+import { getTableConfig, PgDialect } from 'drizzle-orm/pg-core';
 
 import { financeReceipts, financeReceiptUploads } from './finance-receipts';
 
@@ -61,5 +62,16 @@ describe('finance receipt schema', () => {
       uploadConfig.columns.find((column) => column.name === 'expiresAt')
         ?.notNull,
     ).toBe(true);
+
+    const expiresAtDefault = uploadConfig.columns.find(
+      (column) => column.name === 'expiresAt',
+    )?.default;
+    expect(is(expiresAtDefault, SQL)).toBe(true);
+    if (!is(expiresAtDefault, SQL)) {
+      throw new Error('Receipt upload expiry must use a SQL default');
+    }
+    expect(new PgDialect().sqlToQuery(expiresAtDefault).sql).toBe(
+      `(now() + '00:05:00'::interval)`,
+    );
   });
 });

--- a/src/db/schema/finance-receipts.ts
+++ b/src/db/schema/finance-receipts.ts
@@ -39,7 +39,7 @@ export const financeReceiptUploads = pgTable(
       .references(() => eventInstances.id),
     expiresAt: timestamp()
       .notNull()
-      .default(sql`now() + interval '5 minutes'`),
+      .default(sql`(now() + '00:05:00'::interval)`),
     fileName: text().notNull(),
     mimeType: text().notNull(),
     rejectionReason: text(),

--- a/src/db/staging-database-initialization.spec.ts
+++ b/src/db/staging-database-initialization.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  applicationTableNames,
+  resolveStagingDatabaseInitializationState,
+} from './staging-database-initialization';
+
+describe('staging database initialization', () => {
+  it('treats an existing staging tenant as initialized without inspecting rows', async () => {
+    const tableHasRows = vi.fn(async () => false);
+
+    await expect(
+      resolveStagingDatabaseInitializationState({
+        hasStagingTenant: async () => true,
+        tableHasRows,
+      }),
+    ).resolves.toBe('initialized');
+    expect(tableHasRows).not.toHaveBeenCalled();
+  });
+
+  it('allows initialization only when every application table is empty', async () => {
+    await expect(
+      resolveStagingDatabaseInitializationState(
+        {
+          hasStagingTenant: async () => false,
+          tableHasRows: async () => false,
+        },
+        ['tenants', 'users'],
+      ),
+    ).resolves.toBe('empty');
+  });
+
+  it('fails closed when data exists without the staging tenant', async () => {
+    await expect(
+      resolveStagingDatabaseInitializationState(
+        {
+          hasStagingTenant: async () => false,
+          tableHasRows: async (tableName) => tableName === 'users',
+        },
+        ['tenants', 'users', 'events'],
+      ),
+    ).resolves.toBe('inconsistent');
+  });
+
+  it('derives the inspected table set from the Drizzle schema', () => {
+    expect(applicationTableNames).toContain('tenants');
+    expect(applicationTableNames).toContain('users');
+    expect(applicationTableNames.length).toBeGreaterThan(40);
+  });
+});

--- a/src/db/staging-database-initialization.ts
+++ b/src/db/staging-database-initialization.ts
@@ -1,0 +1,60 @@
+import type { Pool } from 'pg';
+
+import { getTableName, isTable } from 'drizzle-orm';
+
+import * as schema from './schema';
+
+export const stagingTenantDomain = 'staging.evorto.app';
+
+export const applicationTableNames = [
+  ...new Set(
+    Object.values(schema).flatMap((value) =>
+      isTable(value) ? [getTableName(value)] : [],
+    ),
+  ),
+].toSorted();
+
+export type StagingDatabaseInitializationState =
+  'empty' | 'inconsistent' | 'initialized';
+
+export interface StagingDatabaseProbe {
+  readonly hasStagingTenant: () => Promise<boolean>;
+  readonly tableHasRows: (tableName: string) => Promise<boolean>;
+}
+
+export const resolveStagingDatabaseInitializationState = async (
+  probe: StagingDatabaseProbe,
+  tableNames: readonly string[] = applicationTableNames,
+): Promise<StagingDatabaseInitializationState> => {
+  if (await probe.hasStagingTenant()) {
+    return 'initialized';
+  }
+
+  for (const tableName of tableNames) {
+    if (await probe.tableHasRows(tableName)) {
+      return 'inconsistent';
+    }
+  }
+
+  return 'empty';
+};
+
+const quoteIdentifier = (identifier: string) =>
+  `"${identifier.replaceAll('"', '""')}"`;
+
+export const inspectStagingDatabaseInitialization = (pool: Pool) =>
+  resolveStagingDatabaseInitializationState({
+    hasStagingTenant: async () => {
+      const result = await pool.query<{ exists: boolean }>(
+        'SELECT EXISTS (SELECT 1 FROM "tenants" WHERE "domain" = $1) AS "exists"',
+        [stagingTenantDomain],
+      );
+      return result.rows[0]?.exists === true;
+    },
+    tableHasRows: async (tableName) => {
+      const result = await pool.query<{ exists: boolean }>(
+        `SELECT EXISTS (SELECT 1 FROM ${quoteIdentifier(tableName)}) AS "exists"`,
+      );
+      return result.rows[0]?.exists === true;
+    },
+  });

--- a/src/server.ts
+++ b/src/server.ts
@@ -96,6 +96,7 @@ import {
 import {
   applySchema,
   explainSchema,
+  initializeEmptyStaging,
   type OpsCommandError,
   seedStaging,
 } from './server/ops/schema-operations';
@@ -443,6 +444,13 @@ const ApplySchemaArguments = Schema.Struct({
 const SeedStagingArguments = Schema.Struct({
   confirmation: Schema.Literal('reset-and-seed-staging'),
 });
+const InitializeStagingArguments = Schema.Struct({
+  mode: Schema.Literal('initialize-empty'),
+});
+const StagingDataArguments = Schema.Union([
+  InitializeStagingArguments,
+  SeedStagingArguments,
+]);
 
 const handleOpsTrigger = <S extends Schema.Constraint, A, R>(
   request: HttpServerRequest.HttpServerRequest,
@@ -500,7 +508,7 @@ const opsSeedStagingRouteLayer = HttpLayerRouter.add(
   'POST',
   opsSeedStagingPath,
   (request) =>
-    handleOpsTrigger(request, SeedStagingArguments, ({ confirmation }) =>
+    handleOpsTrigger(request, StagingDataArguments, (arguments_) =>
       Effect.gen(function* () {
         const deployment = yield* DeploymentRuntimeConfig;
         if (deployment.APP_ENVIRONMENT !== 'staging') {
@@ -509,7 +517,9 @@ const opsSeedStagingRouteLayer = HttpLayerRouter.add(
             seeded: false as const,
           };
         }
-        return yield* seedStaging(confirmation);
+        return 'confirmation' in arguments_
+          ? yield* seedStaging(arguments_.confirmation)
+          : yield* initializeEmptyStaging();
       }),
     ),
 );

--- a/src/server/ops/schema-operations.spec.ts
+++ b/src/server/ops/schema-operations.spec.ts
@@ -6,6 +6,7 @@ import {
   applySchema,
   classifyOpsCommandFailure,
   explainSchema,
+  initializeEmptyStaging,
   type OpsCommandRunner,
   seedStaging,
 } from './schema-operations';
@@ -302,6 +303,33 @@ describe('ops schema operations', () => {
       ]);
       expect(commands[3]).not.toContain('--force');
     }),
+  );
+
+  it.effect(
+    'initializes staging through the seed executable in non-destructive mode',
+    () =>
+      Effect.gen(function* () {
+        const commands: {
+          command: readonly string[];
+          environment?: Readonly<Record<string, string>>;
+        }[] = [];
+        const runner: OpsCommandRunner = {
+          run: (command, options) => {
+            commands.push({ command, environment: options?.environment });
+            return Effect.succeed({ exitCode: 0, stderr: '', stdout: '' });
+          },
+        };
+
+        const response = yield* initializeEmptyStaging(runner);
+
+        expect(response).toEqual({ initialized: true });
+        expect(commands).toEqual([
+          {
+            command: ['bun', 'dist/evorto/ops/seed-staging.mjs'],
+            environment: { STAGING_INITIALIZE_ONLY: 'true' },
+          },
+        ]);
+      }),
   );
 
   it.effect(

--- a/src/server/ops/schema-operations.ts
+++ b/src/server/ops/schema-operations.ts
@@ -626,3 +626,18 @@ export const seedStaging = (
 
     return { reset: true as const, seeded: true as const };
   });
+
+export const initializeEmptyStaging = (
+  runner: OpsCommandRunner = liveOpsCommandRunner,
+) =>
+  Effect.gen(function* () {
+    const seedResult = yield* runner.run(['bun', stagingSeedExecutable], {
+      environment: { STAGING_INITIALIZE_ONLY: 'true' },
+    });
+    yield* requireSuccessfulBoundedCommand(
+      'Empty staging initialization',
+      seedResult,
+    );
+
+    return { initialized: true as const };
+  });


### PR DESCRIPTION
## Purpose

Unblock the first Scaleway staging deployment without making normal reconciliation destructive.

## Scope

- initialize deterministic staging data only when every Drizzle application table is empty
- no-op when staging.evorto.app already exists and fail closed on partially populated state
- run initialization after the safe schema apply and before traffic changes
- preserve the first private ops failure response instead of retrying bounded POST operations
- canonicalize the receipt expiry default so repeated Drizzle plans remain no-change

## Schema and runtime impact

No data is reset during normal deployment. Existing staging data is preserved. A partial database without the staging tenant must use the separately protected reset workflow. The receipt expiry default is semantically unchanged at five minutes.

## Local verification

- format check and lint passed
- server/helper unit: 1436 passed
- Angular unit: 799 passed
- PostgreSQL integration: 55 passed
- production build passed
- Playwright baseline: 150 passed
- Playwright docs: 52 passed
- protected provider suite: 11 passed
- live ESNcard: 27 component plus 9 browser tests passed
- Terraform validation and static scan passed with zero misconfigurations
- Linux/amd64 image gate passed at 152126024 bytes with zero vulnerabilities
- Drizzle read-only plan reported no\_changes

Every collected test passed with zero skips, todos, fixmes, expected failures, retries, flakes, interruptions, or focused tests.

- `main` <!-- branch-stack -->
  - **fix: bootstrap empty staging safely** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Staging deployments now initialize deterministic data only when the database is empty.
  - Existing staging data is preserved during reconciliation.
  - Inconsistent staging databases fail safely instead of being modified.
  - Added support for triggering non-destructive staging initialization.

- **Bug Fixes**
  - Standardized receipt upload expiry defaults while preserving the five-minute expiration window.
  - Prevented automatic retries for bounded staging operations.

- **Documentation**
  - Updated staging deployment and rollback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->