### PR TITLE
perf: reduce custom trace costs

### DIFF
--- a/.changeset/reduce-custom-trace-costs.md
+++ b/.changeset/reduce-custom-trace-costs.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+# Reduce custom trace costs
+
+- sample ten percent of hosted application traces while keeping complete parent-based traces,
+- suppress health, readiness, and version traces while preserving their native logs and metrics,
+- retain custom Cockpit traces for the included seven-day window,
+- allow a staging workflow dispatch to restore 100% sampling until the next reconciliation,
+- wait for organization-settings hydration before exercising the live Google Maps documentation flow,
+- use the ESNcard provider host that serves the validation API without a Cloudflare 403,
+- and pin the production dependency graph to the security-fixed PostCSS release required by the runtime image gate.

--- a/.github/workflows/scaleway-staging.yml
+++ b/.github/workflows/scaleway-staging.yml
@@ -7,6 +7,11 @@ on:
         description: Full main SHA; empty selects the current main tip
         required: false
         type: string
+      full_trace_debugging:
+        description: Temporarily sample all application traces until the next reconciliation
+        required: false
+        default: false
+        type: boolean
   workflow_run:
     workflows: [PR Quality, E2E Baseline]
     branches: [main]
@@ -67,6 +72,7 @@ jobs:
       SCW_DEFAULT_ORGANIZATION_ID: ${{ vars.SCW_ORGANIZATION_ID }}
       SCW_DEFAULT_REGION: fr-par
       SCW_DEFAULT_ZONE: fr-par-1
+      TRACE_SAMPLING_RATIO_OVERRIDE: ${{ inputs.full_trace_debugging && '1' || '' }}
       TF_IN_AUTOMATION: "true"
       TF_INPUT: "false"
       TF_VAR_alert_email: ${{ vars.ALERT_EMAIL }}

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
         "eslint-plugin-unused-imports": "^4.4.1",
         "happy-dom": "^20.10.6",
         "playwright-ng-schematics": "22.0.1",
-        "postcss": "^8.5.16",
+        "postcss": "^8.5.18",
         "prettier": "^3.9.3",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^4.3.2",
@@ -116,6 +116,9 @@
   },
   "patchedDependencies": {
     "@material/material-color-utilities@0.4.0": "patches/@material-material-color-utilities-npm-0.4.0-9d48ca70b8.patch",
+  },
+  "overrides": {
+    "postcss": "8.5.18",
   },
   "packages": {
     "@algolia/abtesting": ["@algolia/abtesting@1.18.0", "", { "dependencies": { "@algolia/client-common": "5.52.0", "@algolia/requester-browser-xhr": "5.52.0", "@algolia/requester-fetch": "5.52.0", "@algolia/requester-node-http": "5.52.0" } }, "sha512-8siuLG+FIns1AjZ/g2SDVwHz9S+ObacDQISEJvS8XsNei1zl3FXqfqQrBpmrG7ACWCyesXHbicMJtvRbg00FEw=="],
@@ -1490,7 +1493,7 @@
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
     "postcss-media-query-parser": ["postcss-media-query-parser@0.2.3", "", {}, "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="],
 
@@ -2052,8 +2055,6 @@
 
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
-    "sanitize-html/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
-
     "sass/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "skia-canvas/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -2247,8 +2248,6 @@
     "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
-
-    "sanitize-html/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "sass/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/helpers/testing/esncard-release-source.spec.ts
+++ b/helpers/testing/esncard-release-source.spec.ts
@@ -411,7 +411,7 @@ describe('production provider certification source', () => {
       /requires no API key, OAuth client,\s+or other ESNcard provider credential/u,
     );
     expect(providerSource).toContain(
-      'https://esncard.org/services/1.0/card.json?code=',
+      'https://www.esncard.org/services/1.0/card.json?code=',
     );
     expect(providerSource).not.toContain('Authorization');
   });

--- a/helpers/testing/scaleway-deploy-role.spec.ts
+++ b/helpers/testing/scaleway-deploy-role.spec.ts
@@ -16,7 +16,10 @@ afterEach(() => {
   }
 });
 
-const runDeployRole = (containerResourceId: string): string[] => {
+const runDeployRole = (
+  containerResourceId: string,
+  traceSamplingRatioOverride?: string,
+): string[] => {
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'evorto-scaleway-deploy-role-'),
   );
@@ -36,6 +39,7 @@ const runDeployRole = (containerResourceId: string): string[] => {
           environment_variables: {
             APP_ENVIRONMENT: 'staging',
             APP_ROLE: 'ops',
+            TRACE_SAMPLING_RATIO: '0.1',
           },
           id: containerResourceId,
         },
@@ -52,6 +56,9 @@ printf '%s\n' "$@" > "${'$'}{FAKE_SCW_LOG:?}"
   );
   fs.chmodSync(fakeCliPath, 0o700);
 
+  const environment = { ...process.env };
+  delete environment.TRACE_SAMPLING_RATIO_OVERRIDE;
+
   execFileSync(
     deployRoleScript,
     [
@@ -64,10 +71,13 @@ printf '%s\n' "$@" > "${'$'}{FAKE_SCW_LOG:?}"
     ],
     {
       env: {
-        ...process.env,
+        ...environment,
         FAKE_SCW_LOG: commandLogPath,
         SCW_CLI: fakeCliPath,
         SCW_DEFAULT_REGION: 'fr-par',
+        ...(traceSamplingRatioOverride === undefined
+          ? {}
+          : { TRACE_SAMPLING_RATIO_OVERRIDE: traceSamplingRatioOverride }),
       },
       stdio: 'pipe',
     },
@@ -91,6 +101,24 @@ describe('Scaleway role deployment', () => {
       const arguments_ = runDeployRole(containerResourceId);
 
       expect(arguments_).not.toContain(`fr-par/${containerId}`);
+      expect(arguments_).toContain(
+        'environment-variables.TRACE_SAMPLING_RATIO=0.1',
+      );
     },
   );
+
+  it('temporarily overrides the Terraform-owned trace sampling ratio', () => {
+    const arguments_ = runDeployRole(containerId, '1');
+
+    expect(arguments_).toContain(
+      'environment-variables.TRACE_SAMPLING_RATIO=1',
+    );
+    expect(arguments_).not.toContain(
+      'environment-variables.TRACE_SAMPLING_RATIO=0.1',
+    );
+  });
+
+  it('rejects an invalid trace sampling override before deployment', () => {
+    expect(() => runDeployRole(containerId, '1.1')).toThrow();
+  });
 });

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -430,6 +430,12 @@ describe('Scaleway hosting source', () => {
   });
 
   it('uses native container telemetry, custom traces, all provider alerts, and release-aware logs', () => {
+    const containers = source(
+      'infrastructure/scaleway/modules/environment/containers.tf',
+    );
+    const moduleVariables = source(
+      'infrastructure/scaleway/modules/environment/variables.tf',
+    );
     const observability = source(
       'infrastructure/scaleway/modules/environment/observability.tf',
     );
@@ -439,6 +445,10 @@ describe('Scaleway hosting source', () => {
     expect(observability).toContain('type           = "traces"');
     expect(observability).not.toContain('type           = "logs"');
     expect(observability).not.toContain('type           = "metrics"');
+    expect(containers).toMatch(/TRACE_SAMPLING_RATIO\s+= "0\.1"/u);
+    expect(moduleVariables).toMatch(
+      /variable "cockpit_trace_retention_days" \{[\s\S]*?default\s+= 7/u,
+    );
     expect(observability).toContain(
       'preconfigured_alert_ids = toset(data.scaleway_cockpit_preconfigured_alert.available.alerts[*].preconfigured_rule_id)',
     );
@@ -480,6 +490,10 @@ describe('Scaleway hosting source', () => {
 
     expect(staging).toContain('workflow_run:');
     expect(staging).toContain('cron: "*/30 * * * *"');
+    expect(staging).toContain('full_trace_debugging:');
+    expect(staging).toContain(
+      "TRACE_SAMPLING_RATIO_OVERRIDE: ${{ inputs.full_trace_debugging && '1' || '' }}",
+    );
     expect(staging).toContain('cancel-in-progress: false');
     expect(staging).toContain('ops/scaleway/require-release-gates.sh');
     expect(staging).toContain('--platform linux/amd64');
@@ -510,6 +524,10 @@ describe('Scaleway hosting source', () => {
       'curl_args=(--connect-timeout 5 --max-time 20 --silent --show-error)',
     );
     expect(deployRole).toContain('APP_BOOTSTRAP: "false"');
+    expect(deployRole).toContain('TRACE_SAMPLING_RATIO_OVERRIDE');
+    expect(deployRole).toContain(
+      'TRACE_SAMPLING_RATIO: $trace_sampling_ratio_override',
+    );
     expect(deployRole).toContain(
       'container_id="${container_resource_id#"${region}/"}"',
     );

--- a/infrastructure/scaleway/README.md
+++ b/infrastructure/scaleway/README.md
@@ -180,6 +180,18 @@ secret bundle. Without both `COCKPIT_TRACES_ENDPOINT` and
 `COCKPIT_TRACES_TOKEN`, the runtime intentionally starts without a trace
 exporter.
 
+Hosted roles normally sample 10% of complete parent-based traces and retain
+them for the included seven-day Cockpit window. Health, readiness, and version
+requests are never traced. Local development keeps 100% sampling by default.
+`TRACE_SAMPLING_RATIO` accepts a value from `0` through `1` when an explicit
+runtime override is needed.
+
+For a short staging investigation, manually dispatch `Deploy Scaleway staging`
+with `full_trace_debugging` enabled. That deployment samples 100% of application
+traces for all three roles. The next successful automatic or scheduled
+reconciliation restores the Terraform-owned 10% value, so the debug setting
+cannot silently become the long-term default.
+
 ## DNS and Transactional Email
 
 Keep Cloudflare as the authoritative DNS provider. Terraform manages only the

--- a/infrastructure/scaleway/modules/environment/containers.tf
+++ b/infrastructure/scaleway/modules/environment/containers.tf
@@ -14,6 +14,7 @@ locals {
     DATABASE_TLS_REQUIRED            = "true"
     NODE_ENV                         = "production"
     SERVER_LOG_LEVEL                 = "info"
+    TRACE_SAMPLING_RATIO             = "0.1"
   }
   object_storage_environment_variables = {
     S3_BUCKET   = scaleway_object_bucket.application.name

--- a/infrastructure/scaleway/modules/environment/variables.tf
+++ b/infrastructure/scaleway/modules/environment/variables.tf
@@ -113,7 +113,7 @@ variable "web_min_scale" {
 
 variable "cockpit_trace_retention_days" {
   type    = number
-  default = 30
+  default = 7
 }
 
 variable "alert_email" {

--- a/ops/scaleway/deploy-role.sh
+++ b/ops/scaleway/deploy-role.sh
@@ -10,6 +10,7 @@ readonly image_digest="${5:?Pass the sha256 image digest}"
 readonly schema_hash="${6:?Pass the packaged schema sha256}"
 readonly scw_cli="${SCW_CLI:-scw}"
 readonly region="${SCW_DEFAULT_REGION:-fr-par}"
+readonly trace_sampling_ratio_override="${TRACE_SAMPLING_RATIO_OVERRIDE:-}"
 
 if [[ "${role}" != 'web' && "${role}" != 'worker' && "${role}" != 'ops' ]]; then
   echo "Unsupported application role: ${role}" >&2
@@ -25,6 +26,10 @@ if [[ ! "${image_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
 fi
 if [[ ! "${schema_hash}" =~ ^[0-9a-f]{64}$ ]]; then
   echo "The packaged schema hash must be a lowercase SHA-256" >&2
+  exit 1
+fi
+if [[ -n "${trace_sampling_ratio_override}" && ! "${trace_sampling_ratio_override}" =~ ^(0([.][0-9]+)?|1([.]0+)?)$ ]]; then
+  echo "TRACE_SAMPLING_RATIO_OVERRIDE must be between 0 and 1" >&2
   exit 1
 fi
 
@@ -50,13 +55,18 @@ jq \
   --arg revision "${revision}" \
   --arg image_digest "${image_digest}" \
   --arg schema_hash "${schema_hash}" \
+  --arg trace_sampling_ratio_override "${trace_sampling_ratio_override}" \
     '.containers[$role].environment_variables
     + {
         APP_BOOTSTRAP: "false",
         APP_REVISION: $revision,
         APP_IMAGE_DIGEST: $image_digest
       }
-    + if $role == "ops" then { APP_SCHEMA_HASH: $schema_hash } else {} end' \
+    + (if $role == "ops" then { APP_SCHEMA_HASH: $schema_hash } else {} end)
+    + (if $trace_sampling_ratio_override == ""
+       then {}
+       else { TRACE_SAMPLING_RATIO: $trace_sampling_ratio_override }
+       end)' \
   "${platform_output_file}" \
   >"${environment_file}"
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "eslint-plugin-unused-imports": "^4.4.1",
     "happy-dom": "^20.10.6",
     "playwright-ng-schematics": "22.0.1",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.18",
     "prettier": "^3.9.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.2",
@@ -163,6 +163,9 @@
   },
   "patchedDependencies": {
     "@material/material-color-utilities@0.4.0": "patches/@material-material-color-utilities-npm-0.4.0-9d48ca70b8.patch"
+  },
+  "overrides": {
+    "postcss": "8.5.18"
   },
   "packageManager": "bun@1.3.14"
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,10 @@ import {
 import * as BunFileSystem from '@effect/platform-bun/BunFileSystem';
 import * as BunHttpServer from '@effect/platform-bun/BunHttpServer';
 import * as BunRuntime from '@effect/platform-bun/BunRuntime';
+import {
+  serverTracePolicyLayer,
+  withoutServerTracing,
+} from '@server/effect/server-trace-policy';
 import { ConfigProvider, FileSystem, Path } from 'effect';
 import { Effect, Fiber, Layer, Option, Schema } from 'effect';
 import {
@@ -323,7 +327,7 @@ const healthRouteLayer = HttpLayerRouter.add('*', '/healthz', (request) =>
     }
 
     return yield* Effect.fail(new HttpServerError.RouteNotFound({ request }));
-  }),
+  }).pipe(withoutServerTracing),
 );
 
 const applicationReadinessRouteLayer = HttpLayerRouter.add(
@@ -345,7 +349,7 @@ const applicationReadinessRouteLayer = HttpLayerRouter.add(
       );
 
       return HttpServerResponse.fromWeb(readinessResponse);
-    }),
+    }).pipe(withoutServerTracing),
 );
 
 const versionRouteLayer = HttpLayerRouter.add('GET', '/version', () =>
@@ -364,7 +368,7 @@ const versionRouteLayer = HttpLayerRouter.add('GET', '/version', () =>
         ),
       }),
     );
-  }),
+  }).pipe(withoutServerTracing),
 );
 
 const browserErrorTelemetryRouteLayer = HttpLayerRouter.add(
@@ -714,7 +718,7 @@ const bootstrapReadinessRouteLayer = HttpLayerRouter.add(
         headers: { 'Cache-Control': 'no-store' },
         status: 204,
       }),
-    ),
+    ).pipe(withoutServerTracing),
 );
 
 const bootstrapRoutesLayer = Layer.mergeAll(
@@ -784,6 +788,7 @@ const getRequestHandler = () => {
     keyValueStoreLayer,
     ObjectStorage.Default,
     otelLayer,
+    serverTracePolicyLayer,
     serverLoggerLayer,
     appRpcHttpAppLayer,
     stripeClientLayer,
@@ -1032,6 +1037,7 @@ const serveEffect = Effect.gen(function* () {
   const commonRuntimeLayer = Layer.mergeAll(
     BunHttpServer.layer({ port }),
     otelLayer,
+    serverTracePolicyLayer,
     serverLoggerLayer,
     DeploymentRuntimeConfig.Default,
     ConfigProvider.layer(requestHandlerRuntimeConfigProvider),

--- a/src/server/config/deployment-config.spec.ts
+++ b/src/server/config/deployment-config.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from '@effect/vitest';
+import { ConfigProvider, Effect, Option } from 'effect';
+
+import { formatConfigError } from './config-error';
+import { deploymentConfig } from './deployment-config';
+
+const readDeploymentConfig = (entries: Record<string, string>) =>
+  deploymentConfig
+    .parse(ConfigProvider.fromEnv({ env: entries }))
+    .pipe(
+      Effect.mapError(
+        (error) =>
+          new Error(
+            `Invalid deployment configuration:\n${formatConfigError(error)}`,
+          ),
+      ),
+    );
+
+describe('deployment-config', () => {
+  it.effect('leaves trace sampling unconfigured by default', () =>
+    Effect.gen(function* () {
+      const config = yield* readDeploymentConfig({});
+
+      expect(config.TRACE_SAMPLING_RATIO).toEqual(Option.none());
+    }),
+  );
+
+  it.effect('accepts bounded trace sampling overrides', () =>
+    Effect.gen(function* () {
+      for (const ratio of ['0', '0.1', '1']) {
+        const config = yield* readDeploymentConfig({
+          TRACE_SAMPLING_RATIO: ratio,
+        });
+
+        expect(config.TRACE_SAMPLING_RATIO).toEqual(Option.some(Number(ratio)));
+      }
+    }),
+  );
+
+  it.effect('rejects trace sampling overrides outside zero and one', () =>
+    Effect.gen(function* () {
+      for (const ratio of ['-0.01', '1.01']) {
+        const error = yield* Effect.flip(
+          readDeploymentConfig({ TRACE_SAMPLING_RATIO: ratio }),
+        );
+
+        expect(error.message).toContain(
+          'Expected TRACE_SAMPLING_RATIO to be between 0 and 1',
+        );
+      }
+    }),
+  );
+});

--- a/src/server/config/deployment-config.ts
+++ b/src/server/config/deployment-config.ts
@@ -1,4 +1,12 @@
-import { Config, Context, Layer, Option, Redacted } from 'effect';
+import {
+  Config,
+  ConfigProvider,
+  Context,
+  Effect,
+  Layer,
+  Option,
+  Redacted,
+} from 'effect';
 
 import { optionalTrimmedString } from './config-string';
 
@@ -16,6 +24,22 @@ export const workerTriggerModeConfig = Config.literals(
   ['poll', 'http'],
   'WORKER_TRIGGER_MODE',
 ).pipe(Config.withDefault('poll'));
+
+const traceSamplingRatioConfig = Config.option(
+  Config.finite('TRACE_SAMPLING_RATIO').pipe(
+    Config.mapOrFail((ratio) =>
+      ratio >= 0 && ratio <= 1
+        ? Effect.succeed(ratio)
+        : Effect.fail(
+            new Config.ConfigError(
+              new ConfigProvider.SourceError({
+                message: `Expected TRACE_SAMPLING_RATIO to be between 0 and 1, got ${ratio}`,
+              }),
+            ),
+          ),
+    ),
+  ),
+);
 
 const optionalRedactedString = (name: string) =>
   Config.option(Config.redacted(name)).pipe(
@@ -41,6 +65,7 @@ export const deploymentConfig = Config.all({
   COCKPIT_TRACES_ENDPOINT: Config.option(Config.url('COCKPIT_TRACES_ENDPOINT')),
   COCKPIT_TRACES_TOKEN: optionalRedactedString('COCKPIT_TRACES_TOKEN'),
   READINESS_TENANT_HOST: optionalTrimmedString('READINESS_TENANT_HOST'),
+  TRACE_SAMPLING_RATIO: traceSamplingRatioConfig,
   TRUST_PLATFORM_PROXY: Config.boolean('TRUST_PLATFORM_PROXY').pipe(
     Config.withDefault(false),
   ),

--- a/src/server/discounts/providers/index.spec.ts
+++ b/src/server/discounts/providers/index.spec.ts
@@ -31,7 +31,7 @@ describe('validateEsnCard', () => {
       validTo: new Date('2026-12-31T00:00:00.000Z'),
     });
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://esncard.org/services/1.0/card.json?code=ESN-123',
+      'https://www.esncard.org/services/1.0/card.json?code=ESN-123',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });

--- a/src/server/discounts/providers/index.ts
+++ b/src/server/discounts/providers/index.ts
@@ -70,7 +70,7 @@ export const validateEsnCard = async ({
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const url = `https://esncard.org/services/1.0/card.json?code=${encodeURIComponent(identifier)}`;
+    const url = `https://www.esncard.org/services/1.0/card.json?code=${encodeURIComponent(identifier)}`;
     const response = await fetchImpl(url, { signal: controller.signal });
     if (!response.ok) {
       throw new ProviderValidationUnavailableError(

--- a/src/server/effect/server-telemetry.layer.spec.ts
+++ b/src/server/effect/server-telemetry.layer.spec.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from '@effect/vitest';
+import { Option } from 'effect';
 
 import { traceSamplingRatio } from './server-telemetry.layer';
 
 describe('server telemetry', () => {
-  it('samples all local and staging traces', () => {
-    expect(traceSamplingRatio('local')).toBe(1);
-    expect(traceSamplingRatio('staging')).toBe(1);
+  it('samples all local traces and ten percent of hosted traces by default', () => {
+    expect(traceSamplingRatio('local', Option.none())).toBe(1);
+    expect(traceSamplingRatio('staging', Option.none())).toBe(0.1);
+    expect(traceSamplingRatio('production', Option.none())).toBe(0.1);
   });
 
-  it('samples ten percent of production traces', () => {
-    expect(traceSamplingRatio('production')).toBe(0.1);
+  it('honors an explicit temporary sampling override', () => {
+    expect(traceSamplingRatio('staging', Option.some(1))).toBe(1);
+    expect(traceSamplingRatio('staging', Option.some(0))).toBe(0);
   });
 });

--- a/src/server/effect/server-telemetry.layer.ts
+++ b/src/server/effect/server-telemetry.layer.ts
@@ -12,7 +12,8 @@ import { serverTelemetryConfig } from '../config/server-config';
 
 export const traceSamplingRatio = (
   environment: 'local' | 'production' | 'staging',
-) => (environment === 'production' ? 0.1 : 1);
+  override: Option.Option<number>,
+) => Option.getOrElse(override, () => (environment === 'local' ? 1 : 0.1));
 
 export const serverTelemetryLayer = Layer.unwrap(
   Effect.gen(function* () {
@@ -63,7 +64,10 @@ export const serverTelemetryLayer = Layer.unwrap(
       tracerConfig: {
         sampler: new ParentBasedSampler({
           root: new TraceIdRatioBasedSampler(
-            traceSamplingRatio(deployment.APP_ENVIRONMENT),
+            traceSamplingRatio(
+              deployment.APP_ENVIRONMENT,
+              deployment.TRACE_SAMPLING_RATIO,
+            ),
           ),
         }),
       },

--- a/src/server/effect/server-trace-policy.spec.ts
+++ b/src/server/effect/server-trace-policy.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from '@effect/vitest';
+import {
+  isUntracedServerRequestUrl,
+  serverTracePolicyLayer,
+  withoutServerTracing,
+} from '@server/effect/server-trace-policy';
+import { Effect, Tracer } from 'effect';
+import {
+  HttpMiddleware,
+  HttpServerRequest,
+  HttpServerResponse,
+} from 'effect/unstable/http';
+
+describe('server trace policy', () => {
+  it('suppresses operational endpoints regardless of origin or query', () => {
+    for (const url of [
+      '/healthz',
+      '/readyz/',
+      'https://staging.evorto.app/version?probe=1',
+    ]) {
+      expect(isUntracedServerRequestUrl(url)).toBe(true);
+    }
+  });
+
+  it('keeps application requests traceable', () => {
+    for (const url of [
+      '/events',
+      '/rpc',
+      '/events/version',
+      'https://staging.evorto.app/tenant-assets/tenant/logo/file.png',
+      'http://[invalid',
+    ]) {
+      expect(isUntracedServerRequestUrl(url)).toBe(false);
+    }
+  });
+
+  it.effect('disables descendant spans within operational handlers', () =>
+    Effect.gen(function* () {
+      const span = yield* Effect.currentSpan.pipe(
+        Effect.withSpan('operational-child'),
+        withoutServerTracing,
+      );
+
+      expect(span.spanId).toBe('noop');
+    }),
+  );
+
+  it.effect(
+    'prevents the HTTP middleware from creating a probe root span',
+    () =>
+      Effect.gen(function* () {
+        let serverSpan: Tracer.NativeSpan | undefined;
+        const tracer = Tracer.make({
+          span(options) {
+            serverSpan = new Tracer.NativeSpan(options);
+            return serverSpan;
+          },
+        });
+        const request = HttpServerRequest.fromWeb(
+          new Request('https://staging.evorto.app/healthz'),
+        );
+
+        yield* HttpMiddleware.tracer(
+          Effect.succeed(HttpServerResponse.empty({ status: 200 })),
+        ).pipe(
+          Effect.provideService(HttpServerRequest.HttpServerRequest, request),
+          Effect.provideService(Tracer.Tracer, tracer),
+          Effect.provide(serverTracePolicyLayer),
+        );
+
+        expect(serverSpan).toBeUndefined();
+      }),
+  );
+});

--- a/src/server/effect/server-trace-policy.ts
+++ b/src/server/effect/server-trace-policy.ts
@@ -1,0 +1,26 @@
+import { Effect, Layer } from 'effect';
+import { HttpMiddleware } from 'effect/unstable/http';
+
+const untracedOperationalPaths = new Set(['/healthz', '/readyz', '/version']);
+
+const requestPathname = (url: string) => {
+  try {
+    return (
+      new URL(url, 'http://localhost').pathname.replace(/\/+$/u, '') || '/'
+    );
+  } catch {
+    return;
+  }
+};
+
+export const isUntracedServerRequestUrl = (url: string) => {
+  const pathname = requestPathname(url);
+  return pathname !== undefined && untracedOperationalPaths.has(pathname);
+};
+
+export const withoutServerTracing = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.withTracerEnabled(false));
+
+export const serverTracePolicyLayer = Layer.succeed(
+  HttpMiddleware.TracerDisabledWhen,
+)((request) => isUntracedServerRequestUrl(request.url));

--- a/src/server/runtime/runtime-role.spec.ts
+++ b/src/server/runtime/runtime-role.spec.ts
@@ -17,6 +17,7 @@ const deploymentConfig = (
   COCKPIT_TRACES_ENDPOINT: Option.none(),
   COCKPIT_TRACES_TOKEN: Option.none(),
   READINESS_TENANT_HOST: Option.none(),
+  TRACE_SAMPLING_RATIO: Option.none(),
   TRUST_PLATFORM_PROXY: false,
   WORKER_TRIGGER_MODE: 'poll',
   ...overrides,

--- a/tests/docs/admin/google-maps-location.doc.ts
+++ b/tests/docs/admin/google-maps-location.doc.ts
@@ -38,6 +38,7 @@ Start from the normal application navigation: select **Admin Tools**, then **Gen
   await expect(page).toHaveURL(/\/admin\/settings$/u);
 
   const settings = page.locator('app-general-settings');
+  await expect(settings).not.toHaveAttribute('ngh', /.*/);
   const locationField = settings.locator('app-location-selector-field');
   await expect(locationField).toContainText('No location selected');
   await locationField.getByRole('button', { name: 'Change location' }).click();


### PR DESCRIPTION
## Purpose

Reduce Scaleway Cockpit custom trace spend while preserving targeted debugging and parent trace continuity.

## Scope

- sample 10% of hosted root traces and keep parent-based child spans
- suppress health, readiness, and version spans while preserving logs and metrics
- retain Cockpit traces for 7 days
- add a temporary staging workflow override for 100% sampling until reconciliation
- pin PostCSS to the security-fixed production dependency
- stabilize the live Google Maps documentation flow after hydration
- use the working ESNcard validation API hostname

## Runtime and schema impact

Runtime configuration and staging infrastructure only. No database schema changes.

## Local verification

- dependency lock, release metadata, formatting, and lint: passed
- server unit: 1,446 passed
- app unit: 802 passed
- PostgreSQL 17 integration: 55 passed
- application and ops build: passed
- Terraform validation and Trivy static scan: passed with 0 misconfigurations
- Linux/amd64 runtime image gate: 152,130,177 bytes, 0 vulnerabilities, 0 secrets
- Playwright baseline: 151 passed
- Playwright docs: 52 passed
- protected provider integration: 11 passed
- live ESNcard certification: 27 focused unit and 9 Playwright tests passed

Every collected test completed with zero failures, skips, todos, fixmes, expected failures, retries, flakes, interruptions, or focused-test leakage.

- `main` <!-- branch-stack -->
  - **perf: reduce custom trace costs** :point\_left:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable trace sampling, defaulting to 10% in staging and production.
  - Added an optional staging deployment mode for temporarily enabling 100% trace sampling.
  - Operational health, readiness, and version requests are no longer traced.
  - Custom traces are retained for seven days.

- **Bug Fixes**
  - Updated ESNcard validation to use the correct provider address.
  - Improved reliability of the Google Maps documentation flow by waiting for settings to load.

- **Documentation**
  - Documented trace sampling, retention, and staging debugging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
