### PR TITLE
fix: honor Scaleway v1 secret maps

### DIFF
--- a/.changeset/fix-scaleway-secret-map-idempotence.md
+++ b/.changeset/fix-scaleway-secret-map-idempotence.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+Compare Scaleway secret environment variable keys using the current container
+API map shape so unchanged scheduled reconciliations do not create new
+deployments.

--- a/helpers/testing/scaleway-deploy-role.spec.ts
+++ b/helpers/testing/scaleway-deploy-role.spec.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 interface CurrentContainer {
   environment_variables: Record<string, string>;
   image: string;
-  secret_environment_variables: { key: string }[];
+  secret_environment_variables: Record<string, string>;
   status: string;
 }
 
@@ -33,7 +33,7 @@ const runDeployRole = ({
   currentContainer = {
     environment_variables: {},
     image: 'rg.fr-par.scw.cloud/evorto-staging/evorto:old',
-    secret_environment_variables: [],
+    secret_environment_variables: {},
     status: 'ready',
   },
   secretValue = 'test-secret',
@@ -152,14 +152,19 @@ const currentContainerFromArguments = (
       }),
   ),
   image: imageReference,
-  secret_environment_variables: arguments_
-    .filter((argument) => argument.startsWith('secret-environment-variables.'))
-    .map((argument) => ({
-      key: argument.slice(
-        'secret-environment-variables.'.length,
-        argument.indexOf('='),
-      ),
-    })),
+  secret_environment_variables: Object.fromEntries(
+    arguments_
+      .filter((argument) =>
+        argument.startsWith('secret-environment-variables.'),
+      )
+      .map((argument) => [
+        argument.slice(
+          'secret-environment-variables.'.length,
+          argument.indexOf('='),
+        ),
+        'redacted',
+      ]),
+  ),
   status: 'ready',
 });
 

--- a/ops/scaleway/deploy-role.sh
+++ b/ops/scaleway/deploy-role.sh
@@ -173,7 +173,7 @@ if jq --exit-status \
   '.status == "ready"
     and (.image // .registry_image) == $image_reference
     and .environment_variables == $desired_environment[0]
-    and ([.secret_environment_variables[]?.key] | sort) == $desired_secret_keys[0]' \
+    and ((.secret_environment_variables // {}) | keys | sort) == $desired_secret_keys[0]' \
   "${current_container_file}" \
   >/dev/null; then
   if [[ -n "${deployment_status_file}" ]]; then


### PR DESCRIPTION
## Purpose

Stop unchanged Scaleway roles from redeploying because the live secret metadata was compared using the wrong API shape.

## Root cause

The current Scaleway container v1 API returns `secret_environment_variables` as a JSON object/map. The deployment script treated it as an array of `{ key }` records, so its equality predicate was false on every reconciliation. Live scheduled run 30212423571 reproduced the issue after PR #120: the exact same SHA and digest redeployed ops, worker, and web.

## Change

- Compare the sorted keys of the Scaleway v1 secret map to the desired role contract.
- Model the real v1 response shape in the regression fixture, so the unchanged-deployment test fails under the old comparison.

## Runtime and schema impact

No application or schema change. This only corrects deployment idempotence; role-secret value changes still alter the keyed fingerprint and trigger a deployment.

## Validation

- lint and formatting
- ShellCheck
- focused Scaleway tests: 22 passed
- server unit: 1,451 passed
- Angular unit: 802 passed
- PostgreSQL integration: 55 passed
- application and ops build
- Terraform validation and Trivy config scan: zero high/critical findings
- Knope validation
- local image security: 152,130,173 bytes; zero high/critical findings

* `main` <!-- branch-stack -->
  - **fix: honor Scaleway v1 secret maps** :point\_left:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment checks for secret environment variables when determining whether a container is already up to date.
  - Secret values are now represented as redacted entries during comparisons, helping prevent sensitive data from being exposed.
  - Improved handling of containers with missing or empty secret environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
