### PR TITLE
feat: add staging latency observability

### DIFF
--- a/.changeset/observe-staging-latency.md
+++ b/.changeset/observe-staging-latency.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+# Observe warm staging latency
+
+- split server traces across authentication, request context, SSR, Angular,
+  Effect RPC, and event-list database boundaries with bounded attributes,
+- run an independent report-only staging latency synthetic every 15 minutes,
+- retain cold-eligible and sequential warm-candidate network timings as
+  workflow evidence, and
+- attach a 10-request warm latency baseline to changed staging deployments and
+  their immutable manifests.

--- a/.github/workflows/scaleway-staging.yml
+++ b/.github/workflows/scaleway-staging.yml
@@ -537,6 +537,7 @@ jobs:
           test "${generated_status}" = "404"
 
       - name: Capture report-only deployment latency baseline
+        continue-on-error: true
         if: >-
           github.event_name != 'schedule'
           || steps.ops.outputs.changed == 'true'
@@ -550,7 +551,9 @@ jobs:
             --warm-samples 10 \
             --mode report-only \
             --vantage github-actions/deployment
-          cat deployment/latency-summary.md >> "${GITHUB_STEP_SUMMARY}"
+          if [ -s deployment/latency-summary.md ]; then
+            cat deployment/latency-summary.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
 
       - name: Write append-only successful deployment manifest
         id: manifest

--- a/.github/workflows/scaleway-staging.yml
+++ b/.github/workflows/scaleway-staging.yml
@@ -536,6 +536,22 @@ jobs:
           generated_status="$(curl "${curl_args[@]}" --output /dev/null --write-out '%{http_code}' "${generated_endpoint}")"
           test "${generated_status}" = "404"
 
+      - name: Capture report-only deployment latency baseline
+        if: >-
+          github.event_name != 'schedule'
+          || steps.ops.outputs.changed == 'true'
+          || steps.traffic.outputs.worker_changed == 'true'
+          || steps.traffic.outputs.web_changed == 'true'
+        run: |
+          ops/scaleway/probe-http-latency.sh \
+            --origin https://staging.evorto.app \
+            --output deployment/latency.json \
+            --summary-output deployment/latency-summary.md \
+            --warm-samples 10 \
+            --mode report-only \
+            --vantage github-actions/deployment
+          cat deployment/latency-summary.md >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Write append-only successful deployment manifest
         id: manifest
         env:
@@ -550,6 +566,10 @@ jobs:
         run: |
           timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           manifest_key="deployments/staging/${REVISION}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          latency_summary='null'
+          if [ -s deployment/latency.json ]; then
+            latency_summary="$(jq --compact-output '.summary' deployment/latency.json)"
+          fi
           jq --null-input \
             --arg digest "${DIGEST}" \
             --arg environment staging \
@@ -562,6 +582,7 @@ jobs:
             --arg workflow "${GITHUB_WORKFLOW}" \
             --arg workflow_run_id "${GITHUB_RUN_ID}" \
             --arg workflow_run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            --argjson latency_summary "${latency_summary}" \
             '{
               status: "succeeded",
               environment: $environment,
@@ -574,6 +595,7 @@ jobs:
               workflow: $workflow,
               workflowRunId: $workflow_run_id,
               workflowRunAttempt: $workflow_run_attempt,
+              latency: $latency_summary,
               timestamp: $timestamp
             }' > deployment/manifest.json
 
@@ -597,7 +619,10 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: scaleway-staging-${{ needs.resolve-revision.outputs.revision }}
-          path: deployment/manifest.json
+          path: |
+            deployment/manifest.json
+            deployment/latency.json
+            deployment/latency-summary.md
           if-no-files-found: error
           retention-days: 90
 

--- a/.github/workflows/staging-latency.yml
+++ b/.github/workflows/staging-latency.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: staging-latency-monitor
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   probe:

--- a/.github/workflows/staging-latency.yml
+++ b/.github/workflows/staging-latency.yml
@@ -1,0 +1,60 @@
+name: Monitor staging latency
+
+on:
+  workflow_dispatch:
+    inputs:
+      enforce_critical:
+        description: Fail when a warm-path critical threshold is exceeded
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: "7,22,37,52 * * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: staging-latency-monitor
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Probe warm staging latency
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout monitor
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Capture external latency samples
+        env:
+          MODE: ${{ inputs.enforce_critical && 'enforce-critical' || 'report-only' }}
+          VANTAGE: github-actions/${{ runner.os }}-${{ runner.arch }}
+        run: |
+          mkdir -p latency
+          ops/scaleway/probe-http-latency.sh \
+            --origin https://staging.evorto.app \
+            --output latency/staging.json \
+            --summary-output latency/summary.md \
+            --warm-samples 4 \
+            --mode "${MODE}" \
+            --vantage "${VANTAGE}"
+
+      - name: Publish latency summary
+        if: always()
+        run: |
+          if [ -s latency/summary.md ]; then
+            cat latency/summary.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload latency evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: staging-latency-${{ github.run_id }}-${{ github.run_attempt }}
+          path: latency/
+          if-no-files-found: warn
+          retention-days: 7

--- a/LATENCY_IMPROVEMENT.md
+++ b/LATENCY_IMPROVEMENT.md
@@ -1,0 +1,286 @@
+# Latency Improvement Playbook
+
+Use this playbook for warm-path latency work in the Angular SSR, Effect RPC, and
+PostgreSQL request path. Cold starts are measured separately and are not allowed
+to hide steady-state regressions.
+
+The operational counterpart is
+[infrastructure/scaleway/LATENCY_MONITORING.md](infrastructure/scaleway/LATENCY_MONITORING.md).
+
+## Incident baseline
+
+The following evidence was captured against `https://staging.evorto.app` on
+2026-07-27. It is a dated comparison point, not a claim about current
+performance:
+
+- Eight consecutive anonymous `/events` requests reported 769-1,006 ms in
+  `X-Envoy-Upstream-Service-Time`.
+- Those requests had 932-1,247 ms external time-to-first-byte.
+- `/healthz` used 43-168 ms of upstream time during the same investigation.
+- One authenticated browser reload issued 12 client RPC requests after the
+  document response. Event data became available roughly 2.5 seconds after the
+  client RPC sequence began.
+- The browser made duplicate `config.tenant` and `events.eventList` requests.
+- Warm `events.eventList` calls used roughly 430-450 ms upstream.
+- Server-rendered `/events` HTML contained `Loading events...`; the event list
+  was not available in the rendered response.
+
+The relevant latency code paths were unchanged between the deployed revision
+and `main` when this evidence was captured.
+
+## Provisional completion budgets
+
+Treat these as initial engineering budgets. Replace them with accepted
+production SLOs after at least seven representative days, but do not loosen
+them merely to make a regression green.
+
+| Boundary                                  | Initial warm budget                                |
+| ----------------------------------------- | -------------------------------------------------- |
+| `/events` upstream service time           | p95 at or below 500 ms over 20 consecutive samples |
+| `/events` external TTFB                   | p95 at or below 750 ms over 20 consecutive samples |
+| `config.bootstrap` RPC, once introduced   | p95 at or below 250 ms                             |
+| `events.eventList` RPC                    | p95 at or below 350 ms                             |
+| Event list visibly ready after navigation | p75 at or below 1.25 s and p95 at or below 2 s     |
+| Duplicate RPCs during one navigation      | zero duplicate method/input pairs                  |
+
+Correct tenant, permission, SSR, event-visibility, and authentication behavior
+remains mandatory. A faster result that weakens one of those boundaries is a
+regression.
+
+## 1. Add enough spans to locate elapsed time
+
+Do this before changing database indexes or adding caches. The existing HTTP
+trace is too coarse to distinguish request-context, connection acquisition,
+query execution, serialization, and Angular rendering.
+
+The first observability slice now provides named `Effect.fn` operations or
+explicit `Effect.withSpan` boundaries for:
+
+- `Server.renderSsr`
+- `Server.loadAuthSession`
+- `Server.resolveHttpRequestContext`
+- `Server.resolveTenantContext`
+- `Server.resolveUserContext`
+- `Server.resolveUserOnboarding`
+- `Server.resolveUserAttributes`
+- all Effect RPC handlers under the stable `Rpc.*` prefix, including
+  `Rpc.events.eventList`;
+- `Db.events.eventList`
+- `Angular.handle`
+
+Add `Rpc.config.bootstrap` through the same RPC prefix when the bootstrap
+endpoint is introduced.
+
+Annotate spans only with bounded, non-sensitive values:
+
+- deployment environment, role, revision, and digest;
+- normalized route or RPC method;
+- authenticated versus anonymous;
+- SSR-internal versus external request;
+- database query name;
+- result count and pagination limit.
+
+Do not record cookies, tokens, email addresses, Auth0 IDs, user IDs, complete
+tenant objects, RPC payloads, or SQL parameter values. Keep SQL statement
+labels stable and low-cardinality.
+
+For a staging investigation, dispatch `Deploy Scaleway staging` with
+`full_trace_debugging` enabled. This temporarily raises trace sampling from 10%
+to 100%; the next normal reconciliation restores 10%. `/healthz`, `/readyz`,
+and `/version` intentionally remain untraced.
+
+Exit criterion: one trace explains at least 90% of the elapsed time for an
+anonymous `/events` request and an authenticated `events.eventList` request.
+
+## 2. Remove the proven duplicate client work
+
+### Tenant configuration
+
+`ConfigService` currently creates a `config.tenant` TanStack query and also
+calls `config.tenant` directly from `initialize()`.
+
+Choose one query and one cache key:
+
+1. Make the generated `config.tenant.queryOptions()` result the browser source
+   of truth.
+2. Have initialization await the same QueryClient entry instead of issuing a
+   separate `.call()`.
+3. On SSR, initialize tenant data from `REQUEST_CONTEXT` and disable the
+   browser-only tenant query.
+4. Add a unit test that constructs and initializes `ConfigService` and proves
+   that only one browser tenant request occurs.
+
+### Event list
+
+`EventListService` puts `users.maybeSelf` data into the `events.eventList`
+input. The first event query runs before `maybeSelf` resolves; the user ID then
+changes the query key and triggers a second event query. The server already
+derives the authenticated user from `RpcAccess`.
+
+1. Remove `userId` from the event-list RPC input schema.
+2. Remove the event-list service's `selfQuery` dependency.
+3. Remove the mismatch-only server warning for the deleted input.
+4. Keep user-specific filtering based only on the trusted RPC request context.
+5. Update RPC, service, and Playwright tests to prove one event-list request per
+   filter state.
+
+Exit criterion: one `/events` navigation contains no duplicate
+`config.tenant` call and exactly one `events.eventList` call for the initial
+filter.
+
+## 3. Collapse browser bootstrap RPC fan-out
+
+The browser currently requests tenant, permissions, platform authority, public
+configuration, authentication, and user state through several RPCs. Every HTTP
+RPC repeats session and request-context resolution.
+
+Introduce one typed `config.bootstrap` RPC response containing the state needed
+to start the browser:
+
+- tenant;
+- permissions;
+- platform authority;
+- public configuration;
+- authentication state;
+- nullable current user.
+
+Use one generated TanStack query as the shared source for `ConfigService`,
+`Auth`, permissions, guards, and navigation. Do not copy the result into
+multiple independent query keys.
+
+Keep onboarding and scanner capability calls separate only if they are not
+derivable from the bootstrap result. Start them concurrently after bootstrap
+when they are both required; do not serialize unrelated calls.
+
+Exit criterion: the browser reaches its first route with one bootstrap
+request, and no component repeats a value already present in that response.
+
+## 4. Remove the SSR loopback request
+
+The outer SSR request resolves its tenant/user context before Angular starts.
+Server-side `ConfigService.initialize()` then calls `config.public` through
+`SSR_RPC_ORIGIN=http://127.0.0.1:4200`, causing `/rpc` to load the session and
+resolve context again.
+
+Extend the server-owned Angular request context with the already validated
+public configuration, or provide an equivalent server-only injection token.
+The server branch of `ConfigService.initialize()` should consume that value
+directly. The browser branch should continue using typed RPC.
+
+Do not solve this with externally supplied "trusted" headers, an authentication
+bypass, or a process-global user cache. Preserve the existing tests proving
+that forged forwarding and tenant headers cannot select another tenant.
+
+Exit criterion: one anonymous `/events` SSR request resolves request context
+once and makes no loopback RPC.
+
+## 5. Reduce authenticated request-context cost
+
+After fan-out and loopback removal, use the new spans to measure the remaining
+context work. Focus on:
+
+- tenant lookup by domain;
+- user and tenant-assignment lookup;
+- onboarding lookup;
+- user-attribute lookup;
+- database connection acquisition.
+
+The current `user_attributes` view aggregates organizing registrations and is
+queried during authenticated context resolution. Compare it with a
+tenant-and-user-scoped `EXISTS` query. Prefer the scoped query when the plan
+shows that the aggregate view scans unrelated tenants or users.
+
+Load expensive user attributes lazily if only a subset of RPC handlers needs
+them. Keep authorization fail-closed: a missing attribute may not silently
+become permission.
+
+Do not add a tenant or user cache until duplicate requests are gone and traces
+prove repeated lookup cost remains material. Any later cache needs an explicit
+key, bounded lifetime, mutation invalidation, tenant-isolation tests, and a
+documented stale-data policy.
+
+## 6. Explain and optimize the event-list SQL
+
+Capture the exact SQL emitted for representative anonymous and authenticated
+inputs. Run the plan through a private PostgreSQL path using the same schema and
+realistic staging cardinality:
+
+```sql
+BEGIN READ ONLY;
+SET LOCAL statement_timeout = '5s';
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+-- exact parameterized SELECT, with test values substituted safely
+;
+ROLLBACK;
+```
+
+Store the redacted JSON plan with the performance evidence. Never include
+personal data or credentials.
+
+The current schema makes these measured candidates worth checking:
+
+- `event_instances` has no dedicated tenant/start listing index;
+- `event_registration_options` has no index led by `event_id`;
+- the active registration lookup already has a partial
+  `(event_id, user_id)` index for non-cancelled rows.
+
+Evaluate, but do not blindly add:
+
+- an `event_instances` index led by `tenant_id` and `start`, with status and
+  listed-state ordering chosen from the real plan;
+- an `event_registration_options(event_id)` index;
+- a partial public-list index if approved, listed events dominate the hot path.
+
+For each proposed index:
+
+1. record the before plan, execution time, rows, loops, shared-buffer hits, and
+   reads;
+2. add it through the Drizzle schema and an explicit migration;
+3. rerun both plans and the PostgreSQL integration suite;
+4. verify write/storage cost is justified by the measured read improvement;
+5. remove the index proposal if PostgreSQL does not use it under realistic
+   cardinality.
+
+## 7. Verify each slice independently
+
+Measure after each phase instead of landing all changes as one opaque
+optimization.
+
+For every slice:
+
+1. capture before/after trace IDs and revision/digest;
+2. run unit tests for changed services, contracts, and handlers;
+3. run the PostgreSQL integration suite for query or schema changes;
+4. use Browser network inspection to verify request count and timing;
+5. add Playwright coverage for stable request-count and visible-loading
+   behavior;
+6. repeat 20 warm `/events` samples and an authenticated event-list journey;
+7. compare p50, p95, worst case, request count, and error count;
+8. update the dated evidence record.
+
+Do not encode tight wall-clock assertions in the general Playwright suite.
+Enforce request shape/count there and enforce latency through the deployment
+and monitoring checks described in the monitoring runbook.
+
+Before a push or PR, run the complete local equivalents of every CI suite the
+change triggers, with zero skips, todos, retries, or other incomplete outcomes,
+as required by `QUALITY.md`.
+
+## Completion record
+
+Record this for the accepted improvement:
+
+```text
+Date:
+Revision:
+Image digest:
+Trace evidence:
+Browser network evidence:
+PostgreSQL plans:
+Warm /events p50/p95/max:
+Authenticated event-data-ready p75/p95:
+Initial client RPC count:
+Tests:
+Remaining bottleneck:
+Accepted by:
+```

--- a/LATENCY_IMPROVEMENT.md
+++ b/LATENCY_IMPROVEMENT.md
@@ -78,7 +78,7 @@ Annotate spans only with bounded, non-sensitive values:
 - authenticated versus anonymous;
 - SSR-internal versus external request;
 - database query name;
-- result count and pagination limit.
+- result count, bounded page-size bucket, and initial-page state.
 
 Do not record cookies, tokens, email addresses, Auth0 IDs, user IDs, complete
 tenant objects, RPC payloads, or SQL parameter values. Keep SQL statement

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -2,6 +2,10 @@
 
 Evorto quality means the app preserves core product behavior, remains understandable to future agents, and can be verified without relying on chat history or human memory.
 
+For warm-path performance defects, use
+[LATENCY_IMPROVEMENT.md](LATENCY_IMPROVEMENT.md) and the
+[Scaleway latency monitoring runbook](infrastructure/scaleway/LATENCY_MONITORING.md).
+
 Avoid a heavy requirements/test matrix for now. Use a lightweight behavior and verification model:
 
 1. Describe important workflows.

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -483,6 +483,27 @@ describe('Scaleway hosting source', () => {
     expect(productionSmoke).toContain('https://alpha.evorto.app/events');
   });
 
+  it('records report-only warm latency independently and on deployments', () => {
+    const monitor = source('.github/workflows/staging-latency.yml');
+    const staging = source('.github/workflows/scaleway-staging.yml');
+    const deploymentProbe = between(
+      staging,
+      '- name: Capture report-only deployment latency baseline',
+      '- name: Write append-only successful deployment manifest',
+    );
+
+    expect(monitor).toContain('cron: "7,22,37,52 * * * *"');
+    expect(monitor).toContain('--warm-samples 4');
+    expect(monitor).toContain('--mode "${MODE}"');
+    expect(monitor).toContain('retention-days: 7');
+    expect(deploymentProbe).toContain('--warm-samples 10');
+    expect(deploymentProbe).toContain('--mode report-only');
+    expect(staging).toContain('--argjson latency_summary');
+    expect(staging).toContain('latency: $latency_summary');
+    expect(staging).toContain('deployment/latency.json');
+    expect(staging).toContain('deployment/latency-summary.md');
+  });
+
   it('builds once, records immutable evidence, and promotes the exact OCI digest', () => {
     const staging = source('.github/workflows/scaleway-staging.yml');
     const production = source('.github/workflows/scaleway-production.yml');

--- a/helpers/testing/scaleway-hosting-source.spec.ts
+++ b/helpers/testing/scaleway-hosting-source.spec.ts
@@ -496,8 +496,13 @@ describe('Scaleway hosting source', () => {
     expect(monitor).toContain('--warm-samples 4');
     expect(monitor).toContain('--mode "${MODE}"');
     expect(monitor).toContain('retention-days: 7');
+    expect(monitor).toContain('cancel-in-progress: false');
     expect(deploymentProbe).toContain('--warm-samples 10');
     expect(deploymentProbe).toContain('--mode report-only');
+    expect(deploymentProbe).toContain('continue-on-error: true');
+    expect(deploymentProbe).toContain(
+      'if [ -s deployment/latency-summary.md ]; then',
+    );
     expect(staging).toContain('--argjson latency_summary');
     expect(staging).toContain('latency: $latency_summary');
     expect(staging).toContain('deployment/latency.json');

--- a/helpers/testing/staging-latency-probe.spec.ts
+++ b/helpers/testing/staging-latency-probe.spec.ts
@@ -187,5 +187,17 @@ describe('staging latency observability', () => {
       expect(source, spanName).toContain(`'${spanName}'`);
     }
     expect(source).toContain("{ spanPrefix: 'Rpc' }");
+    expect(source).toContain("'evorto.events.initial_page'");
+    expect(source).toContain("'evorto.events.page_size_bucket'");
+    expect(source).not.toContain("'evorto.events.limit'");
+    expect(source).not.toContain("'evorto.events.offset'");
+  });
+
+  it('checks every external command used by the latency probe', async () => {
+    const source = await readFile(probeScript, 'utf8');
+
+    expect(source).toContain(
+      'for required_command in awk curl date dirname grep jq mkdir mktemp mv rm; do',
+    );
   });
 });

--- a/helpers/testing/staging-latency-probe.spec.ts
+++ b/helpers/testing/staging-latency-probe.spec.ts
@@ -1,0 +1,191 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const executeFile = promisify(execFile);
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
+const probeScript = path.join(
+  repositoryRoot,
+  'ops/scaleway/probe-http-latency.sh',
+);
+
+const closeServer = async (
+  server: ReturnType<typeof createServer>,
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+describe('staging latency observability', () => {
+  it('records warm samples and enforces only critical latency on request', async () => {
+    let eventRequestCount = 0;
+    let eventUpstreamServiceMs = 200;
+    const server = createServer((request, response) => {
+      if (request.url === '/version') {
+        response.setHeader('Content-Type', 'application/json');
+        response.end(
+          JSON.stringify({
+            environment: 'staging',
+            imageDigest: `sha256:${'b'.repeat(64)}`,
+            revision: 'a'.repeat(40),
+          }),
+        );
+        return;
+      }
+      if (request.url === '/healthz') {
+        response.setHeader('Content-Type', 'application/json');
+        response.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+      if (request.url === '/events') {
+        eventRequestCount += 1;
+        response.setHeader(
+          'X-Envoy-Upstream-Service-Time',
+          String(eventUpstreamServiceMs),
+        );
+        response.setHeader('X-Request-Id', `request-${eventRequestCount}`);
+        response.end('<html><app-root></app-root></html>');
+        return;
+      }
+
+      response.statusCode = 404;
+      response.end('not found');
+    });
+    const temporaryDirectory = await mkdtemp(
+      path.join(os.tmpdir(), 'evorto-latency-probe-'),
+    );
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected the latency fixture to use a TCP port');
+      }
+      const origin = `http://127.0.0.1:${address.port}`;
+      const reportPath = path.join(temporaryDirectory, 'report.json');
+      const summaryPath = path.join(temporaryDirectory, 'summary.md');
+
+      await executeFile('bash', [
+        probeScript,
+        '--origin',
+        origin,
+        '--output',
+        reportPath,
+        '--summary-output',
+        summaryPath,
+        '--warm-samples',
+        '4',
+        '--mode',
+        'report-only',
+        '--vantage',
+        'test-runner',
+      ]);
+
+      const report: unknown = JSON.parse(await readFile(reportPath, 'utf8'));
+      expect(report).toMatchObject({
+        deployment: {
+          environment: 'staging',
+          imageDigest: `sha256:${'b'.repeat(64)}`,
+          revision: 'a'.repeat(40),
+        },
+        mode: 'report-only',
+        schemaVersion: 1,
+        summary: {
+          contentFailures: 0,
+          expectedWarmCandidateCount: 4,
+          overallStatus: 'within_budget',
+          upstreamServiceMs: {
+            max: 200,
+            p50: 200,
+            p95: 200,
+            status: 'within_budget',
+          },
+          warmCandidateCount: 4,
+        },
+        targetOrigin: origin,
+        vantage: 'test-runner',
+      });
+      expect(await readFile(summaryPath, 'utf8')).toContain(
+        '| Upstream service | 200 ms | 200 ms | 200 ms | within_budget |',
+      );
+
+      eventUpstreamServiceMs = 1601;
+      const criticalReportPath = path.join(temporaryDirectory, 'critical.json');
+      await expect(
+        executeFile('bash', [
+          probeScript,
+          '--origin',
+          origin,
+          '--output',
+          criticalReportPath,
+          '--warm-samples',
+          '1',
+          '--mode',
+          'enforce-critical',
+          '--vantage',
+          'test-runner',
+        ]),
+      ).rejects.toMatchObject({ code: 2 });
+      const criticalReport: unknown = JSON.parse(
+        await readFile(criticalReportPath, 'utf8'),
+      );
+      expect(criticalReport).toMatchObject({
+        summary: {
+          overallStatus: 'critical',
+          upstreamServiceMs: {
+            p95: 1601,
+            status: 'critical',
+          },
+        },
+      });
+    } finally {
+      await closeServer(server);
+      await rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it('keeps the diagnosed server boundaries available as stable trace names', async () => {
+    const sources = await Promise.all(
+      [
+        'src/server.ts',
+        'src/server/auth/auth-session.ts',
+        'src/server/context/http-request-context.ts',
+        'src/server/context/request-context-resolver.ts',
+        'src/server/effect/rpc/app-rpcs.web-handler.ts',
+        'src/server/effect/rpc/handlers/events/events-query.handlers.ts',
+      ].map((sourcePath) =>
+        readFile(path.join(repositoryRoot, sourcePath), 'utf8'),
+      ),
+    );
+    const source = sources.join('\n');
+
+    for (const spanName of [
+      'Angular.handle',
+      'Db.events.eventList',
+      'Server.loadAuthSession',
+      'Server.renderSsr',
+      'Server.resolveHttpRequestContext',
+      'Server.resolveTenantContext',
+      'Server.resolveUserAttributes',
+      'Server.resolveUserContext',
+      'Server.resolveUserOnboarding',
+    ]) {
+      expect(source, spanName).toContain(`'${spanName}'`);
+    }
+    expect(source).toContain("{ spanPrefix: 'Rpc' }");
+  });
+});

--- a/helpers/testing/staging-latency-probe.spec.ts
+++ b/helpers/testing/staging-latency-probe.spec.ts
@@ -31,6 +31,7 @@ describe('staging latency observability', () => {
   it('records warm samples and enforces only critical latency on request', async () => {
     let eventRequestCount = 0;
     let eventUpstreamServiceMs = 200;
+    let transportFailureAtEventRequest: number | undefined;
     const server = createServer((request, response) => {
       if (request.url === '/version') {
         response.setHeader('Content-Type', 'application/json');
@@ -50,6 +51,10 @@ describe('staging latency observability', () => {
       }
       if (request.url === '/events') {
         eventRequestCount += 1;
+        if (eventRequestCount === transportFailureAtEventRequest) {
+          request.socket.destroy();
+          return;
+        }
         response.setHeader(
           'X-Envoy-Upstream-Service-Time',
           String(eventUpstreamServiceMs),
@@ -123,6 +128,62 @@ describe('staging latency observability', () => {
         '| Upstream service | 200 ms | 200 ms | 200 ms | within_budget |',
       );
 
+      transportFailureAtEventRequest = eventRequestCount + 2;
+      const transportReportPath = path.join(
+        temporaryDirectory,
+        'transport.json',
+      );
+      const transportSummaryPath = path.join(
+        temporaryDirectory,
+        'transport.md',
+      );
+      await expect(
+        executeFile('bash', [
+          probeScript,
+          '--origin',
+          origin,
+          '--output',
+          transportReportPath,
+          '--summary-output',
+          transportSummaryPath,
+          '--warm-samples',
+          '2',
+          '--mode',
+          'report-only',
+          '--vantage',
+          'test-runner',
+        ]),
+      ).rejects.toMatchObject({ code: 1 });
+      const transportReport: unknown = JSON.parse(
+        await readFile(transportReportPath, 'utf8'),
+      );
+      expect(transportReport).toEqual(
+        expect.objectContaining({
+          samples: expect.arrayContaining([
+            expect.objectContaining({
+              contentValid: false,
+              kind: 'warm_candidate',
+              sequence: 1,
+              statusCode: 0,
+            }),
+            expect.objectContaining({
+              contentValid: true,
+              kind: 'warm_candidate',
+              sequence: 2,
+              statusCode: 200,
+            }),
+          ]),
+          summary: expect.objectContaining({
+            contentFailures: 1,
+            overallStatus: 'critical',
+            warmCandidateCount: 2,
+          }),
+        }),
+      );
+      expect(await readFile(transportSummaryPath, 'utf8')).toContain(
+        '- Overall status: `critical`',
+      );
+
       eventUpstreamServiceMs = 1601;
       const criticalReportPath = path.join(temporaryDirectory, 'critical.json');
       await expect(
@@ -156,7 +217,7 @@ describe('staging latency observability', () => {
       await closeServer(server);
       await rm(temporaryDirectory, { force: true, recursive: true });
     }
-  });
+  }, 30_000);
 
   it('keeps the diagnosed server boundaries available as stable trace names', async () => {
     const sources = await Promise.all(
@@ -199,5 +260,18 @@ describe('staging latency observability', () => {
     expect(source).toContain(
       'for required_command in awk curl date dirname grep jq mkdir mktemp mv rm; do',
     );
+  });
+
+  it('marks planned trace signals as inactive in the monitoring runbook', async () => {
+    const runbook = await readFile(
+      path.join(
+        repositoryRoot,
+        'infrastructure/scaleway/LATENCY_MONITORING.md',
+      ),
+      'utf8',
+    );
+
+    expect(runbook).toContain('`Rpc.config.bootstrap` remains planned');
+    expect(runbook).not.toContain('| `config.bootstrap` trace p95');
   });
 });

--- a/infrastructure/scaleway/LATENCY_MONITORING.md
+++ b/infrastructure/scaleway/LATENCY_MONITORING.md
@@ -34,7 +34,6 @@ so the known defect does not create permanent noise.
 | ------------------------------------------ | ------------- | ----------------------- | ----------------------- |
 | Warm-candidate `/events` upstream p95      | <= 500 ms     | > 750 ms for 3 checks   | > 1,500 ms for 2 checks |
 | Warm-candidate `/events` external TTFB p95 | <= 750 ms     | > 1,000 ms for 3 checks | > 2,000 ms for 2 checks |
-| `config.bootstrap` trace p95               | <= 250 ms     | > 400 ms for 15 min     | > 800 ms for 5 min      |
 | `events.eventList` trace p95               | <= 350 ms     | > 500 ms for 15 min     | > 1,000 ms for 5 min    |
 | Request-context trace p95                  | <= 250 ms     | > 350 ms for 15 min     | > 750 ms for 5 min      |
 | Event-list-ready browser measure           | p75 <= 1.25 s | p75 > 1.5 s for 30 min  | p75 > 2.5 s for 15 min  |
@@ -43,6 +42,10 @@ so the known defect does not create permanent noise.
 Page immediately for availability failures, persistent critical latency, or a
 latency increase paired with elevated errors. Send warnings to the normal
 operational channel for investigation during working hours.
+
+`Rpc.config.bootstrap` remains planned and is not emitted by the application.
+Add it to the active trace objectives and dashboards only after the endpoint
+described in `LATENCY_IMPROVEMENT.md` is implemented.
 
 ## External warm-path synthetic
 
@@ -110,9 +113,11 @@ baseline when a deployment or non-scheduled reconciliation is checked:
 6. upload the JSON with the deployment evidence;
 7. include the summary in the append-only deployment manifest.
 
-The check currently runs in report-only mode. Count seven successful deployment
-baselines after the latency fix meets its budget, then change the deployment
-probe to `enforce-critical`. Preserve rollback behavior: a failed post-traffic
+The check currently runs in report-only mode and cannot trigger deployment
+rollback; the preceding revision/readiness smoke remains the authoritative
+deployment gate. Count seven successful deployment baselines after the latency
+fix meets its budget, then change the deployment probe to `enforce-critical`
+and remove its `continue-on-error`. At that point, a failed post-traffic
 performance check may restore the previous image, while schema changes remain
 forward-only.
 
@@ -136,10 +141,12 @@ Show p50, p95, and p99 duration plus request count for:
 - `Server.resolveHttpRequestContext`;
 - `Server.resolveTenantContext`;
 - `Server.resolveUserContext`;
-- `Rpc.config.bootstrap`;
 - `Rpc.events.eventList`;
 - `Db.events.eventList`;
 - `Angular.handle`.
+
+`Rpc.config.bootstrap` remains planned; add it to this view only after the
+bootstrap endpoint and span exist.
 
 Keep trace attributes bounded. Never group by raw user ID, tenant object,
 cookie, token, email address, full URL query, RPC payload, or SQL parameter.
@@ -167,15 +174,18 @@ Terraform already enables the regional Cockpit alert manager, all available
 preconfigured alerts, and the operational email contact. Test delivery after
 any contact or alert change.
 
-Add data-source-managed Grafana rules for the web container:
+In the Grafana interface, add data-source-managed alert rules using the
+Scaleway Metrics data source for the web container:
 
 - container status is `error` for 10 seconds;
 - CPU exceeds 90% for 10 minutes;
 - memory exceeds 90% for 10 minutes;
 - 5xx percentage exceeds the thresholds above.
 
-Use the `Scaleway Alerting` alert manager in `fr-par`; Cockpit does not support
-Grafana-managed alert rules. Follow Scaleway's
+Select the `Scaleway Alerting` alert manager in `fr-par` for notifications.
+Do not select Grafana-managed rules or the Grafana alert manager; Cockpit
+supports rules evaluated by the data source and notifications handled by
+Scaleway Alerting. Follow Scaleway's
 [container alert guide](https://www.scaleway.com/en/docs/serverless-containers/how-to/configure-alerts-containers)
 and
 [custom alert guide](https://www.scaleway.com/en/docs/cockpit/how-to/configure-alerts-for-scw-resources/).

--- a/infrastructure/scaleway/LATENCY_MONITORING.md
+++ b/infrastructure/scaleway/LATENCY_MONITORING.md
@@ -1,0 +1,287 @@
+# Latency Monitoring Runbook
+
+Use this runbook to detect and diagnose warm-path latency regressions on
+`staging.evorto.app` and, after production is enabled, the equivalent production
+hostname. Improvement work follows
+[../../LATENCY_IMPROVEMENT.md](../../LATENCY_IMPROVEMENT.md).
+
+## Monitoring model
+
+Use three complementary views:
+
+1. An external synthetic measures what the user-facing endpoint actually does.
+2. Application traces divide server time into SSR, context, RPC, and SQL work.
+3. Native Scaleway metrics show platform status and saturation.
+
+Scaleway's native Serverless Container metrics include container status,
+instances, CPU, memory, request rate, status-code percentages, and network
+traffic. The currently documented list does not include request duration, so it
+cannot provide the application latency signal or breakdown required here. See
+Scaleway's
+[Serverless Container monitoring documentation](https://www.scaleway.com/en/docs/serverless-containers/how-to/monitor-container/).
+
+Cockpit custom telemetry is billable. Reuse the existing trace source and
+native metrics first. Add custom OTLP metrics only after confirming the
+expected ingestion volume and cost.
+
+## Provisional latency objectives
+
+These thresholds become active after the corresponding improvement has met the
+budget in `LATENCY_IMPROVEMENT.md`. Until then, collect them in report-only mode
+so the known defect does not create permanent noise.
+
+| Signal                                     | Target        | Warning                 | Critical                |
+| ------------------------------------------ | ------------- | ----------------------- | ----------------------- |
+| Warm-candidate `/events` upstream p95      | <= 500 ms     | > 750 ms for 3 checks   | > 1,500 ms for 2 checks |
+| Warm-candidate `/events` external TTFB p95 | <= 750 ms     | > 1,000 ms for 3 checks | > 2,000 ms for 2 checks |
+| `config.bootstrap` trace p95               | <= 250 ms     | > 400 ms for 15 min     | > 800 ms for 5 min      |
+| `events.eventList` trace p95               | <= 350 ms     | > 500 ms for 15 min     | > 1,000 ms for 5 min    |
+| Request-context trace p95                  | <= 250 ms     | > 350 ms for 15 min     | > 750 ms for 5 min      |
+| Event-list-ready browser measure           | p75 <= 1.25 s | p75 > 1.5 s for 30 min  | p75 > 2.5 s for 15 min  |
+| HTTP 5xx ratio                             | < 1%          | > 1% for 10 min         | > 5% for 5 min          |
+
+Page immediately for availability failures, persistent critical latency, or a
+latency increase paired with elevated errors. Send warnings to the normal
+operational channel for investigation during working hours.
+
+## External warm-path synthetic
+
+Run the synthetic from outside Scaleway every 15 minutes. Do not poll every
+minute: that would keep a scale-to-zero service warm and make the cold and warm
+populations indistinguishable.
+
+Each check must:
+
+1. fetch `/version` and record revision and image digest;
+2. fetch `/healthz` as the DB-free control;
+3. fetch `/events` once and label it `cold_eligible`;
+4. immediately make four more sequential `/events` requests and label them
+   `warm_candidate`;
+5. record HTTP status, DNS/connect/TLS/TTFB/total time,
+   `X-Envoy-Upstream-Service-Time`, `X-Request-Id`, vantage region, and
+   timestamp;
+6. evaluate warm latency from the four-request candidate group and retain every
+   sample rather than only its average;
+7. alert on any request returning 5xx or invalid application content.
+
+The platform does not expose an instance identity in the public response, so a
+post-first request cannot be proven to hit the same instance. Treat the burst
+as warm-candidate evidence and confirm persistent regressions with hot
+application traces.
+
+A manual equivalent is:
+
+```bash
+for sample in 1 2 3 4 5; do
+  curl --silent --show-error --dump-header - --output /dev/null \
+    --write-out "sample=${sample} code=%{http_code} connect=%{time_connect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n" \
+    https://staging.evorto.app/events
+done
+```
+
+`/readyz` is an application-behavior readiness check that renders `/events`.
+Use its status for availability, not as the primary latency signal: it is
+deliberately untraced and its probe semantics differ from a user navigation.
+
+The temporary implementation is
+`.github/workflows/staging-latency.yml`. It runs at minutes 7, 22, 37, and 52
+of every hour, calls `ops/scaleway/probe-http-latency.sh`, writes the full JSON
+sample set plus a Markdown summary, and retains the workflow artifact for seven
+days. It runs independently from deployment reconciliation and records the
+GitHub runner class as its vantage because GitHub does not expose a stable
+runner region.
+
+Latency thresholds remain report-only while the known defect is open. A manual
+workflow dispatch can enable `enforce_critical` to exercise the critical gate.
+Status or application-content failures always fail the check; report-only mode
+suppresses latency-threshold failure, not availability failure. Replace the
+temporary workflow with a fixed-region synthetic service if one is approved.
+
+## Deployment performance check
+
+The post-traffic smoke section of `scaleway-staging.yml` captures a release
+baseline when a deployment or non-scheduled reconciliation is checked:
+
+1. make one cold-eligible `/events` request;
+2. make 10 consecutive warm-candidate requests;
+3. store per-request upstream and total timing as JSON;
+4. calculate p50, p95, and maximum without discarding outliers;
+5. attach revision, digest, workflow URL, and timestamp;
+6. upload the JSON with the deployment evidence;
+7. include the summary in the append-only deployment manifest.
+
+The check currently runs in report-only mode. Count seven successful deployment
+baselines after the latency fix meets its budget, then change the deployment
+probe to `enforce-critical`. Preserve rollback behavior: a failed post-traffic
+performance check may restore the previous image, while schema changes remain
+forward-only.
+
+## Cockpit traces
+
+Application traces are sent to the Terraform-managed
+`evorto-<environment>-traces` source. Hosted roles normally sample 10% of
+complete parent-based traces for seven days.
+
+Create a Grafana trace view filtered by:
+
+- `service.name = evorto-server`;
+- deployment environment and role;
+- revision and image digest;
+- normalized HTTP route or RPC method;
+- span status.
+
+Show p50, p95, and p99 duration plus request count for:
+
+- `Server.renderSsr`;
+- `Server.resolveHttpRequestContext`;
+- `Server.resolveTenantContext`;
+- `Server.resolveUserContext`;
+- `Rpc.config.bootstrap`;
+- `Rpc.events.eventList`;
+- `Db.events.eventList`;
+- `Angular.handle`.
+
+Keep trace attributes bounded. Never group by raw user ID, tenant object,
+cookie, token, email address, full URL query, RPC payload, or SQL parameter.
+
+For a short investigation, manually dispatch `Deploy Scaleway staging` with
+`full_trace_debugging` enabled. Confirm the next normal deployment restores 10%
+sampling. Scaleway documents the OTLP trace endpoint and trace-source workflow
+in its
+[Cockpit tracing guide](https://www.scaleway.com/en/docs/cockpit/how-to/activate-push-traces/).
+
+## Native Scaleway dashboard and alerts
+
+Continue using the `Serverless Containers Overview` and
+`Serverless Containers logs` dashboards. Correlate latency with:
+
+- instance count and container status;
+- CPU utilization;
+- memory utilization;
+- requests per second and concurrent traffic;
+- response status-code percentage;
+- network ingress and egress;
+- deployment revision and restart time.
+
+Terraform already enables the regional Cockpit alert manager, all available
+preconfigured alerts, and the operational email contact. Test delivery after
+any contact or alert change.
+
+Add data-source-managed Grafana rules for the web container:
+
+- container status is `error` for 10 seconds;
+- CPU exceeds 90% for 10 minutes;
+- memory exceeds 90% for 10 minutes;
+- 5xx percentage exceeds the thresholds above.
+
+Use the `Scaleway Alerting` alert manager in `fr-par`; Cockpit does not support
+Grafana-managed alert rules. Follow Scaleway's
+[container alert guide](https://www.scaleway.com/en/docs/serverless-containers/how-to/configure-alerts-containers)
+and
+[custom alert guide](https://www.scaleway.com/en/docs/cockpit/how-to/configure-alerts-for-scw-resources/).
+
+## Optional application metrics
+
+Add a custom Cockpit metrics source only if synthetics plus traces cannot
+provide reliable alerting. Estimate and approve ingestion cost first because
+custom data pushed to Cockpit is billed.
+
+If approved, export low-cardinality histograms and counters through the
+application's OpenTelemetry layer:
+
+- `evorto_http_server_duration_ms` by normalized route, method, status class,
+  environment, and role;
+- `evorto_rpc_duration_ms` by RPC method and outcome;
+- `evorto_request_context_duration_ms` by authenticated/anonymous and source;
+- `evorto_db_pool_acquire_duration_ms` by role;
+- `evorto_db_query_duration_ms` by stable query name and outcome;
+- `evorto_browser_event_list_ready_ms` by environment and coarse navigation
+  type;
+- request and error counters matching those boundaries.
+
+Do not label metrics with IDs, arbitrary paths, query strings, error messages,
+or payload values. Export metrics through the existing layer composition, not
+from individual business functions. Scaleway's supported OTLP metrics endpoint
+is documented in its
+[OTLP metrics guide](https://www.scaleway.com/en/docs/cockpit/how-to/send-metrics-logs-to-cockpit-with-otlp/).
+
+## Browser performance measurement
+
+Server timings do not show when the event list becomes usable. Add a sampled,
+privacy-safe browser measure around navigation:
+
+```text
+events_navigation_start -> events_initial_list_ready
+```
+
+Also collect TTFB, FCP, LCP, and INP when available. Send only:
+
+- metric name and duration;
+- environment and app revision;
+- normalized route template;
+- anonymous/authenticated;
+- success/error outcome.
+
+Do not send URL queries, event names/IDs, user/tenant identifiers, form data, or
+stack traces through this channel. Rate-limit and sample the endpoint, and
+reuse the existing browser telemetry sanitization rules.
+
+Start in dashboard-only mode. Enable alerts after seven representative days and
+after confirming that bots, background tabs, and staging automation are
+excluded.
+
+## Triage workflow
+
+When an alert fires:
+
+1. Record the alert, timestamp, affected environment, and current `/version`.
+2. Reproduce the external request burst and compare total time with
+   `X-Envoy-Upstream-Service-Time`.
+3. If total time is high but upstream time is healthy, investigate DNS, TLS,
+   routing, or the external vantage.
+4. If upstream time is high, find traces for the revision, route, and alert
+   window.
+5. Compare SSR, request-context, RPC, database acquisition, SQL, and Angular
+   spans.
+6. Check container CPU, memory, instances, request rate, status codes, and
+   restart timing.
+7. If SQL dominates, use the read-only JSON
+   `EXPLAIN (ANALYZE, BUFFERS)` procedure in `LATENCY_IMPROVEMENT.md`.
+8. If the regression begins at a deployment, compare the prior manifest and
+   decide whether the documented image rollback is appropriate.
+9. Record the cause, mitigation, evidence links, and follow-up owner.
+
+Do not blame cold start when the post-first burst or sampled hot traces remain
+slow. Do not hide a database or application regression by increasing timeouts,
+retries, minimum instances, or connection-pool size without measured evidence.
+
+## Review cadence
+
+- After every staging deployment: review the release timing artifact.
+- Weekly: review p50/p95/p99, errors, and the slowest trace groups by revision.
+- Monthly: test one warning alert and one resolution notification.
+- Quarterly: review sampling, retention, cardinality, and Cockpit ingestion
+  cost.
+- After each incident: add the missing signal or runbook step that would have
+  shortened diagnosis.
+
+Record threshold changes with the old value, new value, evidence window,
+reason, approver, and effective revision.
+
+## Incident record
+
+```text
+Alert:
+Started/resolved:
+Environment:
+Revision and digest:
+External cold-eligible/warm-candidate timings:
+Request IDs:
+Trace links:
+Platform dashboard:
+Database plan:
+User-visible impact:
+Cause:
+Mitigation:
+Follow-up owner:
+```

--- a/infrastructure/scaleway/README.md
+++ b/infrastructure/scaleway/README.md
@@ -192,6 +192,14 @@ traces for all three roles. The next successful automatic or scheduled
 reconciliation restores the Terraform-owned 10% value, so the debug setting
 cannot silently become the long-term default.
 
+Use [LATENCY_MONITORING.md](LATENCY_MONITORING.md) for warm-path objectives,
+external synthetic checks, trace dashboards, alert thresholds, and latency
+incident response. Application-side improvement work is ordered in
+[../../LATENCY_IMPROVEMENT.md](../../LATENCY_IMPROVEMENT.md).
+The temporary `Monitor staging latency` workflow runs independently every 15
+minutes, while changed staging deployments retain a separate 10-sample
+report-only baseline in their deployment evidence.
+
 ## DNS and Transactional Email
 
 Keep Cloudflare as the authoritative DNS provider. Terraform manages only the

--- a/ops/scaleway/probe-http-latency.sh
+++ b/ops/scaleway/probe-http-latency.sh
@@ -1,0 +1,491 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: probe-http-latency.sh \
+  --origin https://staging.evorto.app \
+  --output latency.json \
+  [--summary-output latency.md] \
+  [--warm-samples 4] \
+  [--mode report-only|enforce-critical] \
+  [--vantage github-actions/ubuntu-latest]
+EOF
+}
+
+origin=''
+output=''
+summary_output=''
+warm_samples=4
+mode='report-only'
+vantage="${GITHUB_ACTIONS:+github-actions/${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}}"
+vantage="${vantage:-local}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --origin)
+      [[ $# -ge 2 ]] || {
+        usage >&2
+        exit 64
+      }
+      origin="$2"
+      shift 2
+      ;;
+    --output)
+      [[ $# -ge 2 ]] || {
+        usage >&2
+        exit 64
+      }
+      output="$2"
+      shift 2
+      ;;
+    --summary-output)
+      [[ $# -ge 2 ]] || {
+        usage >&2
+        exit 64
+      }
+      summary_output="$2"
+      shift 2
+      ;;
+    --warm-samples)
+      [[ $# -ge 2 ]] || {
+        usage >&2
+        exit 64
+      }
+      warm_samples="$2"
+      shift 2
+      ;;
+    --mode)
+      [[ $# -ge 2 ]] || {
+        usage >&2
+        exit 64
+      }
+      mode="$2"
+      shift 2
+      ;;
+    --vantage)
+      [[ $# -ge 2 ]] || {
+        usage >&2
+        exit 64
+      }
+      vantage="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -z "${origin}" || -z "${output}" ]]; then
+  usage >&2
+  exit 64
+fi
+if [[ ! "${warm_samples}" =~ ^[1-9][0-9]*$ ]] || ((warm_samples > 100)); then
+  echo "--warm-samples must be an integer between 1 and 100" >&2
+  exit 64
+fi
+if [[ "${mode}" != 'report-only' && "${mode}" != 'enforce-critical' ]]; then
+  echo "--mode must be report-only or enforce-critical" >&2
+  exit 64
+fi
+if [[ ! "${origin}" =~ ^https?://[^[:space:]]+$ ]]; then
+  echo "--origin must be an absolute HTTP(S) origin" >&2
+  exit 64
+fi
+
+origin="${origin%/}"
+
+for required_command in awk curl date grep jq mktemp mkdir mv; do
+  if ! command -v "${required_command}" >/dev/null; then
+    echo "Missing required command: ${required_command}" >&2
+    exit 69
+  fi
+done
+
+temporary_root="${TMPDIR:-/tmp}"
+working_directory="$(mktemp -d "${temporary_root%/}/evorto-latency.XXXXXX")"
+cleanup() {
+  rm -rf "${working_directory}"
+}
+trap cleanup EXIT
+
+samples_file="${working_directory}/samples.jsonl"
+: >"${samples_file}"
+sample_failures=0
+last_body_file=''
+
+extract_header() {
+  local header_name="$1"
+  local headers_file="$2"
+
+  awk -v header_name="${header_name}" '
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      split(line, fields, ":")
+      if (tolower(fields[1]) == tolower(header_name)) {
+        sub(/^[^:]*:[[:space:]]*/, "", line)
+        value = line
+      }
+    }
+    END {
+      if (value != "") {
+        print value
+      }
+    }
+  ' "${headers_file}"
+}
+
+probe() {
+  local kind="$1"
+  local sequence="$2"
+  local path="$3"
+  local content_validator="$4"
+  local max_time_seconds="$5"
+  local sample_name="${kind}-${sequence}"
+  local headers_file="${working_directory}/${sample_name}.headers"
+  local body_file="${working_directory}/${sample_name}.body"
+  local curl_metrics
+
+  if ! curl_metrics="$(
+    curl \
+      --connect-timeout 5 \
+      --dump-header "${headers_file}" \
+      --header 'Accept-Encoding: identity' \
+      --max-time "${max_time_seconds}" \
+      --output "${body_file}" \
+      --silent \
+      --show-error \
+      --user-agent 'evorto-latency-monitor/1' \
+      --write-out '%{json}' \
+      "${origin}${path}"
+  )"; then
+    echo "Latency probe failed before receiving ${path}" >&2
+    return 1
+  fi
+
+  if ! jq --exit-status '
+    type == "object"
+      and (.http_code | type == "number")
+      and (.http_version | type == "string")
+      and (.num_redirects | type == "number")
+      and (.time_appconnect | type == "number")
+      and (.time_connect | type == "number")
+      and (.time_namelookup | type == "number")
+      and (.time_starttransfer | type == "number")
+      and (.time_total | type == "number")
+  ' <<<"${curl_metrics}" >/dev/null; then
+    echo "curl did not return the expected timing JSON for ${path}" >&2
+    return 1
+  fi
+
+  local status_code
+  status_code="$(jq --raw-output '.http_code' <<<"${curl_metrics}")"
+  local content_valid='true'
+  if ((status_code < 200 || status_code >= 300)); then
+    content_valid='false'
+  else
+    case "${content_validator}" in
+      application)
+        if ! grep --quiet '<app-root' "${body_file}"; then
+          content_valid='false'
+        fi
+        ;;
+      health)
+        if ! jq --exit-status '.status == "ok"' "${body_file}" >/dev/null 2>&1; then
+          content_valid='false'
+        fi
+        ;;
+      version)
+        if ! jq --exit-status '
+          (.environment | type == "string")
+            and (.imageDigest | type == "string")
+            and (.revision | type == "string")
+        ' "${body_file}" >/dev/null 2>&1; then
+          content_valid='false'
+        fi
+        ;;
+      *)
+        echo "Unknown content validator: ${content_validator}" >&2
+        return 1
+        ;;
+    esac
+  fi
+
+  if [[ "${content_valid}" != 'true' ]]; then
+    sample_failures=$((sample_failures + 1))
+  fi
+
+  local upstream_service_ms
+  upstream_service_ms="$(
+    extract_header 'x-envoy-upstream-service-time' "${headers_file}"
+  )"
+  if [[ ! "${upstream_service_ms}" =~ ^[0-9]+$ ]]; then
+    upstream_service_ms=''
+  fi
+
+  local request_id
+  request_id="$(extract_header 'x-request-id' "${headers_file}")"
+
+  jq --null-input --compact-output \
+    --arg kind "${kind}" \
+    --arg path "${path}" \
+    --arg request_id "${request_id}" \
+    --arg timestamp "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+    --arg upstream_service_ms "${upstream_service_ms}" \
+    --arg vantage "${vantage}" \
+    --argjson content_valid "${content_valid}" \
+    --argjson curl_metrics "${curl_metrics}" \
+    --argjson sequence "${sequence}" '
+      def milliseconds:
+        . * 1000 * 100 | round / 100;
+      def non_negative:
+        if . < 0 then 0 else . end;
+
+      {
+        kind: $kind,
+        sequence: $sequence,
+        path: $path,
+        timestamp: $timestamp,
+        vantage: $vantage,
+        statusCode: $curl_metrics.http_code,
+        httpVersion: $curl_metrics.http_version,
+        redirectCount: $curl_metrics.num_redirects,
+        contentValid: $content_valid,
+        requestId: (
+          if $request_id == "" then null else $request_id end
+        ),
+        upstreamServiceMs: (
+          if $upstream_service_ms == ""
+          then null
+          else ($upstream_service_ms | tonumber)
+          end
+        ),
+        timingMs: {
+          dns: ($curl_metrics.time_namelookup | milliseconds),
+          connect: (
+            ($curl_metrics.time_connect - $curl_metrics.time_namelookup)
+            | non_negative
+            | milliseconds
+          ),
+          tls: (
+            if $curl_metrics.time_appconnect == 0
+            then 0
+            else (
+              ($curl_metrics.time_appconnect - $curl_metrics.time_connect)
+              | non_negative
+              | milliseconds
+            )
+            end
+          ),
+          ttfb: ($curl_metrics.time_starttransfer | milliseconds),
+          total: ($curl_metrics.time_total | milliseconds)
+        }
+      }
+    ' >>"${samples_file}"
+
+  last_body_file="${body_file}"
+}
+
+# The control request may wake a scale-to-zero staging instance. Give it a
+# separate availability timeout and exclude it from every latency objective.
+probe 'version' 1 '/version' 'version' 60
+version_body_file="${last_body_file}"
+probe 'healthz' 1 '/healthz' 'health' 20
+probe 'cold_eligible' 1 '/events' 'application' 20
+for ((sample = 1; sample <= warm_samples; sample += 1)); do
+  probe 'warm_candidate' "${sample}" '/events' 'application' 20
+done
+
+deployment_environment="$(
+  jq --raw-output '.environment // "unknown"' "${version_body_file}" 2>/dev/null ||
+    echo 'unknown'
+)"
+image_digest="$(
+  jq --raw-output '.imageDigest // "unknown"' "${version_body_file}" 2>/dev/null ||
+    echo 'unknown'
+)"
+revision="$(
+  jq --raw-output '.revision // "unknown"' "${version_body_file}" 2>/dev/null ||
+    echo 'unknown'
+)"
+workflow_url=''
+if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+  workflow_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+fi
+
+report_file="${working_directory}/report.json"
+jq --slurp \
+  --arg deployment_environment "${deployment_environment}" \
+  --arg image_digest "${image_digest}" \
+  --arg mode "${mode}" \
+  --arg origin "${origin}" \
+  --arg revision "${revision}" \
+  --arg timestamp "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  --arg vantage "${vantage}" \
+  --arg workflow_url "${workflow_url}" \
+  --argjson sample_failures "${sample_failures}" \
+  --argjson warm_samples "${warm_samples}" '
+    def percentile($values; $ratio):
+      ($values | sort) as $sorted
+      | if ($sorted | length) == 0
+        then null
+        else $sorted[
+          (((($sorted | length) * $ratio) | ceil) - 1)
+        ]
+        end;
+
+    def distribution($values):
+      {
+        p50: percentile($values; 0.5),
+        p95: percentile($values; 0.95),
+        max: (
+          if ($values | length) == 0
+          then null
+          else ($values | max)
+          end
+        )
+      };
+
+    def classify($value; $target; $warning; $critical):
+      if $value == null then "insufficient"
+      elif $value > $critical then "critical"
+      elif $value > $warning then "warning"
+      elif $value > $target then "above_target"
+      else "within_budget"
+      end;
+
+    . as $samples
+    | [$samples[] | select(.kind == "warm_candidate")] as $warm
+    | [$warm[].upstreamServiceMs | select(. != null)] as $upstream
+    | [$warm[].timingMs.ttfb] as $ttfb
+    | [$warm[].timingMs.total] as $total
+    | distribution($upstream) as $upstream_distribution
+    | distribution($ttfb) as $ttfb_distribution
+    | distribution($total) as $total_distribution
+    | classify($upstream_distribution.p95; 500; 750; 1500) as $upstream_status
+    | classify($ttfb_distribution.p95; 750; 1000; 2000) as $ttfb_status
+    | (
+        if $sample_failures > 0 then "critical"
+        elif [$upstream_status, $ttfb_status] | any(. == "critical") then "critical"
+        elif [$upstream_status, $ttfb_status] | any(. == "warning") then "warning"
+        elif [$upstream_status, $ttfb_status] | any(. == "above_target") then "above_target"
+        elif [$upstream_status, $ttfb_status] | any(. == "insufficient") then "insufficient"
+        else "within_budget"
+        end
+      ) as $overall_status
+    | {
+        schemaVersion: 1,
+        generatedAt: $timestamp,
+        targetOrigin: $origin,
+        vantage: $vantage,
+        mode: $mode,
+        deployment: {
+          environment: $deployment_environment,
+          revision: $revision,
+          imageDigest: $image_digest,
+          workflowUrl: (
+            if $workflow_url == ""
+            then null
+            else $workflow_url
+            end
+          )
+        },
+        samples: $samples,
+        thresholdsMs: {
+          upstreamServiceP95: {
+            target: 500,
+            warning: 750,
+            critical: 1500
+          },
+          ttfbP95: {
+            target: 750,
+            warning: 1000,
+            critical: 2000
+          }
+        },
+        summary: {
+          overallStatus: $overall_status,
+          contentFailures: $sample_failures,
+          warmCandidateCount: ($warm | length),
+          expectedWarmCandidateCount: $warm_samples,
+          upstreamServiceMs: (
+            $upstream_distribution + { status: $upstream_status }
+          ),
+          ttfbMs: (
+            $ttfb_distribution + { status: $ttfb_status }
+          ),
+          totalMs: $total_distribution
+        }
+      }
+  ' "${samples_file}" >"${report_file}"
+
+mkdir -p "$(dirname "${output}")"
+mv "${report_file}" "${output}"
+
+if [[ -n "${summary_output}" ]]; then
+  mkdir -p "$(dirname "${summary_output}")"
+  {
+    echo '## Warm-path latency probe'
+    echo
+    printf -- "- Target: \`%s\`\n" "${origin}"
+    printf -- "- Deployment: \`%s\` / \`%s\`\n" "${revision}" "${image_digest}"
+    printf -- "- Vantage: \`%s\`\n" "${vantage}"
+    printf -- "- Mode: \`%s\`\n" "${mode}"
+    printf -- "- Overall status: \`%s\`\n" "$(
+      jq --raw-output '.summary.overallStatus' "${output}"
+    )"
+    echo
+    echo '| Warm-candidate signal | p50 | p95 | max | status |'
+    echo '| --- | ---: | ---: | ---: | --- |'
+    jq --raw-output '
+      def display:
+        if . == null then "n/a" else "\(.) ms" end;
+      ([
+          "Upstream service",
+          (.summary.upstreamServiceMs.p50 | display),
+          (.summary.upstreamServiceMs.p95 | display),
+          (.summary.upstreamServiceMs.max | display),
+          .summary.upstreamServiceMs.status
+        ] | @tsv),
+      ([
+          "External TTFB",
+          (.summary.ttfbMs.p50 | display),
+          (.summary.ttfbMs.p95 | display),
+          (.summary.ttfbMs.max | display),
+          .summary.ttfbMs.status
+        ] | @tsv),
+      ([
+          "External total",
+          (.summary.totalMs.p50 | display),
+          (.summary.totalMs.p95 | display),
+          (.summary.totalMs.max | display),
+          "-"
+        ] | @tsv)
+    ' "${output}" |
+      while IFS=$'\t' read -r signal p50 p95 maximum status; do
+        printf '| %s | %s | %s | %s | %s |\n' \
+          "${signal}" "${p50}" "${p95}" "${maximum}" "${status}"
+      done
+  } >"${summary_output}"
+fi
+
+overall_status="$(jq --raw-output '.summary.overallStatus' "${output}")"
+echo "Latency probe status: ${overall_status}"
+
+if ((sample_failures > 0)); then
+  echo "One or more latency samples failed status or content validation" >&2
+  exit 1
+fi
+
+if [[ "${mode}" == 'enforce-critical' && "${overall_status}" == 'critical' ]]; then
+  echo "Warm-path latency exceeded a critical threshold" >&2
+  exit 2
+fi

--- a/ops/scaleway/probe-http-latency.sh
+++ b/ops/scaleway/probe-http-latency.sh
@@ -153,8 +153,12 @@ probe() {
   local headers_file="${working_directory}/${sample_name}.headers"
   local body_file="${working_directory}/${sample_name}.body"
   local curl_metrics
+  local curl_exit_status=0
+  local curl_failed='false'
 
-  if ! curl_metrics="$(
+  : >"${headers_file}"
+  : >"${body_file}"
+  curl_metrics="$(
     curl \
       --connect-timeout 5 \
       --dump-header "${headers_file}" \
@@ -166,9 +170,10 @@ probe() {
       --user-agent 'evorto-latency-monitor/1' \
       --write-out '%{json}' \
       "${origin}${path}"
-  )"; then
+  )" || curl_exit_status=$?
+  if ((curl_exit_status != 0)); then
     echo "Latency probe failed before receiving ${path}" >&2
-    return 1
+    curl_failed='true'
   fi
 
   if ! jq --exit-status '
@@ -183,13 +188,18 @@ probe() {
       and (.time_total | type == "number")
   ' <<<"${curl_metrics}" >/dev/null; then
     echo "curl did not return the expected timing JSON for ${path}" >&2
-    return 1
+    curl_failed='true'
+    curl_metrics='{"http_code":0,"http_version":"","num_redirects":0,"time_appconnect":0,"time_connect":0,"time_namelookup":0,"time_starttransfer":0,"time_total":0}'
+  elif [[ "${curl_failed}" == 'true' ]]; then
+    curl_metrics="$(jq --compact-output '.http_code = 0' <<<"${curl_metrics}")"
   fi
 
   local status_code
   status_code="$(jq --raw-output '.http_code' <<<"${curl_metrics}")"
   local content_valid='true'
-  if ((status_code < 200 || status_code >= 300)); then
+  if [[ "${curl_failed}" == 'true' ]]; then
+    content_valid='false'
+  elif ((status_code < 200 || status_code >= 300)); then
     content_valid='false'
   else
     case "${content_validator}" in

--- a/ops/scaleway/probe-http-latency.sh
+++ b/ops/scaleway/probe-http-latency.sh
@@ -102,7 +102,7 @@ fi
 
 origin="${origin%/}"
 
-for required_command in awk curl date grep jq mktemp mkdir mv; do
+for required_command in awk curl date dirname grep jq mkdir mktemp mv rm; do
   if ! command -v "${required_command}" >/dev/null; then
     echo "Missing required command: ${required_command}" >&2
     exit 69

--- a/src/server.ts
+++ b/src/server.ts
@@ -273,30 +273,41 @@ const extractTenantBrandAsset = (
   };
 };
 
-const renderSsrWeb = (request: HttpServerRequest.HttpServerRequest) =>
-  Effect.gen(function* () {
-    const authSession = yield* loadAuthSession(request);
-    const requestContextOption = yield* resolveHttpRequestContext(
-      request,
-      authSession,
-    ).pipe(
-      Effect.map((context) => Option.fromNullishOr(context)),
-      Effect.catchTag('HttpRequestTenantNotFoundError', () =>
-        Effect.succeed(Option.none()),
-      ),
-    );
-    if (Option.isNone(requestContextOption)) {
-      return null;
-    }
-    const requestContext = requestContextOption.value;
-
-    const webRequest = yield* HttpServerRequest.toWeb(request);
-    const renderedResponse = yield* Effect.tryPromise(() =>
-      angularApp.handle(webRequest, requestContext),
-    );
-
-    return renderedResponse;
+const renderSsrWeb = Effect.fn('Server.renderSsr')(function* (
+  request: HttpServerRequest.HttpServerRequest,
+) {
+  yield* Effect.annotateCurrentSpan({ 'evorto.ssr': true });
+  const authSession = yield* loadAuthSession(request);
+  const requestContextOption = yield* resolveHttpRequestContext(
+    request,
+    authSession,
+  ).pipe(
+    Effect.map((context) => Option.fromNullishOr(context)),
+    Effect.catchTag('HttpRequestTenantNotFoundError', () =>
+      Effect.succeed(Option.none()),
+    ),
+  );
+  if (Option.isNone(requestContextOption)) {
+    return null;
+  }
+  const requestContext = requestContextOption.value;
+  yield* Effect.annotateCurrentSpan({
+    'evorto.authenticated': requestContext.authentication.isAuthenticated,
   });
+
+  const webRequest = yield* HttpServerRequest.toWeb(request);
+  const renderedResponse = yield* Effect.tryPromise(() =>
+    angularApp.handle(webRequest, requestContext),
+  ).pipe(
+    Effect.withSpan('Angular.handle', {
+      attributes: {
+        'evorto.authenticated': requestContext.authentication.isAuthenticated,
+      },
+    }),
+  );
+
+  return renderedResponse;
+});
 
 const renderSsr = (request: HttpServerRequest.HttpServerRequest) =>
   renderSsrWeb(request).pipe(

--- a/src/server/auth/auth-session.ts
+++ b/src/server/auth/auth-session.ts
@@ -300,20 +300,21 @@ export const getRequestAuthData = (authSession: AuthSession | undefined) =>
 export const isAuthenticated = (authSession: AuthSession | undefined) =>
   authSession !== undefined;
 
-export const loadAuthSession = (request: HttpServerRequest.HttpServerRequest) =>
-  Effect.gen(function* () {
-    const storeOptions = createStoreOptions(request);
-    const auth0Client = yield* createAuth0Client(request);
+export const loadAuthSession = Effect.fn('Server.loadAuthSession')(function* (
+  request: HttpServerRequest.HttpServerRequest,
+) {
+  const storeOptions = createStoreOptions(request);
+  const auth0Client = yield* createAuth0Client(request);
 
-    const sessionData = yield* runPromiseOrUndefined('loadAuthSession', () =>
-      auth0Client.getSession(storeOptions),
-    );
+  const sessionData = yield* runPromiseOrUndefined('loadAuthSession', () =>
+    auth0Client.getSession(storeOptions),
+  );
 
-    // The SDK has already validated the encrypted application session here.
-    // OAuth access-token expiry is independent of that session lifetime; use
-    // ServerClient.getAccessToken() if a downstream integration needs a token.
-    return toAuthSession(sessionData);
-  });
+  // The SDK has already validated the encrypted application session here.
+  // OAuth access-token expiry is independent of that session lifetime; use
+  // ServerClient.getAccessToken() if a downstream integration needs a token.
+  return toAuthSession(sessionData);
+});
 
 export const handleLoginRequest = (
   request: HttpServerRequest.HttpServerRequest,

--- a/src/server/context/http-request-context.ts
+++ b/src/server/context/http-request-context.ts
@@ -29,7 +29,7 @@ const resolveRequestHost = (
   request: HttpServerRequest.HttpServerRequest,
 ): readonly string[] | string | undefined => request.headers['host'];
 
-export const resolveHttpRequestContext = (
+const resolveHttpRequestContextEffect = (
   request: HttpServerRequest.HttpServerRequest,
   authSession: AuthSession | undefined,
 ): Effect.Effect<
@@ -41,6 +41,10 @@ export const resolveHttpRequestContext = (
     const requestOrigin = resolveRequestOrigin(request);
     const authentication = resolveAuthenticationContext({
       isAuthenticated: isAuthenticated(authSession),
+    });
+    yield* Effect.annotateCurrentSpan({
+      'evorto.authenticated': authentication.isAuthenticated,
+      'evorto.user_context_resolved': false,
     });
 
     const { cause, tenant } = yield* resolveTenantContext({
@@ -76,6 +80,9 @@ export const resolveHttpRequestContext = (
       oidcUser: authSession?.authData,
       user: tenantUser,
     });
+    yield* Effect.annotateCurrentSpan({
+      'evorto.user_context_resolved': tenantUser !== undefined,
+    });
 
     return Schema.decodeUnknownSync(RequestContext)({
       authentication,
@@ -85,3 +92,7 @@ export const resolveHttpRequestContext = (
       user: tenantUser,
     });
   });
+
+export const resolveHttpRequestContext = Effect.fn(
+  'Server.resolveHttpRequestContext',
+)(resolveHttpRequestContextEffect);

--- a/src/server/context/request-context-resolver.ts
+++ b/src/server/context/request-context-resolver.ts
@@ -140,7 +140,7 @@ export const resolveAuthenticationContext = (input: {
   isAuthenticated: input.isAuthenticated,
 });
 
-export const resolveTenantContext = (input: {
+const resolveTenantContextEffect = (input: {
   cookies: Record<string, unknown> | undefined;
   protocol: string;
   requestHost: readonly string[] | string | undefined;
@@ -175,20 +175,29 @@ export const resolveTenantContext = (input: {
       tenantRecord = yield* findTenantByDomain(tenantCookie);
     }
 
+    const tenant = tenantRecord
+      ? Schema.decodeUnknownSync(Tenant)(tenantRecord)
+      : undefined;
+    yield* Effect.annotateCurrentSpan({
+      'evorto.tenant_resolved': tenant !== undefined,
+    });
+
     return {
       cause,
-      tenant: tenantRecord
-        ? Schema.decodeUnknownSync(Tenant)(tenantRecord)
-        : undefined,
+      tenant,
     };
   });
+
+export const resolveTenantContext = Effect.fn('Server.resolveTenantContext')(
+  resolveTenantContextEffect,
+);
 
 const resolveCurrentTenantOnboarding = (input: {
   tenantId: string;
   userId: string;
 }) => databaseEffect((database) => hasCurrentTenantOnboarding(database, input));
 
-export const resolveUserContext = (
+const resolveUserContextEffect = (
   input: {
     isAuthenticated: boolean;
     oidcUser: unknown;
@@ -197,6 +206,10 @@ export const resolveUserContext = (
   resolveOnboardingComplete = resolveCurrentTenantOnboarding,
 ) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan({
+      'evorto.authenticated': input.isAuthenticated,
+      'evorto.user_context_resolved': false,
+    });
     if (!input.isAuthenticated) {
       return;
     }
@@ -224,7 +237,14 @@ export const resolveUserContext = (
     const onboardingComplete = yield* resolveOnboardingComplete({
       tenantId: input.tenantId,
       userId: user.id,
-    });
+    }).pipe(
+      Effect.tap((complete) =>
+        Effect.annotateCurrentSpan({
+          'evorto.onboarding_complete': complete,
+        }),
+      ),
+      Effect.withSpan('Server.resolveUserOnboarding'),
+    );
     if (!onboardingComplete) {
       return;
     }
@@ -257,23 +277,29 @@ export const resolveUserContext = (
 
     const roleIds = assignedRoles.map((role) => role.id);
 
-    const attributeResponse = yield* databaseEffect((database) =>
-      Effect.map(
+    const attributeResponse = yield* Effect.gen(function* () {
+      const result = yield* databaseEffect((database) =>
         getPreparedStatements(
           database,
         ).getUserAttributesByTenantAndUser.execute({
           tenantId: input.tenantId,
           userId: user.id,
         }),
-        (result) => result[0],
-      ),
-    );
+      );
+      yield* Effect.annotateCurrentSpan({
+        'db.response.returned_rows': result.length,
+      });
+      return result[0];
+    }).pipe(Effect.withSpan('Server.resolveUserAttributes'));
 
     const attributes = [
       ...(attributeResponse?.organizesSome
         ? (['events:organizesSome'] as const)
         : []),
     ];
+    yield* Effect.annotateCurrentSpan({
+      'evorto.user_context_resolved': true,
+    });
 
     return {
       ...user,
@@ -283,6 +309,10 @@ export const resolveUserContext = (
       roleIds,
     };
   });
+
+export const resolveUserContext = Effect.fn('Server.resolveUserContext')(
+  resolveUserContextEffect,
+);
 
 export interface TenantContextResolution {
   cause: {

--- a/src/server/effect/rpc/app-rpcs.web-handler.ts
+++ b/src/server/effect/rpc/app-rpcs.web-handler.ts
@@ -52,7 +52,7 @@ const appRpcRuntimeLayer = Layer.mergeAll(
 );
 
 export const appRpcHttpAppLayer = Layer.effect(AppRpcHttpApp)(
-  RpcServer.toHttpEffect(ServerAppRpcs).pipe(
+  RpcServer.toHttpEffect(ServerAppRpcs, { spanPrefix: 'Rpc' }).pipe(
     Effect.provide(appRpcRuntimeLayer),
   ),
 );

--- a/src/server/effect/rpc/handlers/events/events-query.handlers.ts
+++ b/src/server/effect/rpc/handlers/events/events-query.handlers.ts
@@ -203,10 +203,15 @@ export const eventQueryHandlers = {
     }),
   'events.eventList': (input, _options) =>
     Effect.gen(function* () {
-      const { tenant } = yield* RpcAccess.current();
-      const { user } = yield* RpcAccess.current();
+      const { authenticated, tenant, user } = yield* RpcAccess.current();
       const userPermissions = user?.permissions ?? [];
       const canInspectAllTenantEvents = canInspectTenantEvents(userPermissions);
+      yield* Effect.annotateCurrentSpan({
+        'evorto.authenticated': authenticated,
+        'evorto.events.include_unlisted': input.includeUnlisted,
+        'evorto.events.limit': input.limit,
+        'evorto.events.offset': input.offset,
+      });
 
       if (user?.id !== input.userId) {
         yield* Effect.logWarning(
@@ -267,68 +272,79 @@ export const eventQueryHandlers = {
         rolesToFilterBy.length > 0 ? [...rolesToFilterBy] : [''];
       const startAfter = new Date(input.startAfter);
 
-      const selectedEvents = yield* databaseEffect((database) =>
-        database
-          .select({
-            creatorId: eventInstances.creatorId,
-            icon: eventInstances.icon,
-            id: eventInstances.id,
-            start: eventInstances.start,
-            status: eventInstances.status,
-            title: eventInstances.title,
-            unlisted: eventInstances.unlisted,
-            userRegistered: exists(
-              database
-                .select()
-                .from(eventRegistrations)
-                .where(
-                  and(
-                    eq(eventRegistrations.eventId, eventInstances.id),
-                    eq(eventRegistrations.userId, user?.id ?? ''),
-                    not(eq(eventRegistrations.status, 'CANCELLED')),
+      const selectedEvents = yield* Effect.gen(function* () {
+        yield* Effect.annotateCurrentSpan({
+          'db.operation.name': 'events.eventList',
+          'evorto.events.limit': input.limit,
+          'evorto.events.offset': input.offset,
+        });
+        const events = yield* databaseEffect((database) =>
+          database
+            .select({
+              creatorId: eventInstances.creatorId,
+              icon: eventInstances.icon,
+              id: eventInstances.id,
+              start: eventInstances.start,
+              status: eventInstances.status,
+              title: eventInstances.title,
+              unlisted: eventInstances.unlisted,
+              userRegistered: exists(
+                database
+                  .select()
+                  .from(eventRegistrations)
+                  .where(
+                    and(
+                      eq(eventRegistrations.eventId, eventInstances.id),
+                      eq(eventRegistrations.userId, user?.id ?? ''),
+                      not(eq(eventRegistrations.status, 'CANCELLED')),
+                    ),
                   ),
-                ),
-            ),
-          })
-          .from(eventInstances)
-          .where(
-            and(
-              gt(eventInstances.start, startAfter),
-              eq(eventInstances.tenantId, tenant.id),
-              inArray(eventInstances.status, [...input.status]),
-              ...(input.includeUnlisted
-                ? []
-                : [eq(eventInstances.unlisted, false)]),
-              ...(canInspectAllTenantEvents
-                ? []
-                : [
-                    exists(
-                      database
-                        .select()
-                        .from(eventRegistrationOptions)
-                        .where(
-                          and(
-                            eq(
-                              eventRegistrationOptions.eventId,
-                              eventInstances.id,
-                            ),
-                            or(
-                              sql`cardinality(${eventRegistrationOptions.roleIds}) = 0`,
-                              arrayOverlaps(
-                                eventRegistrationOptions.roleIds,
-                                roleFilters,
+              ),
+            })
+            .from(eventInstances)
+            .where(
+              and(
+                gt(eventInstances.start, startAfter),
+                eq(eventInstances.tenantId, tenant.id),
+                inArray(eventInstances.status, [...input.status]),
+                ...(input.includeUnlisted
+                  ? []
+                  : [eq(eventInstances.unlisted, false)]),
+                ...(canInspectAllTenantEvents
+                  ? []
+                  : [
+                      exists(
+                        database
+                          .select()
+                          .from(eventRegistrationOptions)
+                          .where(
+                            and(
+                              eq(
+                                eventRegistrationOptions.eventId,
+                                eventInstances.id,
+                              ),
+                              or(
+                                sql`cardinality(${eventRegistrationOptions.roleIds}) = 0`,
+                                arrayOverlaps(
+                                  eventRegistrationOptions.roleIds,
+                                  roleFilters,
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                    ),
-                  ]),
-            ),
-          )
-          .limit(input.limit)
-          .offset(input.offset)
-          .orderBy(eventInstances.start),
-      );
+                      ),
+                    ]),
+              ),
+            )
+            .limit(input.limit)
+            .offset(input.offset)
+            .orderBy(eventInstances.start),
+        );
+        yield* Effect.annotateCurrentSpan({
+          'db.response.returned_rows': events.length,
+        });
+        return events;
+      }).pipe(Effect.withSpan('Db.events.eventList'));
 
       const eventRecords = selectedEvents.map((event) => ({
         icon: event.icon,

--- a/src/server/effect/rpc/handlers/events/events-query.handlers.ts
+++ b/src/server/effect/rpc/handlers/events/events-query.handlers.ts
@@ -156,6 +156,23 @@ export const organizerRegistrationApprovalState = ({
 const canInspectTenantEvents = (permissions: readonly Permission[]): boolean =>
   includesPermission('globalAdmin:manageTenants', permissions);
 
+const eventListPageSizeBucket = (limit: number): string => {
+  if (limit === 0) return 'zero';
+  if (limit <= 10) return '1-10';
+  if (limit <= 25) return '11-25';
+  if (limit <= 50) return '26-50';
+  if (limit <= 100) return '51-100';
+  return 'over-100';
+};
+
+const eventListPaginationAttributes = (input: {
+  limit: number;
+  offset: number;
+}) => ({
+  'evorto.events.initial_page': input.offset === 0,
+  'evorto.events.page_size_bucket': eventListPageSizeBucket(input.limit),
+});
+
 export const groupEventsByTenantDay = <EventRecord extends { start: string }>(
   events: readonly EventRecord[],
   timezone: string,
@@ -209,8 +226,7 @@ export const eventQueryHandlers = {
       yield* Effect.annotateCurrentSpan({
         'evorto.authenticated': authenticated,
         'evorto.events.include_unlisted': input.includeUnlisted,
-        'evorto.events.limit': input.limit,
-        'evorto.events.offset': input.offset,
+        ...eventListPaginationAttributes(input),
       });
 
       if (user?.id !== input.userId) {
@@ -275,8 +291,7 @@ export const eventQueryHandlers = {
       const selectedEvents = yield* Effect.gen(function* () {
         yield* Effect.annotateCurrentSpan({
           'db.operation.name': 'events.eventList',
-          'evorto.events.limit': input.limit,
-          'evorto.events.offset': input.offset,
+          ...eventListPaginationAttributes(input),
         });
         const events = yield* databaseEffect((database) =>
           database


### PR DESCRIPTION
## Purpose

Make the post-cold staging latency defect measurable at the server boundaries and from an independent external vantage, without masking the known breach as a cold-start problem.

## Scope

- add stable Effect/OpenTelemetry spans for auth-session loading, request-context and tenant/user resolution, SSR, Angular rendering, Effect RPC methods, and the event-list database query;
- keep trace attributes bounded and non-sensitive (authentication state, pagination, result counts, and stable operation names only);
- add a dependency-free `/events` latency probe with per-sample DNS/connect/TLS/TTFB/total timings, Envoy upstream time, status/content validation, revision, and image digest;
- run four warm-candidate samples independently every 15 minutes and retain report evidence for seven days;
- attach a separate ten-sample report-only baseline to changed staging deployments and their immutable manifest;
- document improvement order, provisional budgets, dashboards, alert activation, and incident triage.

## Runtime, schema, and UI impact

- No database schema change.
- No user-interface behavior change.
- Latency thresholds remain report-only while the known defect is open; status or invalid-content failures still fail immediately, and a manual dispatch can exercise critical enforcement.
- The existing Effect OpenTelemetry exporter is reused; no competing telemetry pipeline is introduced.

## Current staging evidence

A live probe on 2026-07-27 against deployed revision `d117229d3d7d357af9f9fc61fdad8d348d6809ea` classified the warm path as `warning`:

- upstream service time: p50 813 ms, p95/max 1,045 ms;
- external TTFB: p50 929.8 ms, p95/max 1,209.74 ms;
- zero HTTP or application-content failures.

This confirms that the post-start path remains slow and provides the baseline this PR is intended to preserve.

## Verification

Passed on commit `c60092211dbe04a47098b6cbf559c634de8bb718`:

- `bun install --frozen-lockfile`
- `bun run release:validate`
- `bun run format:write`
- `bun run format:check`
- `bun run lint`
- clean working-tree checks
- `bun run test:unit:server` — 1,454 tests
- `bun run test:unit` — 802 tests
- `bun run test:integration:postgres:local` — 55 tests on PostgreSQL 17
- `bun run build:app`
- `bun run infra:check` — valid Terraform, zero misconfigurations
- `bun run image:security:local` — zero detected image vulnerabilities
- `actionlint`, `shellcheck`, `bash -n`, and focused probe/telemetry tests

Not run by explicit request because another E2E execution is currently active elsewhere:

- `bun run test:e2e`
- `bun run test:e2e:docs`

* `main` <!-- branch-stack -->
  - **feat: add staging latency observability** :point\_left:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated staging latency monitoring every 15 minutes, with on-demand checks and optional critical-threshold enforcement.
  - Deployment evidence now includes warm-latency reports and summaries for changed staging deployments.
  - Added comprehensive guidance for monitoring, diagnosing, and improving warm-path performance.

- **Observability**
  - Expanded request tracing and latency metrics across server rendering, authentication, context resolution, RPCs, and event-list queries.

- **Tests**
  - Added coverage for latency reporting, threshold enforcement, deployment evidence, and trace visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
