### PR TITLE
fix: keep Scaleway SSR readiness local

### DIFF
--- a/.changeset/fix-scaleway-ssr-readiness.md
+++ b/.changeset/fix-scaleway-ssr-readiness.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Keep Scaleway SSR readiness checks on the container-local RPC path and bound deployment smoke probes.

--- a/.github/workflows/scaleway-production.yml
+++ b/.github/workflows/scaleway-production.yml
@@ -373,24 +373,26 @@ jobs:
           DIGEST: ${{ steps.image.outputs.digest }}
           REVISION: ${{ steps.staging.outputs.revision }}
         run: |
-          health_body="$(curl --fail --silent --show-error https://alpha.evorto.app/healthz)"
+          curl_args=(--connect-timeout 5 --max-time 20 --silent --show-error)
+
+          health_body="$(curl "${curl_args[@]}" --fail https://alpha.evorto.app/healthz)"
           jq --exit-status '.status == "ok"' <<<"${health_body}" >/dev/null
-          ready_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' https://alpha.evorto.app/readyz)"
+          ready_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' https://alpha.evorto.app/readyz)"
           test "${ready_status}" = "204"
-          version_body="$(curl --fail --silent --show-error https://alpha.evorto.app/version)"
+          version_body="$(curl "${curl_args[@]}" --fail https://alpha.evorto.app/version)"
           jq --exit-status \
             --arg revision "${REVISION}" \
             --arg digest "${DIGEST}" \
             '.environment == "production" and .revision == $revision and .imageDigest == $digest' \
             <<<"${version_body}" >/dev/null
-          curl --fail --silent --show-error \
+          curl "${curl_args[@]}" --fail \
             --header 'X-Forwarded-Host: attacker.invalid' \
             https://alpha.evorto.app/ \
             | grep --quiet '<app-root'
-          login_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' https://alpha.evorto.app/login)"
+          login_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' https://alpha.evorto.app/login)"
           [[ "${login_status}" =~ ^30[12378]$ ]]
           generated_endpoint="$(jq --raw-output .containers.web.endpoint deployment/platform.json)"
-          generated_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "${generated_endpoint}")"
+          generated_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' "${generated_endpoint}")"
           test "${generated_status}" = "404"
 
       - name: Write append-only production deployment manifest

--- a/.github/workflows/scaleway-staging-reset.yml
+++ b/.github/workflows/scaleway-staging-reset.yml
@@ -121,11 +121,12 @@ jobs:
 
       - name: Verify the restored staging application
         run: |
+          curl_args=(--connect-timeout 5 --max-time 20 --silent --show-error)
           expected_revision="$(jq --raw-output .revision reset-evidence/deployment.json)"
           expected_digest="$(jq --raw-output .digest reset-evidence/deployment.json)"
-          ready_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' https://staging.evorto.app/readyz)"
+          ready_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' https://staging.evorto.app/readyz)"
           test "${ready_status}" = "204"
-          version_body="$(curl --fail --silent --show-error https://staging.evorto.app/version)"
+          version_body="$(curl "${curl_args[@]}" --fail https://staging.evorto.app/version)"
           jq --exit-status \
             --arg revision "${expected_revision}" \
             --arg digest "${expected_digest}" \

--- a/.github/workflows/scaleway-staging.yml
+++ b/.github/workflows/scaleway-staging.yml
@@ -465,20 +465,22 @@ jobs:
           DIGEST: ${{ steps.image.outputs.digest }}
           REVISION: ${{ needs.resolve-revision.outputs.revision }}
         run: |
-          health_body="$(curl --fail --silent --show-error https://staging.evorto.app/healthz)"
+          curl_args=(--connect-timeout 5 --max-time 20 --silent --show-error)
+
+          health_body="$(curl "${curl_args[@]}" --fail https://staging.evorto.app/healthz)"
           jq --exit-status '.status == "ok"' <<<"${health_body}" >/dev/null
 
-          ready_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' https://staging.evorto.app/readyz)"
+          ready_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' https://staging.evorto.app/readyz)"
           test "${ready_status}" = "204"
 
-          version_body="$(curl --fail --silent --show-error https://staging.evorto.app/version)"
+          version_body="$(curl "${curl_args[@]}" --fail https://staging.evorto.app/version)"
           jq --exit-status \
             --arg revision "${REVISION}" \
             --arg digest "${DIGEST}" \
             '.environment == "staging" and .revision == $revision and .imageDigest == $digest' \
             <<<"${version_body}" >/dev/null
 
-          curl --fail --silent --show-error \
+          curl "${curl_args[@]}" --fail \
             --dump-header deployment/home.headers \
             --header 'X-Forwarded-Host: attacker.invalid' \
             --output deployment/home.html \
@@ -486,14 +488,14 @@ jobs:
           grep --ignore-case --quiet '^x-robots-tag: noindex, nofollow' deployment/home.headers
           grep --quiet '<app-root' deployment/home.html
 
-          login_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' https://staging.evorto.app/login)"
+          login_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' https://staging.evorto.app/login)"
           [[ "${login_status}" =~ ^30[12378]$ ]]
 
-          rpc_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --header 'Content-Type: application/json' --data '{}' https://staging.evorto.app/rpc)"
+          rpc_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' --header 'Content-Type: application/json' --data '{}' https://staging.evorto.app/rpc)"
           [[ "${rpc_status}" =~ ^4[0-9]{2}$ ]]
 
           generated_endpoint="$(jq --raw-output .containers.web.endpoint deployment/platform.json)"
-          generated_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "${generated_endpoint}")"
+          generated_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' "${generated_endpoint}")"
           test "${generated_status}" = "404"
 
       - name: Write append-only successful deployment manifest

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -237,6 +237,9 @@ describe('Scaleway hosting source', () => {
     expect(web).toContain('max_scale              = 3');
     expect(web.match(/path = "\/readyz"/gu)).toHaveLength(1);
     expect(web.match(/path = "\/healthz"/gu)).toHaveLength(1);
+    expect(containers).toContain(
+      'SSR_RPC_ORIGIN        = "http://127.0.0.1:4200"',
+    );
     for (const privateRole of [worker, ops]) {
       expect(privateRole).toContain('privacy                = "private"');
       expect(privateRole).toContain('min_scale              = 0');
@@ -469,6 +472,9 @@ describe('Scaleway hosting source', () => {
       staging.indexOf('touch deployment/traffic-changed'),
     );
     expect(staging).toContain('Roll back traffic roles to the previous digest');
+    expect(staging).toContain(
+      'curl_args=(--connect-timeout 5 --max-time 20 --silent --show-error)',
+    );
 
     expect(production).not.toContain('docker build ');
     expect(production).not.toContain('docker buildx build ');
@@ -480,6 +486,9 @@ describe('Scaleway hosting source', () => {
     expect(production).toContain('sourceStagingManifestKey:');
     expect(production).toContain(
       'Roll back production traffic roles on failure',
+    );
+    expect(production).toContain(
+      'curl_args=(--connect-timeout 5 --max-time 20 --silent --show-error)',
     );
     expect(deployRole).toContain('APP_BOOTSTRAP: "false"');
     expect(deployRole).toContain(
@@ -505,6 +514,9 @@ describe('Scaleway hosting source', () => {
     );
     expect(reset).toContain('environment: scaleway-staging-reset');
     expect(reset).toContain('/internal/ops/seed-staging');
+    expect(reset).toContain(
+      'curl_args=(--connect-timeout 5 --max-time 20 --silent --show-error)',
+    );
     expect(runtimeVerifier).toContain('maximum_size_bytes=1000000000');
     expect(runtimeVerifier).toContain("'api\\.resend\\.com|cloudflare[_-]r2");
     expect(runtimeVerifier).toContain('|@sentry|@neondatabase|resend)');

--- a/infrastructure/scaleway/modules/environment/containers.tf
+++ b/infrastructure/scaleway/modules/environment/containers.tf
@@ -24,6 +24,7 @@ locals {
     APP_ROLE              = "web"
     BASE_URL              = "https://${var.hostname}"
     READINESS_TENANT_HOST = var.hostname
+    SSR_RPC_ORIGIN        = "http://127.0.0.1:4200"
     TRUST_PLATFORM_PROXY  = "true"
     WORKER_TRIGGER_MODE   = "http"
   })

--- a/tests/README.md
+++ b/tests/README.md
@@ -240,6 +240,9 @@ credentials must not be printed or committed.
   container instead of calling the host-mapped port. Generated and container
   runtime config explicitly sets `NODE_ENV=development`, allowing tenant
   outbound links to retain the worktree-local `BASE_URL` port.
+- Scaleway web containers set `SSR_RPC_ORIGIN=http://127.0.0.1:4200` so their
+  readiness SSR check reaches RPC inside the candidate revision before the
+  public custom domain routes traffic to it.
 - Auth0 callback URLs are registered out-of-band. Worktree-local generated
   ports keep stacks isolated, but authenticated Browser/Playwright validation
   needs a callback URL Auth0 accepts. On this machine, run Docker-backed


### PR DESCRIPTION
## Purpose

Prevent Scaleway from rejecting candidate web revisions when the behavioral readiness SSR render calls RPC through the not-yet-routed public hostname.

## Scope

- configure web-role SSR RPC calls to use the container-local loopback endpoint
- bound staging, production, and reset smoke probes with connection and total timeouts
- add source-contract coverage and deployment documentation

## Runtime and schema impact

Runtime configuration only. No database schema or data changes.

## Verification

- format, lint, release metadata, Terraform validation/static scan
- 1,436 server tests and 799 application tests
- production application build
- 55 PostgreSQL integration tests
- Playwright: 150 baseline, 52 docs, 11 provider, 9 live ESNcard release tests
- Linux/amd64 image: 152,125,951 bytes, zero vulnerability/secret findings
- zero skips, todos, expected failures, retries, flakes, interruptions, or focused tests

## UI evidence

Not applicable; this changes deployment/runtime configuration only.

- `main` <!-- branch-stack -->
  - **fix: keep Scaleway SSR readiness local** :point\_left:
