### PR TITLE
fix: redirect anonymous SSR deep links to login

### DIFF
--- a/.changeset/fix-anonymous-auth-deep-links.md
+++ b/.changeset/fix-anonymous-auth-deep-links.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Fix anonymous authenticated-route deep links
+
+Redirect first-time anonymous visitors from protected staging links into Auth0
+instead of returning the unknown-organization page when Angular cancels its
+initial server-side navigation.

--- a/src/app/core/guards/auth.guard.spec.ts
+++ b/src/app/core/guards/auth.guard.spec.ts
@@ -1,0 +1,84 @@
+import { REQUEST, REQUEST_CONTEXT, RESPONSE_INIT } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  provideRouter,
+  RedirectCommand,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { describe, expect, it } from 'vitest';
+
+import { authGuard } from './auth.guard';
+
+const route = {} as ActivatedRouteSnapshot;
+
+const configureServerGuard = ({
+  isAuthenticated,
+  request,
+  response,
+}: {
+  isAuthenticated: boolean;
+  request: Request;
+  response: ResponseInit;
+}) =>
+  TestBed.configureTestingModule({
+    providers: [
+      provideRouter([]),
+      { provide: REQUEST, useValue: request },
+      {
+        provide: REQUEST_CONTEXT,
+        useValue: { authentication: { isAuthenticated } },
+      },
+      { provide: RESPONSE_INIT, useValue: response },
+    ],
+  });
+
+describe('authGuard', () => {
+  it('turns an anonymous SSR deep link into a same-origin forward-login redirect', async () => {
+    const request = new Request(
+      'https://tenant.example/registration-transfers/private%2Fcredential?from=email&label=two%20words',
+    );
+    const response: ResponseInit = {};
+    configureServerGuard({ isAuthenticated: false, request, response });
+
+    const result = await TestBed.runInInjectionContext(() =>
+      authGuard(route, {
+        url: '/registration-transfers/private%2Fcredential?from=email&label=two%20words',
+      } as RouterStateSnapshot),
+    );
+
+    expect(result).toBeInstanceOf(RedirectCommand);
+    if (!(result instanceof RedirectCommand)) {
+      throw new TypeError(
+        'Expected the SSR guard to return a redirect command',
+      );
+    }
+
+    const router = TestBed.inject(Router);
+    expect(router.serializeUrl(result.redirectTo)).toBe('/404');
+    const browserUrl = result.navigationBehaviorOptions?.browserUrl;
+    expect(browserUrl).toBeInstanceOf(UrlTree);
+    if (!(browserUrl instanceof UrlTree)) {
+      throw new TypeError('Expected a parsed same-origin browser redirect URL');
+    }
+    expect(router.serializeUrl(browserUrl)).toBe(
+      '/forward-login?redirectUrl=%2Fregistration-transfers%2Fprivate%252Fcredential%3Ffrom%3Demail%26label%3Dtwo%2520words',
+    );
+    expect(response.status).toBe(303);
+  });
+
+  it('allows an authenticated SSR request without changing its response', async () => {
+    const request = new Request('https://tenant.example/profile');
+    const response: ResponseInit = {};
+    configureServerGuard({ isAuthenticated: true, request, response });
+
+    expect(
+      await TestBed.runInInjectionContext(() =>
+        authGuard(route, { url: '/profile' } as RouterStateSnapshot),
+      ),
+    ).toBe(true);
+    expect(response.status).toBeUndefined();
+  });
+});

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,5 +1,5 @@
 import { inject, REQUEST, REQUEST_CONTEXT, RESPONSE_INIT } from '@angular/core';
-import { CanActivateFn } from '@angular/router';
+import { CanActivateFn, RedirectCommand, Router } from '@angular/router';
 import {
   forwardLoginPath,
   relativeRedirectPathFromRequest,
@@ -8,24 +8,38 @@ import {
 import { type Context } from '../../../types/custom/context';
 import { AppRpc } from '../effect-rpc-angular-client';
 
+const ssrRedirectCompletionPath = '/404';
+
 export const authGuard: CanActivateFn = async (_, state) => {
   const context = inject(REQUEST_CONTEXT) as Context | undefined;
-  const rpc = AppRpc.injectClient();
-  const response = inject(RESPONSE_INIT);
-  const request = inject(REQUEST);
-  if (!context) {
-    const isAuthenticated = await rpc.config.isAuthenticated.call();
-    if (!isAuthenticated) {
-      globalThis.location.assign(forwardLoginPath(state.url));
-      return false;
+  if (context) {
+    if (context.authentication.isAuthenticated) {
+      return true;
     }
-  } else if (!context.authentication.isAuthenticated) {
+
+    const response = inject(RESPONSE_INIT);
+    const request = inject(REQUEST);
     if (response && request) {
       response.status = 303;
-      response.headers = {
-        Location: forwardLoginPath(relativeRedirectPathFromRequest(request)),
-      };
+      const router = inject(Router);
+      const forwardPath = router.parseUrl(
+        forwardLoginPath(relativeRedirectPathFromRequest(request)),
+      );
+
+      // Angular SSR returns no response when a guard simply rejects its
+      // initial navigation. Complete a safe internal navigation while keeping
+      // the server login endpoint as the browser-facing redirect target.
+      return new RedirectCommand(router.parseUrl(ssrRedirectCompletionPath), {
+        browserUrl: forwardPath,
+      });
     }
+    return false;
+  }
+
+  const rpc = AppRpc.injectClient();
+  const isAuthenticated = await rpc.config.isAuthenticated.call();
+  if (!isAuthenticated) {
+    globalThis.location.assign(forwardLoginPath(state.url));
     return false;
   }
 

--- a/tests/specs/smoke/load-application.test.ts
+++ b/tests/specs/smoke/load-application.test.ts
@@ -9,3 +9,18 @@ test('navigate to events list', async ({ page }) => {
   await page.getByRole('link', { name: 'Events' }).click();
   await expect(page).toHaveURL(/\/events/);
 });
+
+test('redirect anonymous protected deep links to login during SSR', async ({
+  page,
+}) => {
+  const response = await page.request.get(
+    '/registration-transfers/example-token?from=email',
+    { maxRedirects: 0 },
+  );
+
+  expect(response.status()).toBe(303);
+  expect(response.headers()['location']).toBe(
+    '/forward-login?redirectUrl=%2Fregistration-transfers%2Fexample-token%3Ffrom%3Demail',
+  );
+  expect(await response.text()).not.toContain('Unknown tenant');
+});


### PR DESCRIPTION
## Purpose

Fix anonymous protected-route deep links returning the unknown-organization page instead of entering Auth0 during Angular SSR.

## Scope

- Complete anonymous SSR guard navigation with an Angular RedirectCommand while preserving the same-origin forward-login URL.
- Keep authenticated SSR and browser guard behavior unchanged.
- Add focused guard coverage and a real Playwright HTTP regression for transfer claim links.

## Schema and runtime impact

- No schema changes.
- Web SSR behavior only; worker and ops roles are unchanged.

## Local verification

- Release metadata validation
- Terraform validation and static scan: 0 misconfigurations
- Format and lint
- Server unit: 1437 passed
- App unit: 802 passed
- PostgreSQL integration: 55 passed
- Production build
- Playwright baseline: 151 passed
- Playwright docs: 52 passed
- Protected provider suite: 11 passed
- Live ESNcard provider unit: 27 passed
- Live ESNcard browser certification: 9 passed
- Linux/amd64 image security and size gate: 152127640 bytes, 0 vulnerabilities

All collected tests completed with zero skips, todos, fixmes, expected failures, retries, flakes, or interruptions.

- `main` <!-- branch-stack -->
  - **fix: redirect anonymous SSR deep links to login** :point\_left:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous visitors opening protected deep links are now redirected to sign-in instead of seeing an “Unknown tenant” page.
  * Original deep-link destinations are preserved after authentication.
  * Improved server-side handling for unauthenticated route navigation.

* **Tests**
  * Added coverage for anonymous and authenticated server-side navigation scenarios.
  * Added smoke testing to verify correct redirects and page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->