### PR TITLE
fix: align Scaleway smoke checks with runtime

### DIFF
--- a/.changeset/align-scaleway-smoke-contract.md
+++ b/.changeset/align-scaleway-smoke-contract.md
@@ -1,0 +1,6 @@
+---
+default: patch
+---
+
+Align Scaleway release smoke checks with the rendered events route and the
+Effect RPC protocol error envelope.

--- a/.github/workflows/scaleway-production.yml
+++ b/.github/workflows/scaleway-production.yml
@@ -387,7 +387,7 @@ jobs:
             <<<"${version_body}" >/dev/null
           curl "${curl_args[@]}" --fail \
             --header 'X-Forwarded-Host: attacker.invalid' \
-            https://alpha.evorto.app/ \
+            https://alpha.evorto.app/events \
             | grep --quiet '<app-root'
           login_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' https://alpha.evorto.app/login)"
           [[ "${login_status}" =~ ^30[12378]$ ]]

--- a/.github/workflows/scaleway-staging.yml
+++ b/.github/workflows/scaleway-staging.yml
@@ -481,18 +481,23 @@ jobs:
             <<<"${version_body}" >/dev/null
 
           curl "${curl_args[@]}" --fail \
-            --dump-header deployment/home.headers \
+            --dump-header deployment/events.headers \
             --header 'X-Forwarded-Host: attacker.invalid' \
-            --output deployment/home.html \
-            https://staging.evorto.app/
-          grep --ignore-case --quiet '^x-robots-tag: noindex, nofollow' deployment/home.headers
-          grep --quiet '<app-root' deployment/home.html
+            --output deployment/events.html \
+            https://staging.evorto.app/events
+          grep --ignore-case --quiet '^x-robots-tag: noindex, nofollow' deployment/events.headers
+          grep --quiet '<app-root' deployment/events.html
 
           login_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' https://staging.evorto.app/login)"
           [[ "${login_status}" =~ ^30[12378]$ ]]
 
-          rpc_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' --header 'Content-Type: application/json' --data '{}' https://staging.evorto.app/rpc)"
-          [[ "${rpc_status}" =~ ^4[0-9]{2}$ ]]
+          rpc_body="$(curl "${curl_args[@]}" --fail --header 'Content-Type: application/json' --data '{}' https://staging.evorto.app/rpc)"
+          jq --exit-status \
+            'type == "array"
+              and length == 1
+              and .[0]._tag == "Defect"
+              and (.[0].defect | type == "string")' \
+            <<<"${rpc_body}" >/dev/null
 
           generated_endpoint="$(jq --raw-output .containers.web.endpoint deployment/platform.json)"
           generated_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' "${generated_endpoint}")"

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -454,6 +454,25 @@ describe('Scaleway hosting source', () => {
     }
   });
 
+  it('smokes rendered event routes and the Effect RPC protocol contract', () => {
+    const stagingSmoke = between(
+      source('.github/workflows/scaleway-staging.yml'),
+      '- name: Verify staging revision, readiness, tenancy, Auth0, RPC, and noindex',
+      '- name: Write append-only successful deployment manifest',
+    );
+    const productionSmoke = between(
+      source('.github/workflows/scaleway-production.yml'),
+      '- name: Smoke the promoted production release',
+      '- name: Write append-only production deployment manifest',
+    );
+
+    expect(stagingSmoke).toContain('https://staging.evorto.app/events');
+    expect(stagingSmoke).toContain('rpc_body="$(curl');
+    expect(stagingSmoke).toContain('.[0]._tag == "Defect"');
+    expect(stagingSmoke).not.toContain('rpc_status=');
+    expect(productionSmoke).toContain('https://alpha.evorto.app/events');
+  });
+
   it('builds once, records immutable evidence, and promotes the exact OCI digest', () => {
     const staging = source('.github/workflows/scaleway-staging.yml');
     const production = source('.github/workflows/scaleway-production.yml');


### PR DESCRIPTION
Purpose

Make the Scaleway release smoke gate validate the application contract that is actually deployed.

Scope

- probe the rendered /events route instead of the redirecting root route
- validate the Effect RPC Defect envelope returned for malformed protocol input
- keep production smoke aligned with the same rendered route
- add a source-level regression and patch change file

Runtime and schema impact

Workflow-only. No runtime image, schema, or production enablement changes.

Validation

- release metadata, formatting, lint, Terraform validation and static scan
- 1,437 server tests and 800 app tests
- production build and 55 PostgreSQL integration tests
- Playwright: 150 baseline, 52 docs, clean 11-provider suite
- live ESNcard: 27 focused unit tests and 9 browser tests
- Linux/amd64 image: 152,125,911 bytes, zero vulnerability or secret findings
- corrected smoke commands passed against live staging

* `main` <!-- branch-stack -->
  - **fix: align Scaleway smoke checks with runtime** :point\_left:
