### PR TITLE
fix: propagate tenant for anonymous SSR

### DIFF
--- a/.changeset/propagate-anonymous-ssr-tenant.md
+++ b/.changeset/propagate-anonymous-ssr-tenant.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Propagate the resolved tenant through trusted internal RPC requests during anonymous server-side rendering.

--- a/src/app/core/auth-token.interceptor.spec.ts
+++ b/src/app/core/auth-token.interceptor.spec.ts
@@ -32,7 +32,7 @@ class ServerRequest extends Request {
 
   constructor(
     url: string,
-    cookieHeader = sessionCookies,
+    cookieHeader: null | string = sessionCookies,
     headers?: HeadersInit,
   ) {
     super('http://localhost');
@@ -43,7 +43,7 @@ class ServerRequest extends Request {
 
 class ServerRequestHeaders extends Headers {
   constructor(
-    private readonly cookieHeader: string,
+    private readonly cookieHeader: null | string,
     init?: HeadersInit,
   ) {
     super(init);
@@ -124,6 +124,27 @@ describe('authTokenInterceptor', () => {
       httpTesting.verify();
     },
   );
+
+  it('adds the trusted tenant cookie to an internal SSR RPC request without incoming cookies', () => {
+    process.env['SSR_RPC_ORIGIN'] = 'http://127.0.0.1:4200';
+    const anonymousRequest = new ServerRequest(
+      'https://tenant.example.com/events',
+      null,
+    );
+    const { http, httpTesting } = configureServerHttp(anonymousRequest);
+    const rpcUrl = `${resolveServerRpcOrigin(anonymousRequest)}/rpc`;
+
+    http.post(rpcUrl, {}).subscribe();
+
+    const rpcRequest = httpTesting.expectOne(rpcUrl);
+    expect(rpcRequest.request.headers.get('Cookie')).toBe(
+      `evorto-tenant=${trustedTenantDomain}`,
+    );
+    expect(rpcRequest.request.headers.get('x-forwarded-from')).toBe('ssr');
+    expect(rpcRequest.request.headers.get('x-tenant-id')).toBe('tenant-1');
+    rpcRequest.flush({});
+    httpTesting.verify();
+  });
 
   it.each([
     {

--- a/src/app/core/auth-token.interceptor.ts
+++ b/src/app/core/auth-token.interceptor.ts
@@ -28,22 +28,24 @@ const isInternalServerRpcRequest = (outgoingUrl: string): boolean => {
 const tenantCookieName = 'evorto-tenant';
 
 const withTrustedTenantCookie = (
-  cookieHeader: string,
+  cookieHeader: null | string | undefined,
   trustedTenantDomain: string,
 ): string => {
   const cookies = cookieHeader
-    .split(';')
-    .map((cookie) => cookie.trim())
-    .filter((cookie) => {
-      if (!cookie) {
-        return false;
-      }
+    ? cookieHeader
+        .split(';')
+        .map((cookie) => cookie.trim())
+        .filter((cookie) => {
+          if (!cookie) {
+            return false;
+          }
 
-      const equalsIndex = cookie.indexOf('=');
-      const cookieName =
-        equalsIndex === -1 ? cookie : cookie.slice(0, equalsIndex).trim();
-      return cookieName !== tenantCookieName;
-    });
+          const equalsIndex = cookie.indexOf('=');
+          const cookieName =
+            equalsIndex === -1 ? cookie : cookie.slice(0, equalsIndex).trim();
+          return cookieName !== tenantCookieName;
+        })
+    : [];
 
   return [...cookies, `${tenantCookieName}=${trustedTenantDomain}`].join('; ');
 };
@@ -64,13 +66,9 @@ export const authTokenInterceptor: HttpInterceptorFn = (request, next) => {
       const cookieHeader = incomingRequest?.headers.get('cookie');
 
       // Auth0 sessions can span multiple encrypted, chunked cookies. Preserve
-      // those chunks only for this app's internal RPC URL, while replacing the
-      // tenant cookie with the trusted request-context tenant.
-      if (
-        incomingRequest &&
-        cookieHeader &&
-        isInternalServerRpcRequest(request.url)
-      ) {
+      // those chunks when present, and always attach the trusted request-context
+      // tenant to this app's exact internal RPC URL for anonymous SSR requests.
+      if (incomingRequest && isInternalServerRpcRequest(request.url)) {
         request = request.clone({
           setHeaders: {
             Cookie: withTrustedTenantCookie(


### PR DESCRIPTION
## Purpose

Fix Scaleway web readiness for anonymous server-side rendering. The loopback RPC request now retains the tenant already resolved from the public request host even when the browser sent no cookies.

## Scope

- Attach the trusted tenant cookie and SSR identity headers only to the exact configured internal RPC origin and `/rpc` path.
- Preserve existing Auth0 session cookie chunks when present.
- Cover anonymous internal RPC propagation with a regression test.

## Runtime and schema impact

Runtime-only SSR request propagation change. No database schema or infrastructure changes.

## Local verification

- Knope/change-file validation, formatting, lint, and Terraform validation/static scan: passed
- Server unit: 1,436 passed
- App unit: 800 passed
- Build: passed
- PostgreSQL integration: 55 passed
- Playwright baseline: 150 passed
- Playwright docs: 52 passed
- Auth0/Google Maps provider suite: 11 passed
- Live ESNcard release suite: 27 focused unit plus 9 Playwright passed
- Rebuilt local `/readyz`: HTTP 204
- Linux/amd64 image security/size gate: passed at 152,125,911 bytes with zero findings
- Zero skips, todos, expected failures, retries, flakes, interruptions, or focused-test leakage in canonical gates.

* `main` <!-- branch-stack -->
  - **fix: propagate tenant for anonymous SSR** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed anonymous server-rendered requests without cookies so internal requests still receive the correct trusted tenant context.
  * Preserved existing cookies when present while avoiding reliance on missing cookie data.
  * Ensured trusted internal requests include the appropriate tenant and forwarding information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->