### PR TITLE
fix: keep staging initialization idempotent

### DIFF
--- a/.changeset/fix-staging-initialization-noop.md
+++ b/.changeset/fix-staging-initialization-noop.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Keep repeated staging deployments idempotent when the database has already been initialized.

--- a/helpers/database.ts
+++ b/helpers/database.ts
@@ -1,6 +1,7 @@
 import * as BunRuntime from '@effect/platform-bun/BunRuntime';
 import { databaseConfig } from '@db/database-config';
 import { stripeConfig } from '@server/config/stripe-config';
+import consola from 'consola';
 import { Effect, Option, Redacted } from 'effect';
 
 import { createDatabaseClient } from '../src/db/database-client';


### PR DESCRIPTION
## Purpose

Unblock repeated Scaleway staging deployments after the database has already been initialized.

## Root cause and fix

The initialized no-op path in helpers/database.ts called consola.info without importing consola. The first initialization succeeded, but every later seed-staging deployment exited with ReferenceError. Import the existing logger and document the patch release.

## Runtime and schema impact

- No schema change.
- No UI change.
- Repeated staging initialization now exits successfully without modifying existing data.

## Local validation

- Compiled seed-staging artifact: initialized no-op passed twice
- release:validate
- infra:check, including Terraform validation and Trivy configuration scan
- format:check and lint
- Server unit: 1,436 passed
- App unit: 799 passed
- build:app
- PostgreSQL integration: 55 passed
- Playwright baseline: 150 passed
- Playwright docs: 52 passed
- Provider suite: 11 passed
- Live ESNcard: 27 focused unit and 9 Playwright tests passed
- Linux/amd64 image security: 152,125,951 bytes and zero vulnerability findings

Every collected test completed with zero skips, todos, fixmes, expected failures, retries, flakes, interruptions, or focused-test leakage.

- `main` <!-- branch-stack -->
  - **fix: keep staging initialization idempotent** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeated staging deployments so database initialization remains idempotent when the database has already been initialized.
  * Ensured initialization progress logging works reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->